### PR TITLE
refactor(pt): upgrade election-votes-comparison pkg to latest

### DIFF
--- a/packages/politics-tracker/package.json
+++ b/packages/politics-tracker/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@readr-media/react-election-votes-comparison": "1.1.3",
+    "@readr-media/react-election-votes-comparison": "2.0.0-beta.3",
     "@twreporter/errors": "^1.1.1",
     "axios": "^1.1.2",
     "chinese-numbers-converter": "^2.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1284,10 +1284,10 @@
     node-addon-api "^3.2.1"
     node-gyp-build "^4.3.0"
 
-"@readr-media/react-election-votes-comparison@1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@readr-media/react-election-votes-comparison/-/react-election-votes-comparison-1.1.3.tgz#899b21557d908b165416e1c2ed1bda42597e94f0"
-  integrity sha512-2RZfwVV9lo9V9Z6V9563yjcqhp5a9enNOQKVdVpSKRT4JEvahDIfSKv6ethZDTMDZbyniHYrSRxRSNfi/o32nQ==
+"@readr-media/react-election-votes-comparison@2.0.0-beta.3":
+  version "2.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@readr-media/react-election-votes-comparison/-/react-election-votes-comparison-2.0.0-beta.3.tgz#94a489045154b3a7e54c43ea973d97109a9008ae"
+  integrity sha512-lFJ2L42eFEdkifG82Q7qZEDPBE9naw8TJ4XSYZhaKHzg/HBZ8F8NxF630lu1jalNRm41WJBVTfy5NAzX5SxnHQ==
   dependencies:
     "@twreporter/errors" "^1.1.1"
     axios "0.27.2"


### PR DESCRIPTION
### Notable Change
- upgrade @readr-media/react-election-votes-comparison to @2.0.0-beta.3

### 實作細節
因為縣市議員部分的資料還沒有 migrate 到 v2 版本，所以 PR 中有些程式碼是為了補足 v1 版本缺少的資料。