### PR TITLE
feat(politics-tracker/election): add ReactGA click event (tab&selector)

### DIFF
--- a/packages/politics-tracker/pages/election.tsx
+++ b/packages/politics-tracker/pages/election.tsx
@@ -261,7 +261,7 @@ const Election = (props: ElectionPageProps) => {
                 }
                 logGAEvent('click', `點擊身份別的tab(${tabName})`)
               } else if (_type === 'selector') {
-                logGAEvent('click', `點擊選區的selector`)
+                logGAEvent('click', `點擊選區的selector(${_value})`)
               }
             }}
           />

--- a/packages/politics-tracker/pages/election.tsx
+++ b/packages/politics-tracker/pages/election.tsx
@@ -17,6 +17,7 @@ import DefaultLayout from '~/components/layout/default'
 import Nav, { type LinkMember, NavProps } from '~/components/nav'
 import GetElection from '~/graphql/query/election/get-election.graphql'
 import GetElectionHistoryOfArea from '~/graphql/query/election/get-election-history-of-area.graphql'
+import { logGAEvent } from '~/utils/analytics'
 
 const DataLoader = evc.DataLoader
 
@@ -241,6 +242,28 @@ const Election = (props: ElectionPageProps) => {
             election={election}
             scrollTo={props.scrollTo}
             stickyTopOffset="80px"
+            onChange={(_type: string, _value: string) => {
+              if (_type === 'tab') {
+                let tabName = ''
+                switch (_value) {
+                  case 'normal':
+                    tabName = '區域'
+                    break
+                  case 'plainIndigenous':
+                    tabName = '平地原住民'
+                    break
+                  case 'mountainIndigenous':
+                    tabName = '山地原住民'
+                    break
+                  default:
+                    tabName = _value
+                    break
+                }
+                logGAEvent('click', `點擊身份別的tab(${tabName})`)
+              } else if (_type === 'selector') {
+                logGAEvent('click', `點擊「第${_value}選舉區」selector`)
+              }
+            }}
           />
           <Nav {...navProps} />
         </div>

--- a/packages/politics-tracker/pages/election.tsx
+++ b/packages/politics-tracker/pages/election.tsx
@@ -261,7 +261,7 @@ const Election = (props: ElectionPageProps) => {
                 }
                 logGAEvent('click', `點擊身份別的tab(${tabName})`)
               } else if (_type === 'selector') {
-                logGAEvent('click', `點擊「第${_value}選舉區」selector`)
+                logGAEvent('click', `點擊選區的selector`)
               }
             }}
           />


### PR DESCRIPTION
新增：
1) 從`utils/analytics.ts` 取用 `logGAEvent` function：`logGAEvent()`僅需帶入`action`與`label`兩個參數，`category`在此專案中會在 `utils`裡統一設定為 'Projects_PoliticsTracker'。
2) 於`<evc.ReactComponent.EVC>`新增 onChange event：

   - 當 `_type` === 'tab'：透過switch/case將`_value`轉為`tabName`，呈現 `點擊身份別的tab(區域/平地原住民/山地原住民)`。
   - 當 `_type` === 'selector'：label 設定為 `點擊「第${_value}選舉區」selector`，追蹤使用者點擊的選舉區。
   