### PR TITLE
fix(politics-tracker): GA tracking ID missing issue

### DIFF
--- a/packages/politics-tracker/components/ga-script.tsx
+++ b/packages/politics-tracker/components/ga-script.tsx
@@ -1,21 +1,23 @@
 import Script from 'next/script'
-import { gaTrackingId } from '~/constants/config'
+import getConfig from 'next/config'
 
 export default function GAScript(): JSX.Element {
+  const { publicRuntimeConfig } = getConfig()
+
   return (
     <>
       {/* ref: https://nextjs.org/docs/messages/next-script-for-ga#using-gtagjs */}
       {/* Google tag (gtag.js) */}
       <Script
         strategy="afterInteractive"
-        src={`https://www.googletagmanager.com/gtag/js?${gaTrackingId}`}
+        src={`https://www.googletagmanager.com/gtag/js?${publicRuntimeConfig?.gaTrackingId}`}
       />
       <Script id="ga-script" strategy="afterInteractive">
         {`
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', '${gaTrackingId}');
+        gtag('config', '${publicRuntimeConfig?.gaTrackingId}');
       `}
       </Script>
     </>

--- a/packages/politics-tracker/components/layout/default.tsx
+++ b/packages/politics-tracker/components/layout/default.tsx
@@ -1,7 +1,6 @@
 import Header from '~/components/header'
 import Footer from '~/components/footer'
 import ToastProvider from '~/components/toast/toast-provider'
-import GAScript from '~/components/ga-script'
 
 type DefaultLayoutProps = {
   children: React.ReactNode
@@ -12,7 +11,6 @@ export default function DefaultLayout({
 }: DefaultLayoutProps): JSX.Element {
   return (
     <>
-      <GAScript />
       <ToastProvider>
         <>
           <Header />

--- a/packages/politics-tracker/next.config.js
+++ b/packages/politics-tracker/next.config.js
@@ -44,6 +44,9 @@ const nextConfig = {
       },
     ]
   },
+  publicRuntimeConfig: {
+    gaTrackingId: process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID,
+  },
 }
 
 module.exports = nextConfig

--- a/packages/politics-tracker/pages/_app.tsx
+++ b/packages/politics-tracker/pages/_app.tsx
@@ -1,8 +1,14 @@
 import '~/styles/globals.css'
 import type { AppProps } from 'next/app'
+import GAScript from '~/components/ga-script'
 
 function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  return (
+    <>
+      <GAScript />
+      <Component {...pageProps} />
+    </>
+  )
 }
 
 export default MyApp

--- a/packages/politics-tracker/pages/index.jsx
+++ b/packages/politics-tracker/pages/index.jsx
@@ -7,7 +7,6 @@ import { print } from 'graphql'
 import { fireGqlRequest, typedHasOwnProperty } from '~/utils/utils'
 import { cmsApiUrl } from '~/constants/config'
 import LandingPage from '~/components/landing/main'
-import GAScript from '~/components/ga-script'
 import GetPeopleInElection from '~/graphql/query/landing/get-people-in-election.graphql'
 import GetPolticsRelatedToPersonElections from '~/graphql/query/landing/get-politics-related-to-person-elections.graphql'
 
@@ -417,7 +416,6 @@ export const getServerSideProps = async ({ res }) => {
 export default function Home(props) {
   return (
     <Fragment>
-      <GAScript />
       <LandingPage
         // @ts-ignore
         propsData={props}


### PR DESCRIPTION
看起來 `NEXT_PUBLIC_` 的運作方式是會在 build time 時就用 inline 的方式處理，
而在 build 時沒有相關環境變數的資訊，所以輸出來的網頁是 undefined，
如果是要在 runtime 且是在前端頁面變動的設定，
需要用 `next.config.json#publicRuntimeConfig` 的方式來處理