### PR TITLE
feat(politics-tracker/person): add feature of send mutation of `biography`, `contact` info

### DIFF
--- a/packages/politics-tracker/components/person/content.js
+++ b/packages/politics-tracker/components/person/content.js
@@ -14,11 +14,20 @@ const ContentContainer = styled.div`
  * @param {string} props.title
  * @param {React.ReactElement[] | React.ReactElement} props.children
  * @param {React.ReactElement[] | React.ReactElement} [props.editContent]
+ * @param {boolean} props.shouldShowEditMode
+ * @param {function} props.setShouldShowEditMode
  * @returns {React.ReactElement}
  */
-export default function Content({ title, children, editContent }) {
-  const [shouldShowEditMode, setShouldShowEditMode] = useState(false)
-
+export default function Content({
+  title,
+  children,
+  editContent,
+  shouldShowEditMode,
+  setShouldShowEditMode,
+}) {
+  const submitHandler = () => {
+    console.log('submit')
+  }
   return (
     <ContentContainer>
       <ContentTitle title={title}>
@@ -28,14 +37,7 @@ export default function Content({ title, children, editContent }) {
           )}
         </Fragment>
       </ContentTitle>
-      {shouldShowEditMode ? (
-        <Fragment>
-          {editContent}
-          <EditSendOrCancel onClick={() => setShouldShowEditMode(false)} />
-        </Fragment>
-      ) : (
-        children
-      )}
+      {shouldShowEditMode ? <Fragment>{editContent}</Fragment> : children}
     </ContentContainer>
   )
 }

--- a/packages/politics-tracker/components/person/edit-content-basic.js
+++ b/packages/politics-tracker/components/person/edit-content-basic.js
@@ -1,8 +1,9 @@
-import { Fragment } from 'react'
+import { Fragment, useState } from 'react'
 import EditContentItem from './edit-content-item'
 import SourceInput from '../politics/source-input'
 import EditSendOrCancel from './edit-send-or-cancel'
 import EditSource from './edit-source'
+import { stringToSources, sourcesToString, getNewSource } from '~/utils/utils'
 
 /**
  * @typedef {Object} EditContentBasic - Basic information of edit field
@@ -86,11 +87,14 @@ const EDIT_CONTENT_BASIC = [
 /**
  *
  * @param {Object} props
- * @param {string} props.sources
+ * @param {string} [props.sources]
  * @param {function} props.setShouldShowEditMode
  * @returns
  */
 export default function EditContentBasic({ sources, setShouldShowEditMode }) {
+  const [sourceList, setSourceList] = useState(
+    sources ? stringToSources(sources, '\n') : [getNewSource()]
+  )
   return (
     <Fragment>
       {EDIT_CONTENT_BASIC.map(
@@ -115,7 +119,7 @@ export default function EditContentBasic({ sources, setShouldShowEditMode }) {
           ></EditContentItem>
         )
       )}
-      <EditSource sources={sources}></EditSource>
+      <EditSource sourceList={sourceList} setSourceList={setSourceList} />
       <EditSendOrCancel
         onClick={() => setShouldShowEditMode(false)}
         submitHandler={() => {}}

--- a/packages/politics-tracker/components/person/edit-content-basic.js
+++ b/packages/politics-tracker/components/person/edit-content-basic.js
@@ -1,7 +1,7 @@
 import { Fragment } from 'react'
 import EditContentItem from './edit-content-item'
 import SourceInput from '../politics/source-input'
-
+import EditSendOrCancel from './edit-send-or-cancel'
 import EditSource from './edit-source'
 
 /**
@@ -87,9 +87,10 @@ const EDIT_CONTENT_BASIC = [
  *
  * @param {Object} props
  * @param {string} props.sources
+ * @param {function} props.setShouldShowEditMode
  * @returns
  */
-export default function EditContentBasic({ sources }) {
+export default function EditContentBasic({ sources, setShouldShowEditMode }) {
   return (
     <Fragment>
       {EDIT_CONTENT_BASIC.map(
@@ -115,6 +116,10 @@ export default function EditContentBasic({ sources }) {
         )
       )}
       <EditSource sources={sources}></EditSource>
+      <EditSendOrCancel
+        onClick={() => setShouldShowEditMode(false)}
+        submitHandler={() => {}}
+      />
     </Fragment>
   )
 }

--- a/packages/politics-tracker/components/person/edit-content-biography.js
+++ b/packages/politics-tracker/components/person/edit-content-biography.js
@@ -1,11 +1,15 @@
 import React, { Fragment, useState } from 'react'
-import { stringToSources, getNewSource } from '~/utils/utils'
+import { stringToSources, sourcesToString, getNewSource } from '~/utils/utils'
 import { SourceInputWrapper } from './edit-source'
 import SourceInput from '../politics/source-input'
 import styled from 'styled-components'
 import EditSource from './edit-source'
 import AddInputButton from './add-input-button'
 import EditSendOrCancel from './edit-send-or-cancel'
+import { print } from 'graphql'
+import CreatePerson from '~/graphql/mutation/person/create-person.graphql'
+import { fireGqlRequest } from '~/utils/utils'
+
 export const InputWrapperNoLabel = styled(SourceInputWrapper)`
   label {
     display: none;
@@ -15,18 +19,65 @@ export const InputWrapperNoLabel = styled(SourceInputWrapper)`
 /**
  *
  * @param {Object} props
- * @param {string} props.listData
- * @param {string} props.sources
+ * @param {string} [props.listData]
+ * @param {string} [props.sources]
  * @param {function} props.setShouldShowEditMode
+ * @param {import('~/types/person').Person["id"]} props.personId
+ * @param {import('~/types/person').Person["name"]} props.personName
+ * @param {function} props.personName
  * @returns {React.ReactElement}
  */
 export default function EditContentBiography({
   listData,
   sources,
   setShouldShowEditMode,
+  personId,
+  personName,
 }) {
-  const [list, setList] = useState(stringToSources(listData, '\n'))
+  const [list, setList] = useState(
+    listData ? stringToSources(listData, '\n') : [getNewSource()]
+  )
+  const [sourceList, setSourceList] = useState(
+    sources ? stringToSources(sources, '\n') : [getNewSource()]
+  )
 
+  //client side only
+  //TODO: use type Person in person.ts rather than {Object}
+  /** @param {Object} data */
+  async function createPerson(data) {
+    const cmsApiUrl = `${window.location.origin}/api/data`
+
+    try {
+      const variables = {
+        data: {
+          thread_parent: {
+            connect: { id: personId },
+          },
+          ...data,
+        },
+      }
+      const result = await fireGqlRequest(
+        print(CreatePerson),
+        variables,
+        cmsApiUrl
+      )
+      console.log(result)
+      return true
+    } catch (err) {
+      console.error(err)
+      return false
+    }
+  }
+  async function submitHandler() {
+    const isSuccess = await createPerson({
+      name: personName,
+      biography: sourcesToString(list, '\n'),
+      source: sourcesToString(sourceList, '\n'),
+    })
+    if (isSuccess) {
+      setShouldShowEditMode(false)
+    }
+  }
   function addSource() {
     const extended = [...list, getNewSource()]
     setList(extended)
@@ -73,10 +124,10 @@ export default function EditContentBiography({
       ))}
       <AddInputButton addTarget="經歷" onClick={addSource}></AddInputButton>
 
-      <EditSource sources={sources} />
+      <EditSource sourceList={sourceList} setSourceList={setSourceList} />
       <EditSendOrCancel
         onClick={() => setShouldShowEditMode(false)}
-        submitHandler={() => {}}
+        submitHandler={() => submitHandler()}
       />
     </Fragment>
   )

--- a/packages/politics-tracker/components/person/edit-content-biography.js
+++ b/packages/politics-tracker/components/person/edit-content-biography.js
@@ -5,6 +5,7 @@ import SourceInput from '../politics/source-input'
 import styled from 'styled-components'
 import EditSource from './edit-source'
 import AddInputButton from './add-input-button'
+import EditSendOrCancel from './edit-send-or-cancel'
 export const InputWrapperNoLabel = styled(SourceInputWrapper)`
   label {
     display: none;
@@ -16,9 +17,14 @@ export const InputWrapperNoLabel = styled(SourceInputWrapper)`
  * @param {Object} props
  * @param {string} props.listData
  * @param {string} props.sources
+ * @param {function} props.setShouldShowEditMode
  * @returns {React.ReactElement}
  */
-export default function EditContentBiography({ listData, sources }) {
+export default function EditContentBiography({
+  listData,
+  sources,
+  setShouldShowEditMode,
+}) {
   const [list, setList] = useState(stringToSources(listData, '\n'))
 
   function addSource() {
@@ -68,6 +74,10 @@ export default function EditContentBiography({ listData, sources }) {
       <AddInputButton addTarget="經歷" onClick={addSource}></AddInputButton>
 
       <EditSource sources={sources} />
+      <EditSendOrCancel
+        onClick={() => setShouldShowEditMode(false)}
+        submitHandler={() => {}}
+      />
     </Fragment>
   )
 }

--- a/packages/politics-tracker/components/person/edit-content-contact.js
+++ b/packages/politics-tracker/components/person/edit-content-contact.js
@@ -5,6 +5,8 @@ import SourceInput from '../politics/source-input'
 import { InputWrapperNoLabel } from './edit-content-biography'
 import AddInputButton from './add-input-button'
 import EditSource from './edit-source'
+import EditSendOrCancel from './edit-send-or-cancel'
+
 /**
  *
  * @param {Object} props
@@ -12,6 +14,7 @@ import EditSource from './edit-source'
  * @param {string} [props.links]
  * @param {string} [props.contactDetails]
  * @param {string} [props.sources]
+ * @param {function} props.setShouldShowEditMode
  * @returns {React.ReactElement}
  */
 export default function EditContentContact({
@@ -19,6 +22,7 @@ export default function EditContentContact({
   links,
   contactDetails,
   sources,
+  setShouldShowEditMode,
 }) {
   const [emailList, setEmailList] = useState(
     emails ? stringToSources(emails, '\n') : [getNewSource()]
@@ -144,6 +148,10 @@ export default function EditContentContact({
       ))}
       <AddInputButton addTarget="網站" onClick={addLink}></AddInputButton>
       <EditSource sources={sources} />
+      <EditSendOrCancel
+        onClick={() => setShouldShowEditMode(false)}
+        submitHandler={() => {}}
+      />
     </Fragment>
   )
 }

--- a/packages/politics-tracker/components/person/edit-send-or-cancel.js
+++ b/packages/politics-tracker/components/person/edit-send-or-cancel.js
@@ -35,13 +35,14 @@ const ArrowIcon = styled(EditIcon)`
  *
  * @param {Object} props
  * @param {function} props.onClick
+ * @param {function} props.submitHandler
  * @returns {React.ReactElement}
  */
-export default function EditSendOrCancel({ onClick }) {
+export default function EditSendOrCancel({ onClick, submitHandler }) {
   return (
     <EditSendOrCancelContainer>
       <EditCancel onClick={() => onClick()}>取消</EditCancel>
-      <EditSend>
+      <EditSend onClick={() => submitHandler()}>
         送出審核
         <ArrowIcon>
           <ArrowRight />

--- a/packages/politics-tracker/components/person/edit-source.js
+++ b/packages/politics-tracker/components/person/edit-source.js
@@ -15,14 +15,11 @@ export { SourceInputWrapper }
 /**
  *
  * @param {Object} props
- * @param {string} [props.sources]
+ * @param {import('~/types/common').Source[]} props.sourceList
+ * @param {function} props.setSourceList
  * @returns {React.ReactElement}
  */
-export default function EditSource({ sources }) {
-  const [sourceList, setSourceList] = useState(
-    sources ? stringToSources(sources, '\n') : [getNewSource()]
-  )
-
+export default function EditSource({ sourceList, setSourceList }) {
   function addSource() {
     const extended = [...sourceList, getNewSource()]
     setSourceList(extended)

--- a/packages/politics-tracker/components/person/edit-tags.js
+++ b/packages/politics-tracker/components/person/edit-tags.js
@@ -5,6 +5,7 @@ import SourceInput from '../politics/source-input'
 import styled from 'styled-components'
 import EditSource from './edit-source'
 import AddInputButton from './add-input-button'
+import EditSendOrCancel from './edit-send-or-cancel'
 export const InputWrapperNoLabel = styled(SourceInputWrapper)`
   label {
     display: none;
@@ -15,6 +16,7 @@ export const InputWrapperNoLabel = styled(SourceInputWrapper)`
  *
  * @param {Object} props
  * @param {import("~/types/person").Person["tags"]} props.tags
+ * @param {function} props.setShouldShowEditMode
  * @returns {React.ReactElement}
  */
 export default function EditTags(props) {
@@ -71,6 +73,10 @@ export default function EditTags(props) {
         </InputWrapperNoLabel>
       ))}
       <AddInputButton addTarget="標籤" onClick={addSource}></AddInputButton>
+      <EditSendOrCancel
+        onClick={() => props.setShouldShowEditMode(false)}
+        submitHandler={() => {}}
+      />
     </Fragment>
   )
 }

--- a/packages/politics-tracker/components/person/section-body-personal-file.js
+++ b/packages/politics-tracker/components/person/section-body-personal-file.js
@@ -8,7 +8,7 @@ import SectionBody from './section-body'
 import Content from './content'
 import ContentList from './content-list'
 import ContentLink from './content-link'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import moment from 'moment'
 import EditContentBasic from './edit-content-basic'
 import EditContentBiography from './edit-content-biography'
@@ -38,6 +38,10 @@ export default function SectionBodyPersonalFile({
   isActive = false,
   personData = {},
 }) {
+  const [basicEditMode, setBasicEditMode] = useState(false)
+  const [bioEditMode, setBioEditMode] = useState(false)
+  const [contactEditMode, setContactEditMode] = useState(false)
+  const [tagEditMode, setTagEditMode] = useState(false)
   const {
     name = '',
     image = '',
@@ -58,7 +62,6 @@ export default function SectionBodyPersonalFile({
     source = '',
     tags = [],
   } = personData
-  console.log(alternative, other_names)
   /**
    * check the date passed in, which will be checked with two rule:
    * 1. If the date is valid. For Instances, if date passed in is "2022-25-35" or "2022-25" or "25-35", which is not valid.
@@ -157,7 +160,14 @@ export default function SectionBodyPersonalFile({
     <SectionBody shouldShowSectionBody={isActive}>
       <Content
         title="基本資料"
-        editContent={<EditContentBasic sources={source} />}
+        shouldShowEditMode={basicEditMode}
+        setShouldShowEditMode={setBasicEditMode}
+        editContent={
+          <EditContentBasic
+            sources={source}
+            setShouldShowEditMode={setBasicEditMode}
+          />
+        }
       >
         <ContentItem title="姓名" content={name}>
           <ContentPersonImage
@@ -181,8 +191,14 @@ export default function SectionBodyPersonalFile({
 
       <Content
         title="經歷"
+        shouldShowEditMode={bioEditMode}
+        setShouldShowEditMode={setBioEditMode}
         editContent={
-          <EditContentBiography listData={biography} sources={source} />
+          <EditContentBiography
+            listData={biography}
+            sources={source}
+            setShouldShowEditMode={setBioEditMode}
+          />
         }
       >
         <ContentList listData={biography} />
@@ -191,10 +207,13 @@ export default function SectionBodyPersonalFile({
       {/* TODO: show multiple line */}
       <Content
         title="聯絡方式"
+        shouldShowEditMode={contactEditMode}
+        setShouldShowEditMode={setContactEditMode}
         editContent={
           <EditContentContact
             emails={email}
             contactDetails={contact_details}
+            setShouldShowEditMode={setContactEditMode}
             links={links}
             sources={source}
           />
@@ -205,7 +224,17 @@ export default function SectionBodyPersonalFile({
         <ContentLink title="網站" links={links} />
         <Sources sources={source} />
       </Content>
-      <Content title="標籤" editContent={<EditTags tags={tags}></EditTags>}>
+      <Content
+        shouldShowEditMode={tagEditMode}
+        setShouldShowEditMode={setTagEditMode}
+        title="標籤"
+        editContent={
+          <EditTags
+            setShouldShowEditMode={setTagEditMode}
+            tags={tags}
+          ></EditTags>
+        }
+      >
         <TagContainer>
           {tags.map((item) => (
             <Tag key={item.id} id={item.id} name={item.name}></Tag>

--- a/packages/politics-tracker/components/person/section-body-personal-file.js
+++ b/packages/politics-tracker/components/person/section-body-personal-file.js
@@ -43,6 +43,7 @@ export default function SectionBodyPersonalFile({
   const [contactEditMode, setContactEditMode] = useState(false)
   const [tagEditMode, setTagEditMode] = useState(false)
   const {
+    id,
     name = '',
     image = '',
     alternative = '',
@@ -195,6 +196,8 @@ export default function SectionBodyPersonalFile({
         setShouldShowEditMode={setBioEditMode}
         editContent={
           <EditContentBiography
+            personId={id}
+            personName={name}
             listData={biography}
             sources={source}
             setShouldShowEditMode={setBioEditMode}
@@ -211,6 +214,8 @@ export default function SectionBodyPersonalFile({
         setShouldShowEditMode={setContactEditMode}
         editContent={
           <EditContentContact
+            personId={id}
+            personName={name}
             emails={email}
             contactDetails={contact_details}
             setShouldShowEditMode={setContactEditMode}

--- a/packages/politics-tracker/graphql/mutation/person/add-person-to-thread.graphql
+++ b/packages/politics-tracker/graphql/mutation/person/add-person-to-thread.graphql
@@ -1,0 +1,22 @@
+mutation AddPeopleToThread($data: PersonCreateInput!) {
+  createPerson(data: $data) {
+    id
+    name
+    image
+    alternative
+    other_names
+    biography
+    birth_date_year
+    birth_date_month
+    birth_date_day
+    death_date_year
+    death_date_month
+    death_date_day
+    gender
+    national_identity
+    email
+    contact_details
+    links
+    source
+  }
+}

--- a/packages/politics-tracker/graphql/mutation/person/create-person.graphql
+++ b/packages/politics-tracker/graphql/mutation/person/create-person.graphql
@@ -1,4 +1,4 @@
-mutation AddPeopleToThread($data: PersonCreateInput!) {
+mutation CreatePerson($data: PersonCreateInput!) {
   createPerson(data: $data) {
     id
     name
@@ -18,5 +18,9 @@ mutation AddPeopleToThread($data: PersonCreateInput!) {
     contact_details
     links
     source
+    thread_parent {
+      id
+      name
+    }
   }
 }


### PR DESCRIPTION
[a542151](https://github.com/readr-media/Sachiel/pull/69/commits/a542151ed3018c7021b7af4041843390d9f809cd): 重構元件，讓編輯模式的送出審核按鈕可吃到編輯後的資料。
[3fab94c](https://github.com/readr-media/Sachiel/pull/69/commits/3fab94c05e97b32e51db207639e2672ce1cd1423)：新增用於人物頁的gql mutation。
[a1f3801](https://github.com/readr-media/Sachiel/pull/69/commits/a1f3801d56ea265b0806b469e15da6873100e02a)：新增人物頁個人檔案「經歷」及「聯絡方式」的mutation。