### PR TITLE
refactor(readr): replace NextImage with ReactImage

### DIFF
--- a/packages/readr/components/index/category-list.tsx
+++ b/packages/readr/components/index/category-list.tsx
@@ -1,6 +1,6 @@
 // 報導清單
 
-import styled, { css } from 'styled-components'
+import styled, { css, useTheme } from 'styled-components'
 
 import ArticleListCard from '~/components/shared/article-list-card'
 import type { ArticleCard } from '~/types/component'
@@ -55,10 +55,24 @@ type CategoryListProps = {
 export default function CategoryList({
   posts = [],
 }: CategoryListProps): JSX.Element {
+  const theme = useTheme()
+
   const articleItems = posts.map((article) => {
     return (
       <Item key={article.id}>
-        <ArticleListCard {...article} isReport={false} />
+        <ArticleListCard
+          {...article}
+          isReport={false}
+          rwd={{
+            mobile: '30vw',
+            tablet: '50vw',
+            default: '256px',
+          }}
+          breakpoint={{
+            mobile: `${theme.mediaSize.sm - 1}px`,
+            tablet: `${theme.mediaSize.xl - 1}px`,
+          }}
+        />
       </Item>
     )
   })

--- a/packages/readr/components/index/category-report-card.tsx
+++ b/packages/readr/components/index/category-report-card.tsx
@@ -1,13 +1,12 @@
 // 類別專題報導
 
-import NextImage from 'next/image'
+import SharedImage from '@readr-media/react-image'
 import NextLink from 'next/link'
-import styled from 'styled-components'
+import styled, { useTheme } from 'styled-components'
 
 import DateAndReadTimeInfo from '~/components/shared/date-and-read-time-info'
 import ReportLabel from '~/components/shared/report-label'
 import { DEFAULT_POST_IMAGE_PATH } from '~/constants/constant'
-import useFallbackImage from '~/hooks/useFallbackImage'
 import type { ArticleCard } from '~/types/component'
 
 const Container = styled(NextLink)`
@@ -58,6 +57,11 @@ const Container = styled(NextLink)`
       padding-top: 75%;
     }
     img {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
       object-fit: cover;
       object-position: center;
       background-color: #d8d8d8;
@@ -157,26 +161,31 @@ export default function CategoryReportCard({
   const {
     href = '/',
     title = '',
-    image = DEFAULT_POST_IMAGE_PATH,
+    images = {},
     date = '',
     readTimeText = '',
     isReport = false,
   } = report ?? {}
 
-  const { imageSrc, onErrorHandle } = useFallbackImage(
-    image,
-    DEFAULT_POST_IMAGE_PATH
-  )
+  const theme = useTheme()
 
   return (
     <Container href={href} target="_blank">
       <picture>
-        <NextImage
-          src={imageSrc}
-          onError={onErrorHandle}
-          fill={true}
-          unoptimized={true}
+        <SharedImage
+          images={images}
+          defaultImage={DEFAULT_POST_IMAGE_PATH}
           alt={title}
+          priority={false}
+          rwd={{
+            mobile: '100vw',
+            tablet: '40vw',
+            default: '540px',
+          }}
+          breakpoint={{
+            mobile: `${theme.mediaSize.sm - 1}px`,
+            tablet: `${theme.mediaSize.xl - 1}px`,
+          }}
         />
       </picture>
       {isReport && <ReportLabel />}

--- a/packages/readr/components/index/editor-choice-card.tsx
+++ b/packages/readr/components/index/editor-choice-card.tsx
@@ -1,13 +1,16 @@
 // 編輯精選文章卡片
 
-import NextImage from 'next/image'
+import SharedImage from '@readr-media/react-image'
+import type {
+  Breakpoint,
+  Rwd,
+} from '@readr-media/react-image/dist/react-components'
 import NextLink from 'next/link'
-import styled from 'styled-components'
+import styled, { useTheme } from 'styled-components'
 
 import DateAndReadTimeInfo from '~/components/shared/date-and-read-time-info'
 import ReportLabel from '~/components/shared/report-label'
 import { DEFAULT_POST_IMAGE_PATH } from '~/constants/constant'
-import useFallbackImage from '~/hooks/useFallbackImage'
 import IconFeaturedLabel from '~/public/icons/featured-label.svg'
 import type { ArticleCard } from '~/types/component'
 
@@ -55,6 +58,11 @@ const Container = styled(NextLink)<StyledProps>`
       padding-top: 52.5%;
     }
     img {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
       object-fit: cover;
       object-position: center;
       background-color: #d8d8d8;
@@ -177,26 +185,37 @@ export type ArticleCardWithIsFeatured = ArticleCard & {
 export default function EditorChoiceCard({
   href = '/',
   title = '',
-  image = DEFAULT_POST_IMAGE_PATH,
+  images = {},
   date = '',
   readTimeText = '',
   isFeatured = false,
   isReport = false,
 }: ArticleCardWithIsFeatured): JSX.Element {
-  const { imageSrc, onErrorHandle } = useFallbackImage(
-    image,
-    DEFAULT_POST_IMAGE_PATH
-  )
+  const theme = useTheme()
+
+  const breakpoint: Breakpoint = isFeatured
+    ? {
+        mobile: `${theme.mediaSize.xl - 1}px`,
+      }
+    : {
+        mobile: `${theme.mediaSize.md - 1}px`,
+        tablet: `${theme.mediaSize.xl - 1}px`,
+      }
+
+  const rwd: Rwd = isFeatured
+    ? { mobile: '100vw', default: '720px' }
+    : { mobile: '100vw', tablet: '50vw', default: '300px' }
 
   return (
     <Container href={href} target="_blank" $isFeatured={isFeatured}>
       <picture>
-        <NextImage
-          src={imageSrc}
-          onError={onErrorHandle}
-          fill={true}
-          unoptimized={true}
+        <SharedImage
+          images={images}
+          defaultImage={DEFAULT_POST_IMAGE_PATH}
           alt={title}
+          priority={true}
+          rwd={rwd}
+          breakpoint={breakpoint}
         />
       </picture>
       {isReport && <ReportLabel />}

--- a/packages/readr/components/index/feature-card.tsx
+++ b/packages/readr/components/index/feature-card.tsx
@@ -1,11 +1,14 @@
-// 精選文章卡片 (might be legacy)
+// 精選文章卡片
 
-import NextImage from 'next/image'
+import SharedImage from '@readr-media/react-image'
+import type {
+  Breakpoint,
+  Rwd,
+} from '@readr-media/react-image/dist/react-components'
 import NextLink from 'next/link'
-import styled from 'styled-components'
+import styled, { useTheme } from 'styled-components'
 
 import { DEFAULT_POST_IMAGE_PATH } from '~/constants/constant'
-import useFallbackImage from '~/hooks/useFallbackImage'
 import type { FeaturedArticle } from '~/types/component'
 
 type StyledProps = {
@@ -43,6 +46,11 @@ const Container = styled(NextLink)<Pick<StyledProps, '$isFirst'>>`
     }
 
     img {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
       object-fit: cover;
       object-position: center;
       background-color: #d8d8d8;
@@ -212,26 +220,32 @@ export default function FeatureCard({
   href = '/',
   title = '',
   subtitle = '',
-  image = DEFAULT_POST_IMAGE_PATH,
+  images = {},
   description = '',
   isFirst = false,
 }: FeaturedArticleWithIsFirst): JSX.Element {
-  const { imageSrc, onErrorHandle } = useFallbackImage(
-    image,
-    DEFAULT_POST_IMAGE_PATH
-  )
-
   const [emoji, textWithoutEmoji] = description.split(' ')
+  const theme = useTheme()
+
+  const breakpoint: Breakpoint = {
+    mobile: `${theme.mediaSize.md - 1}px`,
+    tablet: `${theme.mediaSize.xl - 1}px`,
+  }
+
+  const rwd: Rwd = isFirst
+    ? { mobile: '100vw', tablet: '50vw', default: '100vw' }
+    : { mobile: '100vw', tablet: '50vw', default: '33vw' }
 
   return (
     <Container href={href} target="_blank" $isFirst={isFirst}>
       <picture>
-        <NextImage
-          src={imageSrc}
-          onError={onErrorHandle}
-          fill={true}
-          unoptimized={true}
+        <SharedImage
+          images={images}
+          defaultImage={DEFAULT_POST_IMAGE_PATH}
           alt={title}
+          priority={true}
+          rwd={rwd}
+          breakpoint={breakpoint}
         />
       </picture>
       {title && (

--- a/packages/readr/components/index/feature-section.tsx
+++ b/packages/readr/components/index/feature-section.tsx
@@ -1,4 +1,4 @@
-// 精選文章卡片 (might be legacy)
+// 精選文章卡片
 
 import styled from 'styled-components'
 

--- a/packages/readr/components/layout/header/header-general.tsx
+++ b/packages/readr/components/layout/header/header-general.tsx
@@ -13,7 +13,7 @@ import IconHamburger from '~/public/icons/hamburger.svg'
 import { mediaSize } from '~/styles/theme'
 import type { ArticleCard } from '~/types/component'
 import * as gtag from '~/utils/gtag'
-import { convertPostToArticleCard, getImageOfArticle } from '~/utils/post'
+import { convertPostToArticleCard } from '~/utils/post'
 
 import CategoriesAndRelatedPosts from './categories-and-related-posts'
 const HamburgerMenu = dynamic(() => import('./hamburger-menu'))
@@ -192,10 +192,8 @@ export default function HeaderGeneral({
       const relatedList =
         item.posts?.map((post) => {
           const { heroImage, ogImage } = post
-          const image = getImageOfArticle({
-            images: [heroImage, ogImage],
-          })
-          return convertPostToArticleCard(post, image)
+          const images = heroImage?.resized ?? ogImage?.resized ?? {}
+          return convertPostToArticleCard(post, undefined, images)
         }) ?? []
 
       return {

--- a/packages/readr/components/layout/header/header-general.tsx
+++ b/packages/readr/components/layout/header/header-general.tsx
@@ -193,7 +193,7 @@ export default function HeaderGeneral({
         item.posts?.map((post) => {
           const { heroImage, ogImage } = post
           const images = heroImage?.resized ?? ogImage?.resized ?? {}
-          return convertPostToArticleCard(post, undefined, images)
+          return convertPostToArticleCard(post, images)
         }) ?? []
 
       return {

--- a/packages/readr/components/layout/header/related-list-in-header.tsx
+++ b/packages/readr/components/layout/header/related-list-in-header.tsx
@@ -71,6 +71,7 @@ export default function RelatedListInHeader({
         {...article}
         shouldHideBottomInfos={true}
         shouldNotLazyload={true}
+        rwd={{ default: '240px' }}
       />
     </li>
   ))

--- a/packages/readr/components/shared/article-list-card.tsx
+++ b/packages/readr/components/shared/article-list-card.tsx
@@ -1,11 +1,14 @@
 // 該元件作為文章資訊卡片使用
 
-import NextImage from 'next/image'
+import SharedImage from '@readr-media/react-image'
+import type {
+  Breakpoint,
+  Rwd,
+} from '@readr-media/react-image/dist/react-components'
 import NextLink from 'next/link'
 import styled from 'styled-components'
 
 import { DEFAULT_POST_IMAGE_PATH } from '~/constants/constant'
-import useFallbackImage from '~/hooks/useFallbackImage'
 import type { ArticleCard } from '~/types/component'
 
 import DateAndReadTimeInfo from './date-and-read-time-info'
@@ -72,6 +75,11 @@ const ImageWrapper = styled.div<StyledProps>`
     }
 
     img {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
       object-fit: cover;
       object-position: center;
       background-color: #d8d8d8;
@@ -178,12 +186,14 @@ type ArticleListCardProps = ArticleCard & {
   shouldHideBottomInfos?: boolean
   shouldNotLazyload?: boolean
   onClick?: () => any
+  rwd?: Rwd
+  breakpoint?: Breakpoint
 }
 
 export default function ArticleListCard({
   href = '/',
   title = '',
-  image = DEFAULT_POST_IMAGE_PATH,
+  images = {},
   date = '',
   readTimeText = '',
   isReport = false,
@@ -192,13 +202,10 @@ export default function ArticleListCard({
   shouldHideBottomInfos = false,
   shouldNotLazyload = false,
   onClick,
+  rwd,
+  breakpoint,
 }: ArticleListCardProps): JSX.Element {
   const isReportAndShouldHighlight = isReport && shouldHighlightReport
-
-  const { imageSrc, onErrorHandle } = useFallbackImage(
-    image,
-    DEFAULT_POST_IMAGE_PATH
-  )
 
   function clickHander(event: unknown) {
     ;(event as Event).stopPropagation()
@@ -220,13 +227,13 @@ export default function ArticleListCard({
         $shouldHighlightReport={isReportAndShouldHighlight}
       >
         <picture>
-          <NextImage
-            src={imageSrc}
-            onError={onErrorHandle}
-            fill={true}
-            unoptimized={true}
+          <SharedImage
+            images={images}
+            defaultImage={DEFAULT_POST_IMAGE_PATH}
             alt={title}
             priority={shouldNotLazyload}
+            rwd={rwd}
+            breakpoint={breakpoint}
           />
         </picture>
         {isReport && <ReportLabel />}

--- a/packages/readr/pages/index.tsx
+++ b/packages/readr/pages/index.tsx
@@ -113,11 +113,17 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async () => {
       editorChoices = data.editorChoices.map((editorChoice) => {
         const { heroImage, ogImage } = editorChoice.choices ?? {}
 
-        const image = getImageOfArticle({
-          images: [editorChoice.heroImage, heroImage, ogImage],
-        })
+        const images =
+          editorChoice.heroImage?.resized ??
+          heroImage?.resized ??
+          ogImage?.resized ??
+          {}
 
-        return convertPostToArticleCard(editorChoice?.choices, image)
+        return convertPostToArticleCard(
+          editorChoice?.choices,
+          undefined,
+          images
+        )
       })
     }
 

--- a/packages/readr/pages/index.tsx
+++ b/packages/readr/pages/index.tsx
@@ -243,11 +243,13 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async () => {
         const { description } = feature
         const { subtitle = '', heroImage, ogImage } = feature.featurePost ?? {}
 
-        const image = getImageOfArticle({
-          images: [heroImage, ogImage],
-        })
+        const images = heroImage?.resized ?? ogImage?.resized ?? {}
 
-        const article = convertPostToArticleCard(feature?.featurePost, image)
+        const article = convertPostToArticleCard(
+          feature?.featurePost,
+          undefined,
+          images
+        )
 
         return {
           ...article,

--- a/packages/readr/pages/index.tsx
+++ b/packages/readr/pages/index.tsx
@@ -29,7 +29,7 @@ import { quotes as quotesQuery } from '~/graphql/query/quote'
 import { ValidPostStyle } from '~/types/common'
 import type { ArticleCard, FeaturedArticle } from '~/types/component'
 import type { CollaborationItem } from '~/types/component'
-import { convertPostToArticleCard, getImageOfArticle } from '~/utils/post'
+import { convertPostToArticleCard } from '~/utils/post'
 
 import type { NextPageWithLayout } from './_app'
 
@@ -119,11 +119,7 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async () => {
           ogImage?.resized ??
           {}
 
-        return convertPostToArticleCard(
-          editorChoice?.choices,
-          undefined,
-          images
-        )
+        return convertPostToArticleCard(editorChoice?.choices, images)
       })
     }
 
@@ -131,7 +127,7 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async () => {
       const convertFunc = (post: Post): ArticleCard => {
         const { heroImage, ogImage } = post
         const images = heroImage?.resized ?? ogImage?.resized ?? {}
-        return convertPostToArticleCard(post, undefined, images)
+        return convertPostToArticleCard(post, images)
       }
 
       {
@@ -245,11 +241,7 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async () => {
 
         const images = heroImage?.resized ?? ogImage?.resized ?? {}
 
-        const article = convertPostToArticleCard(
-          feature?.featurePost,
-          undefined,
-          images
-        )
+        const article = convertPostToArticleCard(feature?.featurePost, images)
 
         return {
           ...article,

--- a/packages/readr/pages/index.tsx
+++ b/packages/readr/pages/index.tsx
@@ -124,8 +124,8 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async () => {
     {
       const convertFunc = (post: Post): ArticleCard => {
         const { heroImage, ogImage } = post
-        const image = getImageOfArticle({ images: [heroImage, ogImage] })
-        return convertPostToArticleCard(post, image)
+        const images = heroImage?.resized ?? ogImage?.resized ?? {}
+        return convertPostToArticleCard(post, undefined, images)
       }
 
       {

--- a/packages/readr/types/component.ts
+++ b/packages/readr/types/component.ts
@@ -5,6 +5,7 @@ export type ArticleCard = {
   href?: string
   title: string
   image?: string
+  images?: ResizedImages
   date?: string
   readTimeText?: string
   isReport?: boolean

--- a/packages/readr/types/component.ts
+++ b/packages/readr/types/component.ts
@@ -4,7 +4,6 @@ export type ArticleCard = {
   id?: string
   href?: string
   title: string
-  image?: string
   images?: ResizedImages
   date?: string
   readTimeText?: string

--- a/packages/readr/utils/post.ts
+++ b/packages/readr/utils/post.ts
@@ -113,7 +113,8 @@ export function getImageOfArticle({
 
 export function convertPostToArticleCard(
   post: Post | null,
-  image?: string
+  image?: string,
+  images?: ResizedImages
 ): ArticleCard {
   const {
     id = 'no-id',
@@ -132,5 +133,6 @@ export function convertPostToArticleCard(
     readTimeText: formatReadTime(readingTime),
     isReport: isReport(style),
     image,
+    images: images ?? {},
   }
 }

--- a/packages/readr/utils/post.ts
+++ b/packages/readr/utils/post.ts
@@ -113,7 +113,6 @@ export function getImageOfArticle({
 
 export function convertPostToArticleCard(
   post: Post | null,
-  image?: string,
   images?: ResizedImages
 ): ArticleCard {
   const {
@@ -132,7 +131,6 @@ export function convertPostToArticleCard(
     date: formatPostDate(publishTime),
     readTimeText: formatReadTime(readingTime),
     isReport: isReport(style),
-    image: image ?? '',
     images: images ?? {},
   }
 }

--- a/packages/readr/utils/post.ts
+++ b/packages/readr/utils/post.ts
@@ -132,7 +132,7 @@ export function convertPostToArticleCard(
     date: formatPostDate(publishTime),
     readTimeText: formatReadTime(readingTime),
     isReport: isReport(style),
-    image,
+    image: image ?? '',
     images: images ?? {},
   }
 }


### PR DESCRIPTION
## 更新內容
* 把既有使用 `NextImage` 和 `useFallbackImage` 處理圖片的邏輯，統一調整由 `@readr-media/react-image` 來處理
* 調整 `ArticleCard` type，移除 `image`，增加 `images`