### PR TITLE
feat(about): add landing of about

### DIFF
--- a/packages/readr/components/about/landing.tsx
+++ b/packages/readr/components/about/landing.tsx
@@ -21,6 +21,7 @@ const MainContainer = styled.div`
       margin: 160px 48px;
       display: flex;
       justify-content: space-between;
+      // max-width = calc(theme.mediaSize.md - 48px * 2);
       max-width: 672px;
     }
   `}

--- a/packages/readr/components/about/landing.tsx
+++ b/packages/readr/components/about/landing.tsx
@@ -26,7 +26,7 @@ const MainContainer = styled.div`
   `}
   ${({ theme }) => `
   ${theme.breakpoint.xl} {
-    margin: 40px 52px;
+    margin: 160px 52px;
     max-width: 1096px;
   }
 `}

--- a/packages/readr/components/about/landing.tsx
+++ b/packages/readr/components/about/landing.tsx
@@ -12,14 +12,13 @@ const Container = styled.div`
 `
 
 const MainContainer = styled.div`
-  z-index: 2;
   position: relative;
   margin: 40px 20px;
   width: 100%;
   position: relative;
   ${({ theme }) => `
     ${theme.breakpoint.md} {
-      margin: 40px 48px;
+      margin: 160px 48px;
       display: flex;
       justify-content: space-between;
       max-width: 672px;
@@ -55,6 +54,7 @@ const LandingContent = styled.div`
   line-height: 150%;
   letter-spacing: 0.03em;
   margin-top: 20px;
+  position: relative;
   .decode-text {
     z-index: 2;
     position: relative;

--- a/packages/readr/components/about/landing.tsx
+++ b/packages/readr/components/about/landing.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import styled from 'styled-components'
 
-import { Language } from '~/types/about'
+import type { Language } from '~/types/about'
 
 const Container = styled.div`
   min-height: 100vh;

--- a/packages/readr/components/about/landing.tsx
+++ b/packages/readr/components/about/landing.tsx
@@ -12,6 +12,8 @@ const Container = styled.div`
 `
 
 const MainContainer = styled.div`
+  z-index: 2;
+  position: relative;
   margin: 40px 20px;
   width: 100%;
   position: relative;
@@ -53,8 +55,10 @@ const LandingContent = styled.div`
   line-height: 150%;
   letter-spacing: 0.03em;
   margin-top: 20px;
-  position: relative;
-  z-index: 2;
+  .decode-text {
+    z-index: 2;
+    position: relative;
+  }
   ${({ theme }) => `
     ${theme.breakpoint.md} {
       margin-top: 0;

--- a/packages/readr/components/about/landing.tsx
+++ b/packages/readr/components/about/landing.tsx
@@ -1,0 +1,330 @@
+import { useCallback, useEffect, useState } from 'react'
+import styled from 'styled-components'
+
+import { Language } from '~/types/about'
+
+const Container = styled.div`
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+`
+
+const MainContainer = styled.div`
+  margin: 40px 20px;
+  width: 100%;
+  position: relative;
+  ${({ theme }) => `
+    ${theme.breakpoint.md} {
+      margin: 40px 48px;
+      display: flex;
+      justify-content: space-between;
+      max-width: 672px;
+    }
+  `}
+  ${({ theme }) => `
+  ${theme.breakpoint.xl} {
+    margin: 40px 52px;
+    max-width: 1096px;
+  }
+`}
+`
+
+const LandingTitle = styled.h2`
+  color: rgba(255, 255, 255, 0.87);
+  font-weight: 700;
+  font-size: 24px;
+  line-height: 150%;
+  letter-spacing: 0.03em;
+  min-width: 211px;
+  z-index: 1;
+  ${({ theme }) => `
+    ${theme.breakpoint.xl} {
+      font-size: 36px;
+    }
+  `}
+`
+
+const LandingContent = styled.div`
+  color: rgba(255, 255, 255, 0.66);
+  font-weight: 700;
+  font-size: 24px;
+  line-height: 150%;
+  letter-spacing: 0.03em;
+  margin-top: 20px;
+  position: relative;
+  z-index: 2;
+  ${({ theme }) => `
+    ${theme.breakpoint.md} {
+      margin-top: 0;
+      position: static;
+    }
+    ${theme.breakpoint.xl} {
+      font-size: 36px;
+      max-width: 724px;
+    }
+  `}
+
+  .text-animation-wrapper {
+    display: inline-block;
+  }
+
+  .text-animation {
+    min-width: 10px;
+    display: inline-block;
+    position: relative;
+    color: transparent;
+    &:before {
+      content: '';
+      color: rgba(235, 240, 44, 1);
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      background: rgba(235, 240, 44, 1);
+      width: 0;
+      height: 1.2em;
+      -webkit-transform: translate(-50%, -55%);
+      -ms-transform: translate(-50%, -55%);
+      transform: translate(-50%, -55%);
+    }
+
+    &.state-1 {
+      &:before {
+        width: 1px;
+      }
+    }
+    &.state-2 {
+      &:before {
+        width: 0.9em;
+      }
+    }
+    &.state-3 {
+      color: rgba(235, 240, 44, 1);
+      &:before {
+        width: 0;
+      }
+    }
+  }
+`
+
+const MainBackground = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100%;
+  z-index: 0;
+  background: -webkit-repeating-linear-gradient(
+    270deg,
+    rgba(0, 0, 0, 0),
+    rgba(0, 0, 0, 0) 34px,
+    #fff 35px,
+    #fff 36px
+  );
+  ${({ theme }) => `
+    ${theme.breakpoint.xl} {
+      background: -webkit-repeating-linear-gradient(
+        270deg,
+        rgba(0, 0, 0, 0),
+        rgba(0, 0, 0, 0) 53px,
+        #fff 53px,
+        #fff 54px
+      );
+    }
+  `}
+`
+
+const LanguageSwitchContainer = styled.div`
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 150%;
+  color: rgba(255, 255, 255, 0.66);
+  ${({ theme }) => `
+    ${theme.breakpoint.md} {
+      top: 80px;
+      right: 48px;
+      right: calc((100vw - 672px)/2);
+    }
+    ${theme.breakpoint.xl} {
+      right: 52px;
+      font-size: 18px;
+      right: calc((100vw - 1096px)/2);
+    }
+  `}
+`
+
+const LanguageChoice = styled.button`
+  margin: 0 20px;
+  :first-child {
+    margin-left: 0;
+  }
+  :last-child {
+    margin-right: 0;
+  }
+  &:hover {
+    color: #ffffff;
+  }
+  ${(props: { isActive: boolean }) => {
+    return props.isActive && 'color: #EBF02C;'
+  }}
+`
+
+export default function Landing({
+  language,
+  setLanguage,
+  title,
+  content,
+}: {
+  language: Language
+  setLanguage: (language: Language) => void
+  title: string
+  content: string
+}): JSX.Element {
+  const [contentHtml, setContentHtml] = useState<string>(content)
+  const [isParsed, setIsParsed] = useState<boolean>(false)
+  const parsedContent = useCallback((): void => {
+    const parts = contentHtml?.split(/(<b>.*?<\/b>)/g)
+    const returnArr = parts.map((part) => {
+      if (part.startsWith('<b>') && part.endsWith('</b>')) {
+        const text = part.substring(3, part.length - 4)
+        const array = Array.from(text)
+        const spanElements = array.map(
+          (char, i) => `<span class="text-animation" key='${i}'>${char}</span>`
+        )
+        if (language === 'en') {
+          return `<div class="text-animation-wrapper">${spanElements.join(
+            ''
+          )}</div>`
+        } else {
+          return spanElements.join('')
+        }
+      } else {
+        return part
+      }
+    })
+    setContentHtml(() => {
+      return returnArr.join('')
+    })
+    setIsParsed(true)
+  }, [contentHtml])
+
+  const thirdStages = useCallback((child: Element) => {
+    if (child.classList.contains('state-2')) {
+      child.classList.add('state-3')
+    }
+  }, [])
+  const secondStages = useCallback(
+    (child: Element) => {
+      if (child.classList.contains('state-1')) {
+        child.classList.add('state-2')
+        setTimeout(thirdStages.bind(null, child), 100)
+      } else if (!child.classList.contains('state-1')) {
+        child.classList.add('state-1')
+      }
+    },
+    [thirdStages]
+  )
+
+  const firstStages = useCallback(
+    (child: Element) => {
+      if (child.classList.contains('state-2')) {
+        child.classList.add('state-3')
+      } else if (child.classList.contains('state-1')) {
+        child.classList.add('state-2')
+      } else if (!child.classList.contains('state-1')) {
+        child.classList.add('state-1')
+        setTimeout(secondStages.bind(null, child), 100)
+      }
+    },
+    [secondStages]
+  )
+
+  const decodeText = useCallback(() => {
+    const text = document
+      .getElementsByClassName('decode-text')[0]
+      .querySelectorAll('.text-animation')
+
+    // assign the placeholder array its places
+    const state: number[] = []
+    for (let i = 0, j = text.length; i < j; i++) {
+      text[i].classList.remove('state-1', 'state-2', 'state-3')
+      state[i] = i
+    }
+
+    // shuffle the array to get new sequences each time
+    const shuffled = shuffle(state)
+
+    for (let i = 0, j = shuffled.length; i < j; i++) {
+      const child = text[shuffled[i]] as Element
+      const classes = child.classList
+
+      // fire the first one at random times
+      const state1Time = Math.round(Math.random() * (2000 - 300)) + 50
+      if (classes.contains('text-animation')) {
+        setTimeout(firstStages.bind(null, child), state1Time)
+      }
+    }
+  }, [firstStages])
+
+  function shuffle(array: number[]) {
+    let currentIndex = array.length
+    let temporaryValue, randomIndex
+
+    // While there remain elements to shuffle...
+    while (0 !== currentIndex) {
+      // Pick a remaining element...
+      randomIndex = Math.floor(Math.random() * currentIndex)
+      currentIndex -= 1
+
+      // And swap it with the current element.
+      temporaryValue = array[currentIndex]
+      array[currentIndex] = array[randomIndex]
+      array[randomIndex] = temporaryValue
+    }
+    return array
+  }
+
+  useEffect(() => {
+    setIsParsed(false)
+    parsedContent()
+    decodeText()
+  }, [parsedContent, decodeText])
+
+  useEffect(() => {
+    if (isParsed) setContentHtml(content)
+  }, [content, isParsed])
+
+  return (
+    <Container>
+      <LanguageSwitchContainer>
+        <LanguageChoice
+          isActive={language === 'ch'}
+          onClick={() => setLanguage('ch')}
+        >
+          中文
+        </LanguageChoice>
+        |
+        <LanguageChoice
+          isActive={language === 'en'}
+          onClick={() => setLanguage('en')}
+        >
+          EN
+        </LanguageChoice>
+      </LanguageSwitchContainer>
+      <MainContainer>
+        <LandingTitle>{title}</LandingTitle>
+        <LandingContent>
+          <MainBackground />
+          <div
+            className="decode-text"
+            dangerouslySetInnerHTML={{ __html: contentHtml }}
+          />
+        </LandingContent>
+      </MainContainer>
+    </Container>
+  )
+}

--- a/packages/readr/pages/about.tsx
+++ b/packages/readr/pages/about.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 
 import Landing from '~/components/about/landing'
 import LayoutWithLogoOnly from '~/components/layout/layout-with-logo-only'
-import { Language } from '~/types/about'
+import type { Language } from '~/types/about'
 
 import type { NextPageWithLayout } from './_app'
 
@@ -14,22 +14,14 @@ import type { NextPageWithLayout } from './_app'
  * This comment specifies that in the English mode, the <b> tags should not be split across lines.
  * However, in the Chinese mode, the <b> tags may still be split across lines due to text wrapping.
  */
-type Wording = {
-  ch: {
-    landing: {
-      title: string
-      content: string
-    }
-  }
-  en: {
-    landing: {
-      title: string
-      content: string
-    }
+type languageWording = {
+  landing: {
+    title: string
+    content: string
   }
 }
 
-const wording: Wording = {
+const wording: Record<Language, languageWording> = {
   ch: {
     landing: {
       title: '關於我們',

--- a/packages/readr/pages/about.tsx
+++ b/packages/readr/pages/about.tsx
@@ -9,6 +9,11 @@ import { Language } from '~/types/about'
 
 import type { NextPageWithLayout } from './_app'
 
+/*
+ * The `content` field is a string that may contain <b> tags for emphasis.
+ * This comment specifies that in the English mode, the <b> tags should not be split across lines.
+ * However, in the Chinese mode, the <b> tags may still be split across lines due to text wrapping.
+ */
 type Wording = {
   ch: {
     landing: {

--- a/packages/readr/pages/about.tsx
+++ b/packages/readr/pages/about.tsx
@@ -1,13 +1,72 @@
 // under construction
 
-import type { ReactElement } from 'react'
+import { ReactElement, useState } from 'react'
+import styled from 'styled-components'
 
+import Landing from '~/components/about/landing'
 import LayoutWithLogoOnly from '~/components/layout/layout-with-logo-only'
+import { Language } from '~/types/about'
 
 import type { NextPageWithLayout } from './_app'
 
+type Wording = {
+  ch: {
+    landing: {
+      title: string
+      content: string
+    }
+  }
+  en: {
+    landing: {
+      title: string
+      content: string
+    }
+  }
+}
+
+const wording: Wording = {
+  ch: {
+    landing: {
+      title: '關於我們',
+      content:
+        'READr 是致力於以<b>資料</b>做<b>新聞</b>與<b>內容實驗</b>的媒體。於 2018 年正式創立，重視與各種專業者、讀者的協作，期望讓以往封閉的新聞編輯室有開放的可能。<b>資料分析、多媒體互動、理想的閱讀體驗、開放資料、開源工具</b>，都是我們提供的服務。',
+    },
+  },
+  en: {
+    landing: {
+      title: 'About',
+      content:
+        'READr uses <b>data</b> for <b>news</b> and <b>content</b> <b>experimentation</b>. Collaboration with diverse professionals and readers opens the once-closed newsroom. We provide services like <b>data</b> <b>analysis,</b> <b>multimedia,</b> <b>ideal</b> <b>reading</b> <b>experiences,</b> <b>open</b> <b>data,</b> <b>and</b> <b>tools.</b>',
+    },
+  },
+}
+
+const Page = styled.div`
+  background: #000928;
+  box-shadow: inset 8px 0px 0px #ebf02c;
+  max-width: 100vw;
+  min-widtht: 100vw;
+  font-family: 'Noto Sans TC';
+  overflow: hidden;
+  ${({ theme }) => `
+    ${theme.breakpoint.md} {
+      box-shadow: inset 20px 0px 0px #ebf02c;
+    }
+  `}
+`
+
 const About: NextPageWithLayout = () => {
-  return <p>About Us page is under construction!</p>
+  const [language, setLanguage] = useState<Language>('ch')
+  return (
+    <Page>
+      <Landing
+        language={language}
+        setLanguage={setLanguage}
+        title={wording[language].landing.title}
+        content={wording[language].landing.content}
+      />
+    </Page>
+  )
 }
 
 About.getLayout = function getLayout(page: ReactElement) {

--- a/packages/readr/types/about.tsx
+++ b/packages/readr/types/about.tsx
@@ -1,0 +1,1 @@
+export type Language = 'ch' | 'en'


### PR DESCRIPTION
### 描述
- 新增 `about` 頁面的 landing。
- 包含可以選擇語言，並且根據語言選擇顯示內容。
- 使用說明：將設計稿上黃色的部分用 `<b>` tag 標記起來，中文的話整塊標即可，英文部份考慮換段需求，請一個單字一個單字標。（例如：`<b>this</b> <b>is</b> <b>a</b> <b>book.</b>`)
- 字串處理原則：先經過 `parsedContent()` 將字串切分成一個字母一個 element，之後更改 state `contentHtml`，並由 `decodeText()` 開始更改 elements 的 className，達成設計稿上預期的動畫效果。

### 參考資料
- 設計稿：https://www.figma.com/file/RfJHjsr8rBa7iIC7ir41AZ/2021_READr_Website?node-id=3360-21686&t=I7ZmiFsdRAogQS0B-0
- 動畫參考：https://codepen.io/BRacicot/pen/Nryjpa