### PR TITLE
fix(politics-tracker): unable show `Minus` icon in `source-input` at mobile

### DIFF
--- a/packages/politics-tracker/components/politics/source-input.module.css
+++ b/packages/politics-tracker/components/politics/source-input.module.css
@@ -15,5 +15,5 @@
   @apply md:text-[16px];
 }
 .minus {
-  @apply ml-1 flex h-8 w-8 shrink-0 cursor-pointer flex-row items-center justify-around self-center text-control;
+  @apply ml-1 block h-8 w-8 shrink-0 cursor-pointer self-center text-control;
 }


### PR DESCRIPTION
修正 `.minus`的css 設定，將`flex`改為`block`，並刪除`flex`的相關設定
