### PR TITLE
fix(politics-tracker/politic-detail): progress-bar error handle

### DIFF
--- a/packages/politics-tracker/components/politics-detail/progressbar.js
+++ b/packages/politics-tracker/components/politics-detail/progressbar.js
@@ -133,6 +133,7 @@ const ProgressBar = styled.div`
 export default function SectionTitle({ politicData }) {
   // @ts-ignore
   const electResult = politicData.person.elected
+
   // @ts-ignore
   const progressType = politicData.current_progress
 

--- a/packages/politics-tracker/components/politics-detail/section-title.js
+++ b/packages/politics-tracker/components/politics-detail/section-title.js
@@ -130,17 +130,18 @@ export default function SectionTitle({ politicData }) {
           </h1>
           <TitlePartyInfo>
             <div className="partyImage">
-              {politicData.person.party.image ? (
-                <img src={politicData.person.party.image} alt=""></img>
+              {politicData.person.party?.image ? (
+                <img src={politicData.person.party?.image} alt=""></img>
               ) : (
                 <img src="/images/default-head-photo.png" alt=""></img>
               )}
             </div>
-            <span>{politicData.person.party.name}</span>
+            {politicData.person.party?.name ? (
+              <span>{politicData.person.party?.name}</span>
+            ) : (
+              <span>無黨籍</span>
+            )}
           </TitlePartyInfo>
-          {/* <Term>
-            任期 <span>2022-12-29~2026-12-27</span>
-          </Term> */}
         </div>
       </Title>
     </Link>

--- a/packages/politics-tracker/components/politics-detail/section.js
+++ b/packages/politics-tracker/components/politics-detail/section.js
@@ -68,7 +68,9 @@ export default function Section({ politicData }) {
     <SectionContainer>
       <div>
         <SectionTitle politicData={politicData}></SectionTitle>
-        <ProgressBar politicData={politicData}></ProgressBar>
+        {politicData.person.votes_obtained_number !== '' && (
+          <ProgressBar politicData={politicData}></ProgressBar>
+        )}
         <SectionContent politicData={politicData}></SectionContent>
         <Sources></Sources>
         <FeedbackFormContainer>

--- a/packages/politics-tracker/graphql/query/politics/get-politic-detail.graphql
+++ b/packages/politics-tracker/graphql/query/politics/get-politic-detail.graphql
@@ -2,7 +2,9 @@ query GetPoliticsDetail($politicId: ID!) {
   politics(where: {id: { equals: $politicId }}) {
     id
     person{
+      votes_obtained_number
       elected
+      incumbent
       id,
       electoral_district{
         id,
@@ -17,6 +19,8 @@ query GetPoliticsDetail($politicId: ID!) {
        type,
        level,
        status,
+       election_year_year
+
       },
       person_id{
         id,

--- a/packages/politics-tracker/pages/politics/detail/[politicId].js
+++ b/packages/politics-tracker/pages/politics/detail/[politicId].js
@@ -55,6 +55,10 @@ export default function PoliticsDetail({
     },
     alwaysShowHome: true,
   }
+  if (politicData.person.party === null) {
+    // @ts-ignore
+    politicData.person.party = { name: '無黨籍' }
+  }
 
   return (
     <DefaultLayout>
@@ -66,8 +70,8 @@ export default function PoliticsDetail({
               name={politicData.person.person_id.name}
               avatar={politicData.person.person_id.image}
               campaign={latestPersonElection}
-              party={politicData.person.party.name}
-              partyIcon={politicData.person.party.image}
+              party={politicData.person.party?.name}
+              partyIcon={politicData.person.party?.image}
               completed={politicAmount.passed}
               waiting={politicAmount.waiting}
             />

--- a/packages/politics-tracker/types/politics-detail.ts
+++ b/packages/politics-tracker/types/politics-detail.ts
@@ -17,6 +17,9 @@ export type Person = {
   party: Party
   election: Election
   person_id: PersonId
+  votes_obtained_number: string
+  elected: Boolean
+  incumbent: Boolean
 }
 
 export type ElectoralDistrict = {


### PR DESCRIPTION
單一政見頁修正：
1) 進度條：當候選人沒有得票數data( `politics>person>votes_obtained_number`) 時，視為選舉尚未結束 => 進度條不會顯示。
2) 進度條：當該屆選舉已結束，顯示進度條，並進行是否當選Boolean判斷( `politics>person>elected`)。如有當選，則顯示未開始/進行中/已完成 ; 如未當選，則顯示未當選。
3) 候選人黨籍如為「無黨籍」，從無顯示資訊修正為顯示：「無黨籍」。