### PR TITLE
fix(politics-tracker): change <Head> to <CustomHead>

### DIFF
--- a/packages/politics-tracker/pages/person/[id].js
+++ b/packages/politics-tracker/pages/person/[id].js
@@ -1,11 +1,10 @@
 import React from 'react'
 import styled from 'styled-components'
 import { ThemeProvider } from 'styled-components'
-import Head from 'next/head'
+import CustomHead from '~/components/custom-head'
 
 import theme from '~/styles/theme'
 import Title from '~/components/person/title'
-import SectionList from '~/components/person/section-list'
 import Section from '~/components/person/section'
 import { cmsApiUrl } from '~/constants/config'
 import { print } from 'graphql'
@@ -51,17 +50,14 @@ export default function People({ personData, personElectionsData }) {
   }
 
   // next/head title & description
-  const HeadInfo = {
+  const headProps = {
     title: `${personData.name} - 個人資訊｜READr 政商人物資料庫`,
     description: `${personData.name}個人資料、經歷，各種政商關係及記錄`,
   }
 
   return (
     <DefaultLayout>
-      <Head>
-        <title>{HeadInfo.title}</title>
-        <meta name="description" content={HeadInfo.description} />
-      </Head>
+      <CustomHead {...headProps} />
       <ThemeProvider theme={theme}>
         <Main>
           <Title name={personData.name} image={personData.image} />

--- a/packages/politics-tracker/pages/politics/detail/[politicId].js
+++ b/packages/politics-tracker/pages/politics/detail/[politicId].js
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { ThemeProvider } from 'styled-components'
 import theme from '~/styles/theme'
-import Head from 'next/head'
+import CustomHead from '~/components/custom-head'
 
 import DefaultLayout from '~/components/layout/default'
 import Nav from '~/components/nav'
@@ -67,35 +67,25 @@ export default function PoliticsDetail({
   }
 
   //next/head title & description
-  const HeadInfo = { title: '', description: '' }
+  const headProps = { title: '', description: '' }
 
-  // if title length > 20，add "..."
-  if (politicData.desc.length > 20) {
-    HeadInfo.title = `${
-      politicData.person.person_id.name
-    } - ${politicData.desc.slice(0, 20)}⋯｜READr 政商人物資料庫`
-  } else {
-    HeadInfo.title = `${politicData.person.person_id.name} - ${politicData.desc}｜READr 政商人物資料庫`
-  }
+  headProps.title = `${politicData.person.person_id.name} - ${politicData.desc}｜READr 政商人物資料庫`
 
   // if election type = councilor，description add "electoral_district.name"
   if (politicData.person.election.type === '縣市議員') {
-    HeadInfo.description = `${politicData.person.person_id.name}在${
+    headProps.description = `${politicData.person.person_id.name}在${
       politicData.person.election.election_year_year
     }${politicData.person.electoral_district.name.slice(
       0,
       3
     )}議員選舉提出的政見：${politicData.desc}`
   } else {
-    HeadInfo.description = `${politicData.person.person_id.name}在${politicData.person.election.election_year_year}${politicData.person.election.type}選舉提出的政見：${politicData.desc}`
+    headProps.description = `${politicData.person.person_id.name}在${politicData.person.election.election_year_year}${politicData.person.election.type}選舉提出的政見：${politicData.desc}`
   }
 
   return (
     <DefaultLayout>
-      <Head>
-        <title>{HeadInfo.title}</title>
-        <meta name="description" content={HeadInfo.description} />
-      </Head>
+      <CustomHead {...headProps} />
       <ConfigContext.Provider value={config}>
         <ThemeProvider theme={theme}>
           <Main>


### PR DESCRIPTION
調整：將原本頁面各自設定的`<Head>`，調整為`<CustomHead>`元件。僅需將各頁面的`title/description`資訊，作為props傳入`<CustomHead>`，即可設定該頁面特定的`title/description`資訊。