### PR TITLE
feat(politics-tracker/people): add `edit-content` and refactor `section-body-personal-file.js`

### DIFF
--- a/packages/politics-tracker/components/people/content.js
+++ b/packages/politics-tracker/components/people/content.js
@@ -1,9 +1,10 @@
-import React, { Fragment } from 'react'
+import React, { Fragment, useState } from 'react'
 
 import ContentTitle from './content-title'
 import EditButton from './edit-button'
 import ContentItem from './content-item'
 import styled from 'styled-components'
+import EditContent from './edit-content'
 const ContentContainer = styled.div`
   padding: 0 0 20px;
 `
@@ -12,15 +13,27 @@ const ContentContainer = styled.div`
  * @param {Object} props
  * @param {string} props.title
  * @param {React.ReactElement[] | React.ReactElement} props.children
+ * @param {React.ReactElement[] | React.ReactElement} props.editContent
  * @returns {React.ReactElement}
  */
-export default function Content({ title, children }) {
+export default function Content({
+  title,
+
+  children,
+  editContent,
+}) {
+  const [shouldShowEditMode, setShouldShowEditMode] = useState(false)
+
   return (
     <ContentContainer>
       <ContentTitle title={title}>
-        <EditButton />
+        <Fragment>
+          {!shouldShowEditMode && (
+            <EditButton onClick={() => setShouldShowEditMode(true)} />
+          )}
+        </Fragment>
       </ContentTitle>
-      {children}
+      {shouldShowEditMode ? editContent : children}
     </ContentContainer>
   )
 }

--- a/packages/politics-tracker/components/people/edit-button.js
+++ b/packages/politics-tracker/components/people/edit-button.js
@@ -1,6 +1,10 @@
 import EditSvg from '../icons/edit'
 import styled from 'styled-components'
-
+import React from 'react'
+/**
+ * @param {Object} props
+ * @param {function} props.onClick
+ */
 const EditButtonContainer = styled.button`
   transition: all 300ms ease-in-out;
   display: flex;
@@ -26,9 +30,15 @@ const EditIcon = styled.div`
   }
 `
 
-export default function EditButton() {
+/**
+ *
+ * @param {Object} props
+ * @param {function} props.onClick
+ * @returns {React.ReactElement}
+ */
+export default function EditButton({ onClick }) {
   return (
-    <EditButtonContainer>
+    <EditButtonContainer onClick={() => onClick()}>
       <span>編輯</span>
       <EditIcon>
         <EditSvg />

--- a/packages/politics-tracker/components/people/edit-content.js
+++ b/packages/politics-tracker/components/people/edit-content.js
@@ -1,0 +1,8 @@
+import React from 'react'
+
+/**
+ * @returns {React.ReactElement}
+ */
+export default function EditContent() {
+  return <> {<div>編輯模式</div>}</>
+}

--- a/packages/politics-tracker/components/people/section-body-personal-file.js
+++ b/packages/politics-tracker/components/people/section-body-personal-file.js
@@ -7,33 +7,9 @@ import SectionBody from './section-body'
 import Content from './content'
 import ContentList from './content-list'
 import ContentLink from './content-link'
-import { useMemo } from 'react'
+import EditContent from './edit-content'
+import { useState, useMemo } from 'react'
 import moment from 'moment'
-const SectionBodyContainer = styled.div`
-  //adjust position for fitting place when section-toggle is pressed
-  margin-left: 10px;
-  transition: all 0.3s ease-in-out;
-  width: 100%;
-  max-height: ${
-    /**
-     * @param {Object} props
-     * @param {boolean} props.shouldShowSectionBody
-     */
-    ({ shouldShowSectionBody }) => (shouldShowSectionBody ? 'unset' : '0px')
-  };
-  min-height: ${({ shouldShowSectionBody }) =>
-    shouldShowSectionBody ? '200px' : '0px'};
-  padding: ${({ shouldShowSectionBody }) =>
-    shouldShowSectionBody ? '20px' : '0px'};
-
-  border-color: ${({ theme }) => theme.borderColor.black};
-  border-width: 0 4px 4px;
-  background-color: ${({ theme }) => theme.backgroundColor.white};
-  * {
-    display: ${({ shouldShowSectionBody }) =>
-      !shouldShowSectionBody && 'none '};
-  }
-`
 
 const ContentPersonImage = styled(ProfileImage)`
   width: 40px;
@@ -70,7 +46,6 @@ export default function SectionBodyPersonalFile({
     contact_details,
     links,
   } = peopleData
-
   /**
    * check the date passed in, which will be checked with two rule:
    * 1. If the date is valid. For Instances, if date passed in is "2022-25-35" or "2022-25" or "25-35", which is not valid.
@@ -166,7 +141,7 @@ export default function SectionBodyPersonalFile({
   const displayedGender = useMemo(() => getDisplayedGender(gender), [gender])
   return (
     <SectionBody shouldShowSectionBody={isActive}>
-      <Content title="基本資料">
+      <Content title="基本資料" editContent={<EditContent></EditContent>}>
         <ContentItem title="姓名" content={name}>
           <ContentPersonImage
             src={image ? image : '/images/default-head-photo.png'}
@@ -185,11 +160,12 @@ export default function SectionBodyPersonalFile({
         <ContentItem title="生理性別" content={displayedGender} />
         <ContentItem title="國籍" content={national_identity} />
       </Content>
-      <Content title="經歷">
+
+      <Content title="經歷" editContent={<EditContent></EditContent>}>
         <ContentList biography={biography} />
       </Content>
       {/* TODO: show multiple line */}
-      <Content title="聯絡方式">
+      <Content title="聯絡方式" editContent={<EditContent></EditContent>}>
         <ContentItem title="電子信箱" content={email} />
         <ContentItem title="電話/地址" content={contact_details} />
         <ContentLink title="網站" links={links} />


### PR DESCRIPTION
[23a5e35](https://github.com/readr-media/Sachiel/pull/40/commits/23a5e352a4d0d020af5ff8ae51e13f2de59dacee):新增元件`edit-content`，用於各content的編輯模式。
[0b652d0](https://github.com/readr-media/Sachiel/pull/40/commits/0b652d0f659da3bb3e0fe47e223a9960acbdf44e)：重構元件，讓`edit-content`可在`section-body-personal-file.js`中被重用