### PR TITLE
1016 refactor list

### DIFF
--- a/packages/politics-tracker/components/people/section-list.js
+++ b/packages/politics-tracker/components/people/section-list.js
@@ -1,101 +1,33 @@
-import React, { useState, Fragment } from 'react'
+import React, { Fragment } from 'react'
 
 import SectionToggle from './section-toggle'
-import SectionBody from './section-body'
-import styled from 'styled-components'
-const SectionListWrapper = styled.div`
-  max-width: 688px;
-  margin: 0 auto;
-  padding: 0 26px 0 16px;
-`
 
 /**
+ *
  * @param {Object} props
- * @param {import('../../types/person').Person} props.peopleData
- * @param {import('../../types/politics').PersonElection[]} props.personElectionsData
+ * @param {null|string} props.id
+ * @param {boolean} props.isActive
+ * @param {Function} props.setActive
+ * @param {string} props.color
+ * @param {React.ReactElement} [props.children]
  * @returns {React.ReactElement}
  */
-export default function SectionList({ peopleData, personElectionsData }) {
-  const [activeId, setActiveId] = useState('')
-  const elections = [
-    {
-      id: '1',
-      name: '2014 臺北市議員選舉如果這行很長居然有一行以上會這樣排版',
-      year: '2014',
-      month: '08',
-      day: '08',
-      politics: [
-        {
-          id: '1',
-          desc: '便捷交通：推動綠色軌道運輸，爭取東部快鐵、鐵路高架捷運化；打通南(蘇澳)、北(礁溪)交通瓶頸； 建構縣內四縱六橫交通骨幹，銜接烏石港、礁溪、宜蘭、羅東、蘇澳五大轉運站，串聯aaaaaaaaaaaaaaaaaaaaaaaaa縣內公共運輸；並規劃跨縣市太平洋藍色公路及旅遊系統，建置智慧交通管理系統（ITS）， 以建構速捷交通網絡，打造北宜便捷生活圈。',
-          source:
-            'https://wwww.google.com\r\n選舉公報\r\n測試\r\njavascript:void(0)\r\nhttp://javascript:void(0)\r\nhttps://plurk.com',
-        },
-        {
-          id: '2',
-          desc: '建構縣內四縱六橫交通骨幹，銜接烏石港、礁溪、宜蘭、羅東、蘇澳五大轉運站，串聯aaaaaaaaaaaaaaaaaaaaaaaaa縣內公共運輸；並規劃跨縣市太平洋藍色公路及旅遊系統，建置智慧交通管理系統（ITS）， 以建構速捷交通網絡，打造北宜便捷生活圈。',
-          source:
-            'https://wwww.google.com\r\n選舉公報\r\n測試\r\njavascript:void(0)\r\nhttp://javascript:void(0)\r\nhttps://plurk.com',
-        },
-        {
-          id: '3',
-          desc: '便捷交通：推動綠色軌道運輸，爭取東部快鐵、鐵路高架捷運化',
-          source:
-            'https://wwww.google.com\r\n測試\r\njavascript:void(0)https://plurk.com\r\nhttps://twitter.com',
-        },
-      ],
-    },
-    {
-      id: '2',
-      name: '2014 臺北市議員選舉',
-      year: '2014',
-      month: '08',
-      day: '08',
-      politics: [
-        {
-          id: '1',
-          desc: '便捷交通：推動綠色軌道運輸，爭取東部快鐵、鐵路高架捷運化；打通南(蘇澳)、北(礁溪)交通瓶頸； 建構縣內四縱六橫交通骨幹，銜接烏石港、礁溪、宜蘭、羅東、蘇澳五大轉運站，串聯aaaaaaaaaaaaaaaaaaaaaaaaa縣內公共運輸；並規劃跨縣市太平洋藍色公路及旅遊系統，建置智慧交通管理系統（ITS）， 以建構速捷交通網絡，打造北宜便捷生活圈。',
-          source:
-            'https://wwww.google.com\r\n選舉公報\r\n測試\r\njavascript:void(0)\r\nhttp://javascript:void(0)\r\nhttps://plurk.com',
-        },
-        {
-          id: '2',
-          desc: '建構縣內四縱六橫交通骨幹，銜接烏石港、礁溪、宜蘭、羅東、蘇澳五大轉運站，串聯aaaaaaaaaaaaaaaaaaaaaaaaa縣內公共運輸；並規劃跨縣市太平洋藍色公路及旅遊系統，建置智慧交通管理系統（ITS）， 以建構速捷交通網絡，打造北宜便捷生活圈。',
-          source:
-            'https://wwww.google.com\r\n選舉公報\r\n測試\r\njavascript:void(0)\r\nhttp://javascript:void(0)\r\nhttps://plurk.com',
-        },
-        {
-          id: '3',
-          desc: '便捷交通：推動綠色軌道運輸，爭取東部快鐵、鐵路高架捷運化；打通南(蘇澳)、北(礁溪)交通瓶頸； 建構縣內四縱六橫交通骨幹，銜接烏石港、礁溪、宜蘭、羅東、蘇澳五大轉運站，串聯aaaaaaaaaaaaaaaaaaaaaaaaa縣內公共運輸；並規劃跨縣市太平洋藍色公路及旅遊系統，建置智慧交通管理系統（ITS）， 以建構速捷交通網絡，打造北宜便捷生活圈。',
-          source:
-            'https://wwww.google.com\r\n測試\r\njavascript:void(0)https://plurk.com\r\nhttps://twitter.com',
-        },
-      ],
-    },
-    {
-      id: '3',
-      name: '2014 臺北市議員選舉',
-      year: '2014',
-      month: '08',
-      day: '08',
-      politics: [],
-    },
-  ]
-  const electionList = elections.map((e) => {
-    return (
-      <Fragment key={e.id}>
-        <SectionToggle
-          id={e.id}
-          isActive={activeId === e.id}
-          setActive={(
-            /** @type {import("react").SetStateAction<string>} */ id
-          ) => setActiveId(id)}
-          color={'orange'}
-        />
-        <SectionBody isActive={activeId === e.id}></SectionBody>
-      </Fragment>
-    )
-  })
-
-  return <>{electionList}</>
+export default function SectionList2({
+  id,
+  isActive,
+  setActive,
+  color,
+  children,
+}) {
+  return (
+    <Fragment>
+      <SectionToggle
+        id={id}
+        isActive={isActive}
+        setActive={(/** @type {null|string} id */ id) => setActive(id)}
+        color={color}
+      />
+      {children}
+    </Fragment>
+  )
 }

--- a/packages/politics-tracker/components/people/section-list.js
+++ b/packages/politics-tracker/components/people/section-list.js
@@ -2,7 +2,6 @@ import React, { useState, Fragment } from 'react'
 
 import SectionToggle from './section-toggle'
 import SectionBody from './section-body'
-
 import styled from 'styled-components'
 const SectionListWrapper = styled.div`
   max-width: 688px;
@@ -98,5 +97,5 @@ export default function SectionList({ peopleData, personElectionsData }) {
     )
   })
 
-  return <SectionListWrapper>{electionList}</SectionListWrapper>
+  return <>{electionList}</>
 }

--- a/packages/politics-tracker/components/people/section-toggle.js
+++ b/packages/politics-tracker/components/people/section-toggle.js
@@ -108,15 +108,17 @@ const ToggleIcon = styled.span`
  * @param {string} props.color
  * @param {boolean} props.isActive
  * @param {Function} props.setActive
- * @param {string} props.id
+ * @param {null|string} props.id
  * @returns {React.ReactElement}
  */
 export default function SectionToggle({ color, isActive, setActive, id }) {
   function toggle() {
-    if (isActive) {
-      setActive('')
-    } else {
-      setActive(id)
+    if (id) {
+      if (isActive) {
+        setActive('')
+      } else {
+        setActive(id)
+      }
     }
   }
 

--- a/packages/politics-tracker/components/people/section.js
+++ b/packages/politics-tracker/components/people/section.js
@@ -1,0 +1,24 @@
+import styled from 'styled-components'
+
+import SectionList from './section-list'
+const SectionContainer = styled.div`
+  max-width: 688px;
+  margin: 0 auto;
+  padding: 0 26px 0 16px;
+`
+/**
+ * @param {Object} props
+ * @param {import('../../types/person').Person} props.peopleData
+ * @param {import('../../types/politics').PersonElection[]} props.personElectionsData
+ * @returns {React.ReactElement}
+ */
+export default function Section({ peopleData, personElectionsData }) {
+  return (
+    <SectionContainer>
+      <SectionList
+        peopleData={peopleData}
+        personElectionsData={personElectionsData}
+      />
+    </SectionContainer>
+  )
+}

--- a/packages/politics-tracker/components/people/section.js
+++ b/packages/politics-tracker/components/people/section.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components'
-
+import { useState } from 'react'
 import SectionList from './section-list'
+import SectionBody from './section-body'
 const SectionContainer = styled.div`
   max-width: 688px;
   margin: 0 auto;
@@ -13,12 +14,31 @@ const SectionContainer = styled.div`
  * @returns {React.ReactElement}
  */
 export default function Section({ peopleData, personElectionsData }) {
+  const [activeId, setActiveId] = useState('')
   return (
     <SectionContainer>
       <SectionList
-        peopleData={peopleData}
-        personElectionsData={personElectionsData}
-      />
+        id={'0'}
+        isActive={activeId === '0'}
+        setActive={setActiveId}
+        color={'blue'}
+      >
+        <SectionBody isActive={activeId === '0'}></SectionBody>
+      </SectionList>
+      <SectionList
+        id={'1'}
+        isActive={activeId === '1'}
+        setActive={setActiveId}
+        color={'orange'}
+      >
+        <SectionBody isActive={activeId === '1'}></SectionBody>
+      </SectionList>
+      <SectionList
+        id={null}
+        color={'disable'}
+        isActive={false}
+        setActive={setActiveId}
+      ></SectionList>
     </SectionContainer>
   )
 }

--- a/packages/politics-tracker/pages/people/[id].js
+++ b/packages/politics-tracker/pages/people/[id].js
@@ -5,12 +5,12 @@ import { ThemeProvider } from 'styled-components'
 import theme from '~/styles/theme'
 import Title from '~/components/people/title'
 import SectionList from '~/components/people/section-list'
+import Section from '~/components/people/section'
 import { cmsApiUrl } from '~/constants/config'
 import { print } from 'graphql'
 import { fireGqlRequest } from '~/utils/utils'
 import GetPersonBasicInfo from '~/graphql/query/people/get-person-basic-info.graphql'
 import GetPersonElections from '~/graphql/query/people/get-person-elections.graphql'
-
 const Main = styled.main`
   background-color: #f3f4ff;
   height: 100%;
@@ -28,7 +28,7 @@ export default function People({ peopleData, personElectionsData }) {
     <ThemeProvider theme={theme}>
       <Main>
         <Title name={peopleData.name} image={peopleData.image} />
-        <SectionList
+        <Section
           peopleData={peopleData}
           personElectionsData={personElectionsData}
         />

--- a/packages/politics-tracker/styles/theme/index.js
+++ b/packages/politics-tracker/styles/theme/index.js
@@ -31,6 +31,7 @@ export const theme = {
     brown: '#B3800D',
     black: sharedColor.black,
     skinColor: '#FFF5E7',
+    disable: '#C5CBCD',
   },
   textColor: {
     blue: '#544AC9', //different with backgroundColor.blue
@@ -42,6 +43,7 @@ export const theme = {
     black: '#0F2D35',
     white: sharedColor.white,
     pink: '#FFF1E8',
+    disable: sharedColor.gray,
   },
   borderColor: {
     black: sharedColor.black,


### PR DESCRIPTION
[a771f25](https://github.com/readr-media/Sachiel/pull/25/commits/a771f252c2c2b83f93ca175038c5a54c66a47d26): 新增一元件`Section`於人物頁。現在的元件父子關係為 `people/[id].js` -> `section` -> `section-list`
[c51a471](https://github.com/readr-media/Sachiel/pull/25/commits/c51a471dce016a707c2097be7ea2c125bf47b7ee)：重構元件`section-list`，讓子元件可以`children`的形式被傳入，提高元件在不同資料結構的復用性