### PR TITLE
fix(politics-tracker/politic-detail): <Title> election type data error handle

### DIFF
--- a/packages/politics-tracker/pages/politics/detail/[politicId].js
+++ b/packages/politics-tracker/pages/politics/detail/[politicId].js
@@ -164,7 +164,8 @@ export async function getServerSideProps({ query, res }) {
           passed: passedAmount,
           waiting: waitingAmount,
         },
-        latestPersonElection: personAllElections[0].election.type,
+        latestPersonElection:
+          personAllElections[personAllElections.length - 1].election.type,
         config: feedbackFormConfig,
       }, // will be passed to the page component as props
     }


### PR DESCRIPTION
調整：
1) 傳入<Title>的候選人選舉類型data，因`personAllElections`的`election`( = 候選人歷屆參與過的選舉），排序上是越新參與的選舉index值越大。故調整data取值為`personAllElections[personAllElections.length - 1].election.type`，取得最新一筆候選人參選的選舉資訊。
2) 調整後部分單一政見頁與政見總覽頁在「參選類型」上的不同步狀況已解決。