### PR TITLE
feat(politics-tracker): add href prop to icon component

### DIFF
--- a/packages/politics-tracker/components/icon.tsx
+++ b/packages/politics-tracker/components/icon.tsx
@@ -1,12 +1,10 @@
-import type { LinkProps } from 'next/link'
+import type { LinkHref } from '~/types/common'
 import React from 'react'
 import Link from 'next/link'
 import Image from 'next/future/image'
 import { useState } from 'react'
 import classNames from 'classnames'
 import s from './icon.module.css'
-
-type LinkHref = LinkProps['href']
 
 type IconProps = {
   src: string

--- a/packages/politics-tracker/components/icon.tsx
+++ b/packages/politics-tracker/components/icon.tsx
@@ -1,8 +1,12 @@
+import type { LinkProps } from 'next/link'
 import React from 'react'
+import Link from 'next/link'
 import Image from 'next/future/image'
 import { useState } from 'react'
 import classNames from 'classnames'
 import s from './icon.module.css'
+
+type LinkHref = LinkProps['href']
 
 type IconProps = {
   src: string
@@ -11,9 +15,10 @@ type IconProps = {
   height: number
   borderWidth: number
   unoptimized?: boolean
+  href?: LinkHref
 }
 
-const Icon = React.memo(function Icon(props: IconProps): JSX.Element {
+const IconInner = (props: IconProps) => {
   const [complete, setComplete] = useState<boolean>(false)
 
   const defaultIconStyle = classNames(s['default-icon'], { hidden: complete })
@@ -61,6 +66,20 @@ const Icon = React.memo(function Icon(props: IconProps): JSX.Element {
         </svg>
       </div>
     </div>
+  )
+}
+
+const Icon = React.memo(function Icon(props: IconProps): JSX.Element {
+  return (
+    <>
+      {props.href ? (
+        <Link href={props.href} legacyBehavior={false}>
+          <IconInner {...props} />
+        </Link>
+      ) : (
+        <IconInner {...props} />
+      )}
+    </>
   )
 })
 

--- a/packages/politics-tracker/components/nav.tsx
+++ b/packages/politics-tracker/components/nav.tsx
@@ -1,12 +1,10 @@
-import type { LinkProps } from 'next/link'
+import type { LinkHref } from '~/types/common'
 import classNames from 'classnames'
 import Link from 'next/link'
 import Home from '~/components/icons/home'
 import ArrowLeft from '~/components/icons/arrow-left'
 import ArrowRight from '~/components/icons/arrow-right'
 import s from './nav.module.css'
-
-type LinkHref = LinkProps['href']
 
 export type LinkMember = {
   content: string

--- a/packages/politics-tracker/components/politics/section-body.tsx
+++ b/packages/politics-tracker/components/politics/section-body.tsx
@@ -20,7 +20,7 @@ export default function SectionBody(props: SectionBodyProps): JSX.Element {
           {props.politics.length > 0 ? (
             politicList
           ) : (
-            <div className={s['default']}>這個人還沒有政見...</div>
+            <div className={s['default']}>這個人還沒有被新增政見...</div>
           )}
           <AddPoliticBlock />
         </>

--- a/packages/politics-tracker/components/politics/title.module.css
+++ b/packages/politics-tracker/components/politics/title.module.css
@@ -22,7 +22,7 @@
 }
 .title {
   @apply sub-text;
-  @apply md:mb-2 md:inline-block md:w-[54px];
+  @apply md:flex flex-col flex-nowrap md:mb-2 md:w-[54px] md:mx-auto;
 }
 .content {
   @apply main-text overflow-hidden text-ellipsis;

--- a/packages/politics-tracker/components/politics/title.tsx
+++ b/packages/politics-tracker/components/politics/title.tsx
@@ -1,5 +1,5 @@
 import type { PersonOverview } from '~/types/politics'
-import type { LinkProps } from 'next/link'
+import type { LinkHref } from '~/types/common'
 import Link from 'next/link'
 import { useCallback, useState } from 'react'
 import useFitText from 'use-fit-text'
@@ -113,7 +113,6 @@ type TextConfig = {
   lineHeight: number
   customClass: string
 }
-type LinkHref = LinkProps['href']
 
 export default function Title(props: PersonOverview): JSX.Element {
   const personLarge: IconConfig = {

--- a/packages/politics-tracker/components/politics/title.tsx
+++ b/packages/politics-tracker/components/politics/title.tsx
@@ -23,7 +23,10 @@ type MultipleLineBlock = Pick<
   BlockProps,
   'content' | 'fontSize' | 'lineHeight' | 'children' | 'customClass'
 >
-type PoliticsBlockProps = Pick<BlockProps, 'title' | 'customClass' | 'children'>
+type PoliticsBlockProps = Pick<
+  BlockProps,
+  'title' | 'customClass' | 'children'
+> & { subTitle?: string }
 
 const SingleLineBlock = (props: SingleLineBlock) => {
   const style = classNames(s['single-line-block'], props.customClass)
@@ -87,7 +90,10 @@ const PoliticsBlock = (props: PoliticsBlockProps) => {
   return (
     <div className={containerStyle}>
       <div className={s['text-group']}>
-        <div className={s.title}>{props.title}</div>
+        <div className={s.title}>
+          <span>{props.title}</span>
+          {props.subTitle && <span>{props.subTitle}</span>}
+        </div>
         <div className={s.content}>{props.children}</div>
       </div>
     </div>
@@ -180,13 +186,21 @@ export default function Title(props: PersonOverview): JSX.Element {
             />
           </MultipleLineBlock>
         </PoliticsBlock>
-        <PoliticsBlock title="已審核政見" customClass={s['already-block']}>
+        <PoliticsBlock
+          title="目前"
+          subTitle="政見數"
+          customClass={s['already-block']}
+        >
           <SingleLineBlock
             content={props.completed}
             customClass={mainTextClass}
           />
         </PoliticsBlock>
-        <PoliticsBlock title="待審核政見" customClass={s['waiting-block']}>
+        <PoliticsBlock
+          title="待確認"
+          subTitle="政見數"
+          customClass={s['waiting-block']}
+        >
           <SingleLineBlock
             content={props.waiting}
             customClass={mainTextClass}

--- a/packages/politics-tracker/components/politics/title.tsx
+++ b/packages/politics-tracker/components/politics/title.tsx
@@ -1,4 +1,6 @@
 import type { PersonOverview } from '~/types/politics'
+import type { LinkProps } from 'next/link'
+import Link from 'next/link'
 import { useCallback, useState } from 'react'
 import useFitText from 'use-fit-text'
 import classNames from 'classnames'
@@ -111,6 +113,7 @@ type TextConfig = {
   lineHeight: number
   customClass: string
 }
+type LinkHref = LinkProps['href']
 
 export default function Title(props: PersonOverview): JSX.Element {
   const personLarge: IconConfig = {
@@ -149,19 +152,31 @@ export default function Title(props: PersonOverview): JSX.Element {
     customClass: subTextClass,
   }
 
+  const hrefObject: LinkHref = {
+    pathname: '/person/[id]',
+    query: {
+      id: props.id,
+    },
+  }
+
   return (
     <div className={s['main-container']}>
       <div className={s['profile-block']}>
         <span className={s['avatar-large']}>
-          <Icon src={props.avatar} {...personLarge} />
+          <Icon src={props.avatar} {...personLarge} href={hrefObject} />
         </span>
         <span className={s['avatar-small']}>
-          <Icon src={props.avatar} {...personSmall} />
+          <Icon src={props.avatar} {...personSmall} href={hrefObject} />
         </span>
         <div className={s.name}>
-          <MultipleLineBlock content={props.name} {...mainText}>
-            <SingleLineBlock content={props.name} customClass={mainTextClass} />
-          </MultipleLineBlock>
+          <Link href={hrefObject} legacyBehavior={false}>
+            <MultipleLineBlock content={props.name} {...mainText}>
+              <SingleLineBlock
+                content={props.name}
+                customClass={mainTextClass}
+              />
+            </MultipleLineBlock>
+          </Link>
           <div className={s.party}>
             <Icon src={props.partyIcon} {...party} />
             <div className={s['party-name']}>

--- a/packages/politics-tracker/pages/politics/[personId].tsx
+++ b/packages/politics-tracker/pages/politics/[personId].tsx
@@ -315,7 +315,7 @@ const Politics = (props: PoliticsPageProps) => {
   const navProps: withKeyObject<LinkMember | undefined> = {
     prev: {
       backgroundColor: 'bg-person',
-      content: '回上層',
+      content: '回個人資訊',
       href: {
         pathname: '/person/[id]',
         query: {

--- a/packages/politics-tracker/pages/politics/[personId].tsx
+++ b/packages/politics-tracker/pages/politics/[personId].tsx
@@ -55,6 +55,7 @@ export const getServerSideProps: GetServerSideProps<
 
   try {
     const profile: PersonOverview = {
+      id: '',
       name: '',
       avatar: '',
       party: '',
@@ -165,6 +166,7 @@ export const getServerSideProps: GetServerSideProps<
       const person = latestPersonElection.person_id as RawPerson
       const election = latestPersonElection.election as RawElection
       const party = latestPersonElection.party
+      profile.id = person?.id ?? ''
       profile.name = person?.name ?? ''
       profile.avatar = person?.image ?? ''
       profile.party = partyName(party?.name)

--- a/packages/politics-tracker/types/common.ts
+++ b/packages/politics-tracker/types/common.ts
@@ -1,3 +1,7 @@
+import type { LinkProps } from 'next/link'
+
+export type LinkHref = LinkProps['href']
+
 export type withKeyObject<T> = Record<string, T>
 
 export type GenericGQLData<T, U extends string> = {

--- a/packages/politics-tracker/types/politics.ts
+++ b/packages/politics-tracker/types/politics.ts
@@ -1,4 +1,5 @@
 export type PersonOverview = {
+  id: string
   name: string
   avatar: string
   party: string


### PR DESCRIPTION
* Fix politics#title wording [政見頁 wording 修改](https://app.asana.com/0/1203213267790681/1203234221156472/f)
* Fix politics#section-body default wording [政見頁 wording 修改](https://app.asana.com/0/1203213267790681/1203234221156472/f)
* Update politics#nav back wording [政見頁回人物頁的相關 UI 修改](https://app.asana.com/0/1203213267790681/1203225447575569/f)
* Add href prop to Icon component [政見頁回人物頁的相關 UI 修改](https://app.asana.com/0/1203213267790681/1203225447575569/f)
* Add link to politics#title personal image and name [政見頁回人物頁的相關 UI 修改](https://app.asana.com/0/1203213267790681/1203225447575569/f)