### PR TITLE
feat(politics-tracker/person): add component for edit mode

### DIFF
--- a/packages/politics-tracker/components/person/add-input-button.js
+++ b/packages/politics-tracker/components/person/add-input-button.js
@@ -6,6 +6,7 @@ const AddInputButtonWrapper = styled.button`
   display: flex;
   width: 100%;
   margin-top: 8px;
+  margin-bottom: 20px;
   justify-content: center;
   align-items: center;
   padding: 12px 0;

--- a/packages/politics-tracker/components/person/content-item.js
+++ b/packages/politics-tracker/components/person/content-item.js
@@ -1,5 +1,6 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import styled from 'styled-components'
+import { stringToSources, getNewSource } from '~/utils/utils'
 
 const ContentItemContainer = styled.div`
   display: flex;
@@ -7,6 +8,7 @@ const ContentItemContainer = styled.div`
   width: 100%;
   margin-top: 20px;
   justify-content: start;
+  align-items: start;
   min-height: 40px;
   ${({ theme }) => theme.fontSize['title-sub']};
   ${({ theme }) => theme.breakpoint.md} {
@@ -21,7 +23,6 @@ const ContentItemTitle = styled.div`
 
   ${({ theme }) => theme.breakpoint.md} {
     ${({ theme }) => theme.fontSize['title-sub-md']};
-
     display: flex;
     justify-content: start;
     align-items: center;
@@ -37,26 +38,33 @@ const ContentItemContent = styled.div`
   margin-top: 8px;
   ${({ theme }) => theme.breakpoint.md} {
     margin-top: 0;
+    margin-bottom: 8px;
   }
 `
 export { ContentItemContainer, ContentItemTitle, ContentItemContent }
 /**
  * @param {Object} props
  * @param {String} [props.title]
- * @param {?(String|number)} [props.content]
+ * @param {String} props.content
  * @param {React.ReactElement} [props.children]
  * @returns  {React.ReactElement}
  */
-export default function ContentItem({ title = '', content = '', children }) {
+export default function ContentItem({ title = '', content, children }) {
+  const contentList = useMemo(
+    () => (content ? stringToSources(content, '\n') : []),
+    [content]
+  )
   return (
     <ContentItemContainer>
       <ContentItemTitle>{title}</ContentItemTitle>
-      {content && (
-        <ContentItemContent>
-          {children}
-          {content}
-        </ContentItemContent>
-      )}
+      <div>
+        {contentList?.map((item) => (
+          <ContentItemContent key={item.id}>
+            {children}
+            {item.value}{' '}
+          </ContentItemContent>
+        ))}
+      </div>
     </ContentItemContainer>
   )
 }

--- a/packages/politics-tracker/components/person/content-link.js
+++ b/packages/politics-tracker/components/person/content-link.js
@@ -4,25 +4,41 @@ import {
   ContentItemContent,
 } from './content-item'
 import styled from 'styled-components'
+import React, { useMemo } from 'react'
+import { stringToSources, getNewSource } from '~/utils/utils'
 
 const ContentItemLink = styled(ContentItemContent)`
   color: ${({ theme }) => theme.textColor.blue};
+  margin-bottom: 8px;
 `
-
-export default function ContentLink({ title = '', links = '' }) {
+/**
+ *
+ * @param {Object} props
+ * @param {string} props.title
+ * @param {import('~/types/person').Person["links"]} props.links
+ * @returns {React.ReactElement}
+ */
+export default function ContentLink({ title, links }) {
+  const linkList = useMemo(
+    () => (links ? stringToSources(links, '\n') : []),
+    [links]
+  )
   return (
     <ContentItemContainer>
       <ContentItemTitle>{title}</ContentItemTitle>
-      {links && (
-        <ContentItemLink
-          as="a"
-          href={links}
-          target="_blank"
-          rel="noreferrer noopener"
-        >
-          {links}
-        </ContentItemLink>
-      )}
+      <div>
+        {linkList?.map((item) => (
+          <ContentItemLink
+            key={item.id}
+            as="a"
+            href={item.value}
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            {item.value}
+          </ContentItemLink>
+        ))}
+      </div>
     </ContentItemContainer>
   )
 }

--- a/packages/politics-tracker/components/person/content-list.js
+++ b/packages/politics-tracker/components/person/content-list.js
@@ -1,5 +1,6 @@
+import { useMemo } from 'react'
 import styled from 'styled-components'
-
+import { stringToSources } from '~/utils/utils'
 const UnorderedList = styled.ul`
   list-style: none;
   margin: 0;
@@ -23,16 +24,20 @@ export { UnorderedList, ListItem }
 /**
  *
  * @param {Object} props
- * @param {import('~/types/person').Person["biography"]} props.biography
+ * @param {string} props.biography
  * @returns {React.ReactElement}
  */
 export default function ContentList({ biography }) {
+  const biographyList = useMemo(
+    () => stringToSources(biography, '\n'),
+    [biography]
+  )
   return (
     <UnorderedList>
-      {biography &&
-        biography
-          ?.split('\n')
-          .map((item, index) => <ListItem key={index}>{item}</ListItem>)}
+      {biographyList &&
+        biographyList.map((item) => (
+          <ListItem key={item.id}>{item.value}</ListItem>
+        ))}
     </UnorderedList>
   )
 }

--- a/packages/politics-tracker/components/person/content-list.js
+++ b/packages/politics-tracker/components/person/content-list.js
@@ -24,13 +24,13 @@ export { UnorderedList, ListItem }
 /**
  *
  * @param {Object} props
- * @param {string} props.biography
+ * @param {string} props.listData
  * @returns {React.ReactElement}
  */
-export default function ContentList({ biography }) {
+export default function ContentList({ listData }) {
   const biographyList = useMemo(
-    () => stringToSources(biography, '\n'),
-    [biography]
+    () => stringToSources(listData, '\n'),
+    [listData]
   )
   return (
     <UnorderedList>

--- a/packages/politics-tracker/components/person/content-list.js
+++ b/packages/politics-tracker/components/person/content-list.js
@@ -35,7 +35,7 @@ export default function ContentList({ listData }) {
   return (
     <UnorderedList>
       {biographyList &&
-        biographyList.map((item) => (
+        biographyList?.map((item) => (
           <ListItem key={item.id}>{item.value}</ListItem>
         ))}
     </UnorderedList>

--- a/packages/politics-tracker/components/person/edit-content-basic.js
+++ b/packages/politics-tracker/components/person/edit-content-basic.js
@@ -88,6 +88,8 @@ const EDIT_CONTENT_BASIC = [
     isRequired: false,
   },
 ]
+export { SourceInputWrapper }
+
 /**
  *
  * @param {Object} props

--- a/packages/politics-tracker/components/person/edit-content-biography.js
+++ b/packages/politics-tracker/components/person/edit-content-biography.js
@@ -1,0 +1,67 @@
+import React, { useState } from 'react'
+import { stringToSources, getNewSource } from '~/utils/utils'
+import { SourceInputWrapper } from './edit-content-basic'
+import SourceInput from '../politics/source-input'
+import styled from 'styled-components'
+
+const InputWrapperNoLabel = styled(SourceInputWrapper)`
+  label {
+    display: none;
+  }
+`
+/**
+ *
+ * @param {Object} props
+ * @param {string} props.listData
+ * @returns {React.ReactElement}
+ */
+export default function EditContentBiography({ listData }) {
+  const [list, setList] = useState(stringToSources(listData, '\n'))
+
+  function addSource() {
+    const extended = [...list, getNewSource()]
+    setList(extended)
+  }
+
+  /**
+   *
+   * @param {string} id
+   * @param {string} value
+   */
+  function updateSource(id, value) {
+    const updated = list.map((item) => {
+      if (id === item.id) {
+        return { ...item, value }
+      }
+      return item
+    })
+    setList(updated)
+  }
+  /**
+   * @param {string} id
+   */
+  function deleteSource(id) {
+    const remain = list.filter((item) => id !== item.id)
+    setList(remain)
+  }
+  return (
+    <div>
+      {list.map((item, index) => (
+        //TODO: add error and show error
+        <InputWrapperNoLabel key={item.id}>
+          <SourceInput
+            placeholder={'經歷'}
+            id={item.id}
+            no={index + 1}
+            value={item.value}
+            error={item.error}
+            showError={false}
+            removable={index !== 0}
+            onChange={updateSource}
+            onDelete={deleteSource}
+          />
+        </InputWrapperNoLabel>
+      ))}
+    </div>
+  )
+}

--- a/packages/politics-tracker/components/person/edit-content-biography.js
+++ b/packages/politics-tracker/components/person/edit-content-biography.js
@@ -4,11 +4,12 @@ import { SourceInputWrapper } from './edit-content-basic'
 import SourceInput from '../politics/source-input'
 import styled from 'styled-components'
 
-const InputWrapperNoLabel = styled(SourceInputWrapper)`
+export const InputWrapperNoLabel = styled(SourceInputWrapper)`
   label {
     display: none;
   }
 `
+
 /**
  *
  * @param {Object} props
@@ -46,7 +47,7 @@ export default function EditContentBiography({ listData }) {
   }
   return (
     <div>
-      {list.map((item, index) => (
+      {list?.map((item, index) => (
         //TODO: add error and show error
         <InputWrapperNoLabel key={item.id}>
           <SourceInput

--- a/packages/politics-tracker/components/person/edit-content-contact.js
+++ b/packages/politics-tracker/components/person/edit-content-contact.js
@@ -1,0 +1,141 @@
+import React, { Fragment, useState } from 'react'
+import { EditContentItemTitle } from './edit-content-item'
+import { stringToSources, getNewSource } from '~/utils/utils'
+import SourceInput from '../politics/source-input'
+import { InputWrapperNoLabel } from './edit-content-biography'
+import AddInputButton from './add-input-button'
+/**
+ *
+ * @param {Object} props
+ * @param {string} [props.emails]
+ * @param {string} [props.links]
+ * @param {string} [props.contactDetails]
+ * @returns {React.ReactElement}
+ */
+export default function EditContentContact({ emails, links, contactDetails }) {
+  const [emailList, setEmailList] = useState(
+    emails ? stringToSources(emails, '\n') : [getNewSource()]
+  )
+  const [linkList, setLinkList] = useState(
+    links ? stringToSources(links, '\n') : [getNewSource()]
+  )
+  const [contactList, setContactList] = useState(
+    contactDetails ? stringToSources(contactDetails, '\n') : [getNewSource()]
+  )
+
+  /**
+   *
+   * @param  {import('~/types/common').Source[]} list
+   * @param {function} setList
+   * @returns {()=>void}
+   */
+  function addList(list, setList) {
+    return () => {
+      const extended = [...list, getNewSource()]
+      setList(extended)
+    }
+  }
+  /**
+   * @param  {import('~/types/common').Source[]} list
+   * @param {Function} setList
+   * @returns {() => void}
+   */
+  function updateList(list, setList) {
+    return (/** @type {string} */ id, /** @type {string} */ value) => {
+      const updated = list.map((item) => {
+        if (id === item.id) {
+          return { ...item, value }
+        }
+        return item
+      })
+      setList(updated)
+    }
+  }
+
+  /**
+   * @param  {import('~/types/common').Source[]} list
+   * @param {Function} setList
+   * @returns {() => void}
+   */
+  function deleteList(list, setList) {
+    return (/** @type {string} */ id) => {
+      const remain = list.filter((item) => id !== item.id)
+      setList(remain)
+    }
+  }
+
+  const updateEmail = updateList(emailList, setEmailList)
+  const addEmail = addList(emailList, setEmailList)
+  const deleteEmail = deleteList(emailList, setEmailList)
+  const updateLink = updateList(linkList, setLinkList)
+  const addLink = addList(linkList, setLinkList)
+  const deleteLink = deleteList(linkList, setLinkList)
+  const updateContact = updateList(contactList, setContactList)
+  const addContact = addList(contactList, setContactList)
+  const deleteContact = deleteList(contactList, setContactList)
+
+  return (
+    <Fragment>
+      <EditContentItemTitle>電子信箱</EditContentItemTitle>
+
+      {emailList?.map((item, index) => (
+        //TODO: add error and show error
+        <InputWrapperNoLabel key={item.id}>
+          <SourceInput
+            placeholder={'信箱'}
+            id={item.id}
+            no={index + 1}
+            value={item.value}
+            error={item.error}
+            showError={false}
+            removable={index !== 0}
+            onChange={updateEmail}
+            onDelete={deleteEmail}
+          />
+        </InputWrapperNoLabel>
+      ))}
+      <AddInputButton addTarget="電子信箱" onClick={addEmail}></AddInputButton>
+
+      <EditContentItemTitle>電話/地址</EditContentItemTitle>
+      {contactList?.map((item, index) => (
+        //TODO: add error and show error
+        <InputWrapperNoLabel key={item.id}>
+          <SourceInput
+            placeholder={'電話/地址'}
+            id={item.id}
+            no={index + 1}
+            value={item.value}
+            error={item.error}
+            showError={false}
+            removable={index !== 0}
+            onChange={updateContact}
+            onDelete={deleteContact}
+          />
+        </InputWrapperNoLabel>
+      ))}
+      <AddInputButton
+        addTarget="電話/地址"
+        onClick={addContact}
+      ></AddInputButton>
+      <EditContentItemTitle>網站</EditContentItemTitle>
+
+      {linkList?.map((item, index) => (
+        //TODO: add error and show error
+        <InputWrapperNoLabel key={item.id}>
+          <SourceInput
+            placeholder={'網站'}
+            id={item.id}
+            no={index + 1}
+            value={item.value}
+            error={item.error}
+            showError={false}
+            removable={index !== 0}
+            onChange={updateLink}
+            onDelete={deleteLink}
+          />
+        </InputWrapperNoLabel>
+      ))}
+      <AddInputButton addTarget="網站" onClick={addLink}></AddInputButton>
+    </Fragment>
+  )
+}

--- a/packages/politics-tracker/components/person/section-body-personal-file.js
+++ b/packages/politics-tracker/components/person/section-body-personal-file.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 
-import { stringToSources, sourcesToString, getNewSource } from '~/utils/utils'
+import { stringToSources } from '~/utils/utils'
 
 import ContentItem from './content-item'
 import ProfileImage from './profile-image'
@@ -12,6 +12,7 @@ import { useMemo } from 'react'
 import moment from 'moment'
 import EditContentBasic from './edit-content-basic'
 import EditContentBiography from './edit-content-biography'
+import EditContentContact from './edit-content-contact'
 import Sources from './sources'
 const ContentPersonImage = styled(ProfileImage)`
   width: 40px;
@@ -116,19 +117,7 @@ export default function SectionBodyPersonalFile({
     () => formatDate(death_date_year, death_date_month, death_date_day),
     [death_date_year, death_date_month, death_date_day]
   )
-  /**
-   *
-   * @param {string} source
-   * @returns  {import('~/types/common').Source[]}
-   */
-  const getSource = (source) => {
-    if (source) {
-      return stringToSources(source, '\n')
-    } else {
-      return []
-    }
-  }
-  const sourceList = useMemo(() => getSource(source), [source])
+
   const lifespan = useMemo(() => {
     if (
       birth_date_year &&
@@ -190,7 +179,16 @@ export default function SectionBodyPersonalFile({
         <Sources sources={source} />
       </Content>
       {/* TODO: show multiple line */}
-      <Content title="聯絡方式">
+      <Content
+        title="聯絡方式"
+        editContent={
+          <EditContentContact
+            emails={email}
+            contactDetails={contact_details}
+            links={links}
+          />
+        }
+      >
         <ContentItem title="電子信箱" content={email} />
         <ContentItem title="電話/地址" content={contact_details} />
         <ContentLink title="網站" links={links} />

--- a/packages/politics-tracker/components/person/section-body-personal-file.js
+++ b/packages/politics-tracker/components/person/section-body-personal-file.js
@@ -43,7 +43,7 @@ export default function SectionBodyPersonalFile({
     death_date_day,
     gender,
     national_identity,
-    biography,
+    biography = '',
     email,
     contact_details,
     links,

--- a/packages/politics-tracker/components/person/section-body-personal-file.js
+++ b/packages/politics-tracker/components/person/section-body-personal-file.js
@@ -12,6 +12,7 @@ import ContentLink from './content-link'
 import { useState, useMemo } from 'react'
 import moment from 'moment'
 import EditContentBasic from './edit-content-basic'
+import EditContentBiography from './edit-content-biography'
 import Sources from './sources'
 const ContentPersonImage = styled(ProfileImage)`
   width: 40px;
@@ -182,8 +183,11 @@ export default function SectionBodyPersonalFile({
         <Sources sources={source} />
       </Content>
 
-      <Content title="經歷">
-        <ContentList biography={biography} />
+      <Content
+        title="經歷"
+        editContent={<EditContentBiography listData={biography} />}
+      >
+        <ContentList listData={biography} />
         <Sources sources={source} />
       </Content>
       {/* TODO: show multiple line */}

--- a/packages/politics-tracker/components/person/section-body-personal-file.js
+++ b/packages/politics-tracker/components/person/section-body-personal-file.js
@@ -1,15 +1,14 @@
 import styled from 'styled-components'
 
 import { stringToSources, sourcesToString, getNewSource } from '~/utils/utils'
-import ContentTitle from './content-title'
-import EditButton from './edit-button'
+
 import ContentItem from './content-item'
 import ProfileImage from './profile-image'
 import SectionBody from './section-body'
 import Content from './content'
 import ContentList from './content-list'
 import ContentLink from './content-link'
-import { useState, useMemo } from 'react'
+import { useMemo } from 'react'
 import moment from 'moment'
 import EditContentBasic from './edit-content-basic'
 import EditContentBiography from './edit-content-biography'
@@ -32,25 +31,25 @@ export default function SectionBodyPersonalFile({
   personData = {},
 }) {
   const {
-    name,
-    image,
-    alternative,
-    other_names,
+    name = '',
+    image = '',
+    alternative = '',
+    other_names = '',
     birth_date_year,
     birth_date_month,
     birth_date_day,
     death_date_year,
     death_date_month,
     death_date_day,
-    gender,
-    national_identity,
+    gender = '',
+    national_identity = '',
     biography = '',
-    email,
-    contact_details,
-    links,
+    email = '',
+    contact_details = '',
+    links = '',
     source = '',
   } = personData
-
+  console.log(alternative, other_names)
   /**
    * check the date passed in, which will be checked with two rule:
    * 1. If the date is valid. For Instances, if date passed in is "2022-25-35" or "2022-25" or "25-35", which is not valid.
@@ -95,11 +94,11 @@ export default function SectionBodyPersonalFile({
    * @param {import('~/types/person').Person["birth_date_year"]} year
    * @param {import('~/types/person').Person["birth_date_month"]} month
    * @param {import('~/types/person').Person["birth_date_day"]}  day
-   * @returns {String | null}
+   * @returns {String}
    */
   const formatDate = (year = null, month = null, day = null) => {
     if (!validateDate(year, month, day)) {
-      return null
+      return ''
     } else if (year && month && !day) {
       return `${year}-${month}`
     } else if (year && !month && !day) return `${year}`
@@ -154,7 +153,7 @@ export default function SectionBodyPersonalFile({
       return '男'
     } else if (gender === 'F' || gender === '女') {
       return '女'
-    } else return null
+    } else return ''
   }
   const displayedGender = useMemo(() => getDisplayedGender(gender), [gender])
   return (
@@ -172,11 +171,11 @@ export default function SectionBodyPersonalFile({
         <ContentItem title="舊名" content={other_names} />
         <ContentItem
           title="出生日期"
-          content={dateOfBirth ? `${dateOfBirth}${age}` : null}
+          content={dateOfBirth ? `${dateOfBirth}${age}` : ''}
         />
         <ContentItem
           title="死亡日期"
-          content={dateOfDeath ? `${dateOfDeath}${lifespan}` : null}
+          content={dateOfDeath ? `${dateOfDeath}${lifespan}` : ''}
         />
         <ContentItem title="生理性別" content={displayedGender} />
         <ContentItem title="國籍" content={national_identity} />

--- a/packages/politics-tracker/components/person/sources.js
+++ b/packages/politics-tracker/components/person/sources.js
@@ -29,18 +29,21 @@ const SourcesTitle = styled.div`
 /**
  *
  * @param {Object} props
- * @param {string} props.sources
+ * @param {string} [props.sources]
  * @returns
  */
 export default function Sources({ sources }) {
   const [isOpen, setIsOpen] = useState(false)
-  const sourceList = useMemo(() => stringToSources(sources, '\n'), [sources])
+  const sourceList = useMemo(
+    () => (sources ? stringToSources(sources, '\n') : []),
+    [sources]
+  )
   return (
     <Fragment>
       {isOpen && (
         <SourcesContainer>
           <SourcesTitle>來源</SourcesTitle>
-          {sourceList.map((item, index) => (
+          {sourceList?.map((item, index) => (
             <SourceItem
               key={item.id}
               no={index}

--- a/packages/politics-tracker/components/person/sources.js
+++ b/packages/politics-tracker/components/person/sources.js
@@ -37,7 +37,7 @@ export default function Sources({ sources }) {
   const sourceList = useMemo(() => stringToSources(sources, '\n'), [sources])
   return (
     <Fragment>
-      {isOpen && sources && (
+      {isOpen && (
         <SourcesContainer>
           <SourcesTitle>來源</SourcesTitle>
           {sourceList.map((item, index) => (

--- a/packages/politics-tracker/components/politics/source-input.tsx
+++ b/packages/politics-tracker/components/politics/source-input.tsx
@@ -8,6 +8,7 @@ type SourceInputProps = {
   error: string
   showError: boolean
   removable: boolean
+  placeholder?: string
   onChange: (id: string, value: string) => void
   onDelete: (id: string) => void
 }
@@ -21,7 +22,9 @@ export default function SourceInput(props: SourceInputProps): JSX.Element {
         </label>
         <input
           className={s['input']}
-          placeholder="網址, 選舉公報..."
+          placeholder={
+            props.placeholder ? props.placeholder : '網址, 選舉公報...'
+          }
           value={props.value}
           onChange={(e) => {
             props.onChange(props.id, e.target.value)

--- a/packages/politics-tracker/types/person.ts
+++ b/packages/politics-tracker/types/person.ts
@@ -1,10 +1,10 @@
 type PersonType = {
   id: string
   name: string
-  alternative?: string
-  other_names?: string
-  image: string | null
-  gender: string | null
+  alternative: string
+  other_names: string
+  image: string
+  gender: string
   biography: string
   birth_date_year: number | null
   birth_date_month: number | null
@@ -12,10 +12,10 @@ type PersonType = {
   death_date_year: number | null
   death_date_month: number | null
   death_date_day: number | null
-  national_identity: string | null
-  email: string | null
-  contact_details: string | null
-  links?: string
+  national_identity: string
+  email: string
+  contact_details: string
+  links: string
   source: string
 }
 

--- a/packages/politics-tracker/types/person.ts
+++ b/packages/politics-tracker/types/person.ts
@@ -5,7 +5,7 @@ type PersonType = {
   other_names?: string
   image: string | null
   gender: string | null
-  biography: string | null
+  biography: string
   birth_date_year: number | null
   birth_date_month: number | null
   birth_date_day: number | null


### PR DESCRIPTION
- [7714657](https://github.com/readr-media/Sachiel/pull/62/commits/7714657590ffae2722691004bd1a36bc666211eb):使用utils function將字串轉為陣列
- [1093b1a](https://github.com/readr-media/Sachiel/pull/62/commits/1093b1a63bee6d0f11fa27cedcb2f7462796342f)：調整元件`components/politics/source-input.tsx`，新增一傳入變數placeholder，以調整input placeholder的值（預設為`'網址, 選舉公報...'`
- [8356958](https://github.com/readr-media/Sachiel/pull/62/commits/8356958dc059094f35dc7e30b74aefb95a26afa5)：新增元件`edit-content-biography`，用於經歷欄位的編輯模式
- [e2d4a38](https://github.com/readr-media/Sachiel/pull/62/commits/e2d4a387eee720333ccb2997eb327c1e1944f360)：調整content-item，使其可以顯示多藍內容
- [61f13a9](https://github.com/readr-media/Sachiel/pull/62/commits/61f13a9268e89b3c36b87b4e363a90d468c69c98)：新增元件 `edit-content-contact`，用於聯絡方式欄位的編輯模式