### PR TITLE
chore(politics-tracker/politic-detail): adjust GQL(expert order by reviewDate: desc)

### DIFF
--- a/packages/politics-tracker/graphql/query/politics/get-politic-detail.graphql
+++ b/packages/politics-tracker/graphql/query/politics/get-politic-detail.graphql
@@ -36,7 +36,7 @@ query GetPoliticsDetail($politicId: ID!) {
       content,
       link
     }
-    expertPoint{
+    expertPoint(orderBy:{reviewDate: desc}){
       id,
       avatar,
       contributer,
@@ -46,6 +46,5 @@ query GetPoliticsDetail($politicId: ID!) {
       link,
     }
     dispute
-    
   }
 }


### PR DESCRIPTION
調整 `get-politic-detail.graphql`：politics > expertPoint 新增orderBy條件：reviewDate: desc，越近期發表的專家看點(expertPoint)會排列於專家區塊較上方。（由上到下=>由近到遠）