### PR TITLE
feat(politics-tracker): move custom <Head> title/description to _app.tsx

### DIFF
--- a/packages/politics-tracker/components/custom-head.tsx
+++ b/packages/politics-tracker/components/custom-head.tsx
@@ -72,8 +72,6 @@ export default function CustomHead(): JSX.Element {
 
   return (
     <>
-      <title>{siteInformation.title}</title>
-      <meta name="description" content={siteInformation.description} />
       <OpenGraph properties={siteInformation} />
       <link
         rel="apple-touch-icon"

--- a/packages/politics-tracker/components/custom-head.tsx
+++ b/packages/politics-tracker/components/custom-head.tsx
@@ -31,37 +31,59 @@ const OpenGraph = ({ properties }: { properties: OGProperties }) => {
 
   return (
     <>
-      <meta property="og:locale" content={locale || 'zh_TW'} />
-      <meta property="og:title" content={title} />
-      <meta property="og:type" content={type} />
-      <meta property="og:description" content={description || ''} />
-      <meta property="og:url" content={url} />
-      <meta property="og:site_name" content={site_name} />
+      <meta property="og:locale" content={locale || 'zh_TW'} key="og:locale" />
+      <meta property="og:title" content={title} key="og:title" />
+      <meta property="og:type" content={type} key="og:type" />
+      <meta
+        property="og:description"
+        content={description || ''}
+        key="og:description"
+      />
+      <meta property="og:url" content={url} key="og:url" />
+      <meta property="og:site_name" content={site_name} key="og:site_name" />
       {image && (
         <>
-          <meta property="og:image" content={image.url} />
+          <meta property="og:image" content={image.url} key="og:image" />
           <meta
             property="og:image:secure_url"
             content={image.url.replace('http://', 'https://')}
+            key="og:image:secure_url"
           />
-          <meta property="og:image:width" content={image.width} />
-          <meta property="og:image:height" content={image.height} />
-          <meta property="og:image:type" content={image.type} />
-          <meta name="twitter:image" content={image.url} />
+          <meta
+            property="og:image:width"
+            content={image.width}
+            key="og:image:width"
+          />
+          <meta
+            property="og:image:height"
+            content={image.height}
+            key="og:image:height"
+          />
+          <meta
+            property="og:image:type"
+            content={image.type}
+            key="og:image:type"
+          />
+          <meta name="twitter:image" content={image.url} key="twitter:image" />
         </>
       )}
-      <meta name="twitter:card" content={card} />
-      <meta name="twitter:url" content={url} />
-      <meta name="twitter:title" content={title} />
-      <meta name="twitter:description" content={description || ''} />
+      <meta name="twitter:card" content={card} key="twitter:card" />
+      <meta name="twitter:url" content={url} key="twitter:url" />
+      <meta name="twitter:title" content={title} key="twitter:title" />
+      <meta
+        name="twitter:description"
+        content={description || ''}
+        key="twitter:description"
+      />
     </>
   )
 }
 
 export default function CustomHead(props: HeadProps): JSX.Element {
   const siteInformation: OGProperties = {
-    title: '政見不失憶：臺灣 2022 選舉政見協作平台',
+    title: props.title ?? '政見不失憶：臺灣 2022 選舉政見協作平台',
     description:
+      props.description ??
       '政治總是選前端牛肉，選後變空頭？談政見嚴肅不討好，認真實踐卻鮮少獲得關注？READr 協作平台邀請你一起追蹤候選人選舉時提出的政見，並監督他是否在任期內達成。',
     site_name: '政見不失憶：臺灣 2022 選舉政見協作平台',
     url: siteUrl,
@@ -75,35 +97,11 @@ export default function CustomHead(props: HeadProps): JSX.Element {
     card: 'summary_large_image',
   }
 
-  // console.log(props.title)
-
   return (
     <>
-      <title>{props.title}</title>
-      <meta name="description" content={props.description} />
+      <meta name="description" content={props.description} key="description" />
       <OpenGraph properties={siteInformation} />
-      <link
-        rel="apple-touch-icon"
-        sizes="180x180"
-        href="/apple-touch-icon.png"
-      />
-      <link
-        rel="icon"
-        type="image/png"
-        sizes="32x32"
-        href="/favicon-32x32.png"
-      />
-      <link
-        rel="icon"
-        type="image/png"
-        sizes="16x16"
-        href="/favicon-16x16.png"
-      />
-      <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#04295e" />
-      <link rel="manifest" href="/site.webmanifest" />
       <meta name="application-name" content={siteInformation.title} />
-      <meta name="msapplication-TileColor" content="#04295e" />
-      <meta name="theme-color" content="#04295e" />
     </>
   )
 }

--- a/packages/politics-tracker/components/custom-head.tsx
+++ b/packages/politics-tracker/components/custom-head.tsx
@@ -1,4 +1,5 @@
 import { siteUrl } from '~/constants/config'
+import Head from 'next/head'
 
 export type OGProperties = {
   locale?: 'zh_TW'
@@ -98,10 +99,15 @@ export default function CustomHead(props: HeadProps): JSX.Element {
   }
 
   return (
-    <>
-      <meta name="description" content={props.description} key="description" />
+    <Head>
+      <title key="title">{siteInformation.title}</title>
+      <meta
+        name="description"
+        content={siteInformation.description}
+        key="description"
+      />
       <OpenGraph properties={siteInformation} />
       <meta name="application-name" content={siteInformation.title} />
-    </>
+    </Head>
   )
 }

--- a/packages/politics-tracker/components/custom-head.tsx
+++ b/packages/politics-tracker/components/custom-head.tsx
@@ -20,6 +20,11 @@ export type OGProperties = {
   card: 'summary_large_image'
 }
 
+export type HeadProps = {
+  title?: string
+  description?: string
+}
+
 const OpenGraph = ({ properties }: { properties: OGProperties }) => {
   const { locale, url, site_name, title, type, description, image, card } =
     properties
@@ -53,7 +58,7 @@ const OpenGraph = ({ properties }: { properties: OGProperties }) => {
   )
 }
 
-export default function CustomHead(): JSX.Element {
+export default function CustomHead(props: HeadProps): JSX.Element {
   const siteInformation: OGProperties = {
     title: '政見不失憶：臺灣 2022 選舉政見協作平台',
     description:
@@ -70,8 +75,12 @@ export default function CustomHead(): JSX.Element {
     card: 'summary_large_image',
   }
 
+  // console.log(props.title)
+
   return (
     <>
+      <title>{props.title}</title>
+      <meta name="description" content={props.description} />
       <OpenGraph properties={siteInformation} />
       <link
         rel="apple-touch-icon"

--- a/packages/politics-tracker/pages/_app.tsx
+++ b/packages/politics-tracker/pages/_app.tsx
@@ -8,6 +8,7 @@ import { useEffect } from 'react'
 import { useRouter } from 'next/router'
 import { initGA, logPageView } from '~/utils/analytics'
 import Head from 'next/head'
+import CustomHead from '~/components/custom-head'
 
 function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter()
@@ -34,11 +35,8 @@ function MyApp({ Component, pageProps }: AppProps) {
   return (
     <>
       <Head>
-        <title>政見不失憶：臺灣 2022 選舉政見協作平台</title>
-        <meta
-          name="description"
-          content="政治總是選前端牛肉，選後變空頭？談政見嚴肅不討好，認真實踐卻鮮少獲得關注？READr 協作平台邀請你一起追蹤候選人選舉時提出的政見，並監督他是否在任期內達成。"
-        />
+        <title key="title">政見不失憶：臺灣 2022 選舉政見協作平台</title>
+        <CustomHead />
       </Head>
       {/* ref: https://nextjs.org/docs/messages/next-script-for-ga#using-gtagjs */}
       {/* Google tag (gtag.js) */}

--- a/packages/politics-tracker/pages/_app.tsx
+++ b/packages/politics-tracker/pages/_app.tsx
@@ -7,6 +7,7 @@ import NextNProgress from 'nextjs-progressbar'
 import { useEffect } from 'react'
 import { useRouter } from 'next/router'
 import { initGA, logPageView } from '~/utils/analytics'
+import Head from 'next/head'
 
 function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter()
@@ -32,6 +33,13 @@ function MyApp({ Component, pageProps }: AppProps) {
 
   return (
     <>
+      <Head>
+        <title>政見不失憶：臺灣 2022 選舉政見協作平台</title>
+        <meta
+          name="description"
+          content="政治總是選前端牛肉，選後變空頭？談政見嚴肅不討好，認真實踐卻鮮少獲得關注？READr 協作平台邀請你一起追蹤候選人選舉時提出的政見，並監督他是否在任期內達成。"
+        />
+      </Head>
       {/* ref: https://nextjs.org/docs/messages/next-script-for-ga#using-gtagjs */}
       {/* Google tag (gtag.js) */}
       <Script

--- a/packages/politics-tracker/pages/_app.tsx
+++ b/packages/politics-tracker/pages/_app.tsx
@@ -7,7 +7,6 @@ import NextNProgress from 'nextjs-progressbar'
 import { useEffect } from 'react'
 import { useRouter } from 'next/router'
 import { initGA, logPageView } from '~/utils/analytics'
-import Head from 'next/head'
 import CustomHead from '~/components/custom-head'
 
 function MyApp({ Component, pageProps }: AppProps) {

--- a/packages/politics-tracker/pages/_app.tsx
+++ b/packages/politics-tracker/pages/_app.tsx
@@ -34,10 +34,7 @@ function MyApp({ Component, pageProps }: AppProps) {
 
   return (
     <>
-      <Head>
-        <title key="title">政見不失憶：臺灣 2022 選舉政見協作平台</title>
-        <CustomHead />
-      </Head>
+      <CustomHead />
       {/* ref: https://nextjs.org/docs/messages/next-script-for-ga#using-gtagjs */}
       {/* Google tag (gtag.js) */}
       <Script

--- a/packages/politics-tracker/pages/_document.tsx
+++ b/packages/politics-tracker/pages/_document.tsx
@@ -35,7 +35,6 @@ export default class MyDocument extends Document {
     return (
       <Html lang="en">
         <Head>
-          <CustomHead />
           <link rel="preconnect" href="https://fonts.googleapis.com" />
           <link
             rel="preconnect"
@@ -46,6 +45,31 @@ export default class MyDocument extends Document {
             href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@100;300;400;500;700;900&display=swap"
             rel="stylesheet"
           />
+          <link
+            rel="apple-touch-icon"
+            sizes="180x180"
+            href="/apple-touch-icon.png"
+          />
+          <link
+            rel="icon"
+            type="image/png"
+            sizes="32x32"
+            href="/favicon-32x32.png"
+          />
+          <link
+            rel="icon"
+            type="image/png"
+            sizes="16x16"
+            href="/favicon-16x16.png"
+          />
+          <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#04295e" />
+          <link rel="manifest" href="/site.webmanifest" />
+          <meta
+            name="msapplication-TileColor"
+            content="#04295e"
+            key="msapplication-TileColor"
+          />
+          <meta name="theme-color" content="#04295e" key="theme-color" />
         </Head>
         <body>
           <Main />

--- a/packages/politics-tracker/pages/politics/[personId].tsx
+++ b/packages/politics-tracker/pages/politics/[personId].tsx
@@ -15,7 +15,6 @@ import {
   PROGRESS,
 } from '~/types/common'
 
-import Head from 'next/head'
 import CustomHead, { type HeadProps } from '~/components/custom-head'
 import { useState } from 'react'
 import moment from 'moment'
@@ -402,10 +401,7 @@ const Politics = (props: PoliticsPageProps) => {
 
   return (
     <DefaultLayout>
-      <Head>
-        <title key="title">{headProps.title}</title>
-        <CustomHead {...headProps} />
-      </Head>
+      <CustomHead {...headProps} />
       <main className="flex w-screen flex-col items-center bg-politics">
         <Title {...props.titleProps} {...politicAmounts} />
         <div className="my-10 lg:my-[60px]">

--- a/packages/politics-tracker/pages/politics/[personId].tsx
+++ b/packages/politics-tracker/pages/politics/[personId].tsx
@@ -17,6 +17,7 @@ import {
 
 import { useState } from 'react'
 import moment from 'moment'
+import Head from 'next/head'
 import { print } from 'graphql'
 import { PoliticAmountContext } from '~/components/politics/react-context/politics-context'
 import {
@@ -394,8 +395,17 @@ const Politics = (props: PoliticsPageProps) => {
     <SectionList key={e.id} order={index} {...e} />
   ))
 
+  const HeadInfo = {
+    title: `${props.titleProps.name} - 政見總覽｜READr 政商人物資料庫`,
+    description: `${props.titleProps.name}參選紀錄及相關政見`,
+  }
+
   return (
     <DefaultLayout>
+      <Head>
+        <title>{HeadInfo.title}</title>
+        <meta name="description" content={HeadInfo.description} />
+      </Head>
       <main className="flex w-screen flex-col items-center bg-politics">
         <Title {...props.titleProps} {...politicAmounts} />
         <div className="my-10 lg:my-[60px]">

--- a/packages/politics-tracker/pages/politics/[personId].tsx
+++ b/packages/politics-tracker/pages/politics/[personId].tsx
@@ -17,7 +17,6 @@ import {
 
 import { useState } from 'react'
 import moment from 'moment'
-import Head from 'next/head'
 import { print } from 'graphql'
 import { PoliticAmountContext } from '~/components/politics/react-context/politics-context'
 import {
@@ -34,9 +33,9 @@ import Title from '~/components/politics/title'
 import SectionList from '~/components/politics/section-list'
 // import Nav from '~/components/politics/nav'
 import Nav, { type NavProps } from '~/components/nav'
+import CustomHead, { type HeadProps } from '~/components/custom-head'
 import GetPersonOverView from '~/graphql/query/politics/get-person-overview.graphql'
 import GetPolticsRelatedToPersonElections from '~/graphql/query/politics/get-politics-related-to-person-elections.graphql'
-
 type PoliticsPageProps = {
   titleProps: PersonOverview
   elections: PersonElection[]
@@ -395,17 +394,14 @@ const Politics = (props: PoliticsPageProps) => {
     <SectionList key={e.id} order={index} {...e} />
   ))
 
-  const HeadInfo = {
+  const headProps: HeadProps = {
     title: `${props.titleProps.name} - 政見總覽｜READr 政商人物資料庫`,
     description: `${props.titleProps.name}參選紀錄及相關政見`,
   }
 
   return (
     <DefaultLayout>
-      <Head>
-        <title>{HeadInfo.title}</title>
-        <meta name="description" content={HeadInfo.description} />
-      </Head>
+      <CustomHead {...headProps} />
       <main className="flex w-screen flex-col items-center bg-politics">
         <Title {...props.titleProps} {...politicAmounts} />
         <div className="my-10 lg:my-[60px]">

--- a/packages/politics-tracker/pages/politics/[personId].tsx
+++ b/packages/politics-tracker/pages/politics/[personId].tsx
@@ -15,6 +15,8 @@ import {
   PROGRESS,
 } from '~/types/common'
 
+import Head from 'next/head'
+import CustomHead, { type HeadProps } from '~/components/custom-head'
 import { useState } from 'react'
 import moment from 'moment'
 import { print } from 'graphql'
@@ -33,7 +35,6 @@ import Title from '~/components/politics/title'
 import SectionList from '~/components/politics/section-list'
 // import Nav from '~/components/politics/nav'
 import Nav, { type NavProps } from '~/components/nav'
-import CustomHead, { type HeadProps } from '~/components/custom-head'
 import GetPersonOverView from '~/graphql/query/politics/get-person-overview.graphql'
 import GetPolticsRelatedToPersonElections from '~/graphql/query/politics/get-politics-related-to-person-elections.graphql'
 type PoliticsPageProps = {
@@ -401,7 +402,10 @@ const Politics = (props: PoliticsPageProps) => {
 
   return (
     <DefaultLayout>
-      <CustomHead {...headProps} />
+      <Head>
+        <title key="title">{headProps.title}</title>
+        <CustomHead {...headProps} />
+      </Head>
       <main className="flex w-screen flex-col items-center bg-politics">
         <Title {...props.titleProps} {...politicAmounts} />
         <div className="my-10 lg:my-[60px]">
@@ -413,6 +417,7 @@ const Politics = (props: PoliticsPageProps) => {
         </div>
         <Nav {...navProps} />
       </main>
+      {/* </Fragment> */}
     </DefaultLayout>
   )
 }


### PR DESCRIPTION
調整：

1) `pages/politics/[personId.tsx]` ：新增「政見總覽頁」的`<Head>`與相應的`title/description`資訊。

2) 將 `CustomHead`裡 `title/description` 的資訊，移至`pages/_app.tsx`：

     - 對於通用頁籤的資訊，原設定於`components/custom-head.tsx`中，並export `<CustomHead>` 至`pages/_document.tsx`中做設定。
     - 因專案需求改為「不同頁面有各自頁籤」，在參考[官方文件](https://nextjs.org/docs/messages/no-document-title)後，將通用頁籤的 `title/description` 移至 `pages/_app.tsx`。（因 `_document.tsx` only rendered on the initial pre-render，當切換至其他頁面再跳回首頁時，原首頁的`title/description` 會無法顯示，移至`_app.tsx`後可解決此狀況。）