### PR TITLE
feat(politics-tracker): add `styled-component` and `ThemeProvider` setting

### DIFF
--- a/packages/politics-tracker/.babelrc
+++ b/packages/politics-tracker/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["next/babel"],
+  "plugins": [["styled-components", { "ssr": true, "displayName": true }]]
+}

--- a/packages/politics-tracker/package.json
+++ b/packages/politics-tracker/package.json
@@ -21,6 +21,7 @@
     "@types/node": "18.8.1",
     "@types/react": "18.0.21",
     "@types/react-dom": "18.0.6",
+    "@types/styled-components": "^5.1.26",
     "@types/uuid": "^8.3.4",
     "autoprefixer": "^10.4.12",
     "cssnano": "^5.1.13",

--- a/packages/politics-tracker/pages/people/[name].js
+++ b/packages/politics-tracker/pages/people/[name].js
@@ -1,0 +1,24 @@
+import React from 'react'
+import styled from 'styled-components'
+import { ThemeProvider } from 'styled-components'
+import theme from '~/styles/theme'
+
+const CustomDiv = styled.div`
+  width: 100px;
+  height: 100px;
+  background-color: black;
+  ${({ theme }) => theme.breakpoint.md} {
+    background-color: green;
+  }
+`
+
+/**
+ * @returns {React.ReactElement}
+ */
+export default function People() {
+  return (
+    <ThemeProvider theme={theme}>
+      <CustomDiv />
+    </ThemeProvider>
+  )
+}

--- a/packages/politics-tracker/styles/theme/index.js
+++ b/packages/politics-tracker/styles/theme/index.js
@@ -1,0 +1,20 @@
+const mediaSize = {
+  xs: 0,
+  sm: 576,
+  md: 768,
+  lg: 992,
+  xl: 1200,
+  xxl: 1440,
+}
+export const theme = {
+  breakpoint: {
+    xs: `@media (min-width: ${mediaSize.xs}px)`,
+    sm: `@media (min-width: ${mediaSize.sm}px)`,
+    md: `@media (min-width: ${mediaSize.md}px)`,
+    lg: `@media (min-width: ${mediaSize.lg}px)`,
+    xl: `@media (min-width: ${mediaSize.xl}px)`,
+    xxl: `@media (min-width: ${mediaSize.xxl}px)`,
+  },
+}
+
+export default theme

--- a/yarn.lock
+++ b/yarn.lock
@@ -1306,6 +1306,14 @@
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
+"@types/hoist-non-react-statics@*":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
@@ -1361,6 +1369,15 @@
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
+
+"@types/styled-components@^5.1.26":
+  version "5.1.26"
+  resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-5.1.26.tgz#5627e6812ee96d755028a98dae61d28e57c233af"
+  integrity sha512-KuKJ9Z6xb93uJiIyxo/+ksS7yLjS1KzG6iv5i78dhVg/X3u5t1H7juRWqVmodIdz6wGVaIApo1u01kmFRdJHVw==
+  dependencies:
+    "@types/hoist-non-react-statics" "*"
+    "@types/react" "*"
+    csstype "^3.0.2"
 
 "@types/uuid@^8.3.4":
   version "8.3.4"
@@ -3411,7 +3428,7 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hoist-non-react-statics@^3.0.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==


### PR DESCRIPTION
- [cc02ebf](https://github.com/readr-media/Sachiel/pull/6/commits/cc02ebf0e40c440e555cbb99f6802cdc21d40abf): 新增`.babelrc`，讓styled-components不會在網頁重新整理後失效。
- [16f6c4f](https://github.com/readr-media/Sachiel/pull/6/commits/16f6c4f52d47ddcf8218b63c9a197d3e6e42b12c)：加入devDep `@types/styled-components`
- [095a980](https://github.com/readr-media/Sachiel/pull/6/commits/095a9801d23a0444f65468d18e0aac02103009ff)：在`/styles`底下新增一資料夾`/theme`，用來放styled-component的custom Theme設定
- [aa51382](https://github.com/readr-media/Sachiel/pull/6/commits/aa513820b128629698796f83b8733cd3ba2cef72)：新增頁面`/people/_name`