### PR TITLE
fix(politics-tracker/landing): toggle and link click event collision issues

### DIFF
--- a/packages/politics-tracker/components/landing/council-content.js
+++ b/packages/politics-tracker/components/landing/council-content.js
@@ -537,6 +537,7 @@ export default function CouncilContent({
                                     as={`/politics/${value.id}`}
                                     key={value.name}
                                     legacyBehavior={false}
+                                    onClick={(e) => e.stopPropagation()}
                                   >
                                     {value.name}
                                   </Link>
@@ -578,6 +579,7 @@ export default function CouncilContent({
                                     as={`/politics/${value.id}`}
                                     key={value.name}
                                     legacyBehavior={false}
+                                    onClick={(e) => e.stopPropagation()}
                                   >
                                     {value.name}
                                   </Link>
@@ -617,6 +619,7 @@ export default function CouncilContent({
                                     as={`/politics/${value.id}`}
                                     key={value.name}
                                     legacyBehavior={false}
+                                    onClick={(e) => e.stopPropagation()}
                                   >
                                     {value.name}
                                   </Link>

--- a/packages/politics-tracker/components/landing/mayor-content.js
+++ b/packages/politics-tracker/components/landing/mayor-content.js
@@ -532,6 +532,7 @@ export default function MayorContent({
                                     as={`/politics/${value.id}`}
                                     key={value.name}
                                     legacyBehavior={false}
+                                    onClick={(e) => e.stopPropagation()}
                                   >
                                     {value.name}
                                   </Link>
@@ -573,6 +574,7 @@ export default function MayorContent({
                                     as={`/politics/${value.id}`}
                                     key={value.name}
                                     legacyBehavior={false}
+                                    onClick={(e) => e.stopPropagation()}
                                   >
                                     {value.name}
                                   </Link>
@@ -612,6 +614,7 @@ export default function MayorContent({
                                     as={`/politics/${value.id}`}
                                     key={value.name}
                                     legacyBehavior={false}
+                                    onClick={(e) => e.stopPropagation()}
                                   >
                                     {value.name}
                                   </Link>

--- a/packages/politics-tracker/package.json
+++ b/packages/politics-tracker/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@readr-media/react-election-votes-comparison": "2.0.0-beta.8",
+    "@readr-media/react-election-votes-comparison": "2.0.0-beta.11",
     "@twreporter/errors": "^1.1.1",
     "axios": "^1.1.2",
     "chinese-numbers-converter": "^2.3.1",

--- a/packages/politics-tracker/pages/election.tsx
+++ b/packages/politics-tracker/pages/election.tsx
@@ -7,7 +7,7 @@ import type {
 } from '~/types/common'
 import { print } from 'graphql'
 import { fireGqlRequest, electionName } from '~/utils/utils'
-import { cmsApiUrl } from '~/constants/config'
+import { cmsApiUrl, env } from '~/constants/config'
 import { districtsMapping, electionTypesMapping } from '~/constants/election'
 // @ts-ignore: no definition
 import errors from '@twreporter/errors'
@@ -46,7 +46,7 @@ export const getServerSideProps: GetServerSideProps<
   switch (electionType) {
     case 'mayor': {
       ldr = new DataLoader({
-        apiOrigin: 'https://whoareyou-gcs.readr.tw',
+        apiUrl: `https://whoareyou-gcs.readr.tw/${env === 'dev' ? 'elections-dev': 'elections'}`,
         year,
         type: electionType,
         district: 'all',
@@ -57,11 +57,11 @@ export const getServerSideProps: GetServerSideProps<
     }
     case 'councilMember': {
       ldr = new DataLoader({
-        apiOrigin: 'https://whoareyou-gcs.readr.tw',
+        apiUrl: `https://whoareyou-gcs.readr.tw/${env === 'dev' ? 'elections-dev': 'elections'}`,
         year,
         type: electionType,
         district: mappedAreaStr,
-        version: 'v1',
+        version: 'v2',
       })
       break
     }
@@ -73,7 +73,7 @@ export const getServerSideProps: GetServerSideProps<
   }
 
   try {
-    const data = Object.assign({ type: electionType }, await ldr.loadData())
+    const data = await ldr.loadData()
 
     const electionMap: Record<string, RawElection> = {}
     const elections: ElectionLink[] = []

--- a/yarn.lock
+++ b/yarn.lock
@@ -1284,10 +1284,10 @@
     node-addon-api "^3.2.1"
     node-gyp-build "^4.3.0"
 
-"@readr-media/react-election-votes-comparison@2.0.0-beta.8":
-  version "2.0.0-beta.8"
-  resolved "https://registry.yarnpkg.com/@readr-media/react-election-votes-comparison/-/react-election-votes-comparison-2.0.0-beta.8.tgz#910fc420c919ef8140c1aab9a6a1b40c3968ceb8"
-  integrity sha512-qQ3ddnqldC1qKCBkUB0ta7CdH8JmeD+AIVrdoso0Iu03PW730sGm8pJJJ/Y9iUkrsCfY6kihc1PiqSURBkT68w==
+"@readr-media/react-election-votes-comparison@2.0.0-beta.11":
+  version "2.0.0-beta.11"
+  resolved "https://registry.yarnpkg.com/@readr-media/react-election-votes-comparison/-/react-election-votes-comparison-2.0.0-beta.11.tgz#4790e1650ebd936ebfbd1f1d68a230be83c4256a"
+  integrity sha512-SVM87wD9uaFkpUh9Qe3bYYrCgS4YP1i7fARGBdI2J78Ie8nD2dX4hA+A/fIs78Kjpclb/Gw/xbo+E3nhdHr5lA==
   dependencies:
     "@twreporter/errors" "^1.1.1"
     axios "0.27.2"


### PR DESCRIPTION
修正 mobile 版型下，縣市長與議員的區域展開功能，會與候選人名稱個別連結在點擊事件上處理產生衝突的情況。
成因：
由於候選人名稱連結在 DOM tree 結構上是包覆在區域的容器底下，當點擊 event 從候選人名稱往上 bubble 時，
被區域容器的點擊監聽處理，整個區域容器被關閉，導致候選人名稱點擊的事件被清除，於是不會跳轉到候選人的政見頁。

cc @ChangRongXuan 

ref: [React: Event Bubbling and Capturing](https://www.robinwieruch.de/react-event-bubbling-capturing/)