### PR TITLE
fix(politics-tracker/politic-detail): adjust progress-bar elected fix(politics-tracker/politic-detail): adjust progress-bar elected false status

### DIFF
--- a/packages/politics-tracker/components/politics-detail/progressbar.js
+++ b/packages/politics-tracker/components/politics-detail/progressbar.js
@@ -116,6 +116,11 @@ const ProgressBar = styled.div`
     background: #2fb7bf;
     color: #ffffff;
   }
+
+  //progress: no election
+  .step4 {
+    width: 50%;
+  }
 `
 /**
  * @param {Object} props
@@ -127,37 +132,53 @@ const ProgressBar = styled.div`
  */
 export default function SectionTitle({ politicData }) {
   // @ts-ignore
+  const electResult = politicData.person.elected
+  // @ts-ignore
   const progressType = politicData.current_progress
 
   return (
     <ProgressBar>
       <div className="arrow-steps clearfix">
-        <div className="step step1">
-          <span>提出政見</span>
-        </div>
-        {(progressType === 'no-progress' || progressType === undefined) && (
-          <div className="step step2 bg-gray">
-            <span>未開始</span>
-          </div>
-        )}
-        {(progressType === 'in-progress' || progressType === 'complete') && (
-          <div className="step step2 bg-yellow">
-            <span>進行中</span>
-          </div>
-        )}
-        {progressType === 'in-trouble' && (
-          <div className="step step2 bg-red">
-            <span>卡關中</span>
-          </div>
-        )}
-        {progressType === 'complete' ? (
-          <div className="step step3 bg-green">
-            <span>已完成</span>
-          </div>
+        {electResult ? (
+          <>
+            <div className="step step1">
+              <span>提出政見</span>
+            </div>
+            {(progressType === 'no-progress' || progressType === undefined) && (
+              <div className="step step2 bg-gray">
+                <span>未開始</span>
+              </div>
+            )}
+            {(progressType === 'in-progress' ||
+              progressType === 'complete') && (
+              <div className="step step2 bg-yellow">
+                <span>進行中</span>
+              </div>
+            )}
+            {progressType === 'in-trouble' && (
+              <div className="step step2 bg-red">
+                <span>卡關中</span>
+              </div>
+            )}
+            {progressType === 'complete' ? (
+              <div className="step step3 bg-green">
+                <span>已完成</span>
+              </div>
+            ) : (
+              <div className="step step3">
+                <span>已完成</span>
+              </div>
+            )}
+          </>
         ) : (
-          <div className="step step3">
-            <span>已完成</span>
-          </div>
+          <>
+            <div className="step step1 step4">
+              <span>提出政見</span>
+            </div>
+            <div className="step step3">
+              <span>未當選</span>
+            </div>
+          </>
         )}
       </div>
     </ProgressBar>

--- a/packages/politics-tracker/graphql/query/politics/get-politic-detail.graphql
+++ b/packages/politics-tracker/graphql/query/politics/get-politic-detail.graphql
@@ -2,6 +2,7 @@ query GetPoliticsDetail($politicId: ID!) {
   politics(where: {id: { equals: $politicId }}) {
     id
     person{
+      elected
       id,
       electoral_district{
         id,


### PR DESCRIPTION
1) 調整 `get-politic-detail.graphql` ，新增 politics > person > elected，取得該候選人該次選舉是否當選data。
2) 調整 `progressbar.js` ，新增 elected 的boolean條件判斷，如 elected為false 則顯示「未當選」進度條設計樣式。