### PR TITLE
fix(politics-tracker): og:title error handle

### DIFF
--- a/packages/politics-tracker/pages/_app.tsx
+++ b/packages/politics-tracker/pages/_app.tsx
@@ -7,7 +7,6 @@ import NextNProgress from 'nextjs-progressbar'
 import { useEffect } from 'react'
 import { useRouter } from 'next/router'
 import { initGA, logPageView } from '~/utils/analytics'
-import CustomHead from '~/components/custom-head'
 
 function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter()
@@ -33,7 +32,6 @@ function MyApp({ Component, pageProps }: AppProps) {
 
   return (
     <>
-      <CustomHead />
       {/* ref: https://nextjs.org/docs/messages/next-script-for-ga#using-gtagjs */}
       {/* Google tag (gtag.js) */}
       <Script

--- a/packages/politics-tracker/pages/index.jsx
+++ b/packages/politics-tracker/pages/index.jsx
@@ -16,6 +16,7 @@ import LandingPage from '~/components/landing/main'
 import GetPeopleInElection from '~/graphql/query/landing/get-people-in-election.graphql'
 import GetPolticsRelatedToPersonElections from '~/graphql/query/landing/get-politics-related-to-person-elections.graphql'
 import GetPostsWithPoliticsTracker from '~/graphql/query/landing/get-posts-related-to-politics-tracker-tag.graphql'
+import CustomHead from '~/components/custom-head'
 
 /**
  * @typedef { import('~/types/landing').PropsData } PropsData
@@ -520,6 +521,7 @@ export const getServerSideProps = async ({ res }) => {
 export default function Home(props) {
   return (
     <Fragment>
+      <CustomHead />
       <LandingPage
         // @ts-ignore
         propsData={props}


### PR DESCRIPTION
調整：
1) 移除原 `pages/_app.tsx` 的`<CustomHead>`，避免各頁面與`_app.tsx`對於 og:title 的重複render。
2) 於 `pages/index.jsx` 新增 `<CustomHead>`。