### PR TITLE
feat(post): adjust `@mirrormedia/lilith-draft-renderer` style for specific blocks

### DIFF
--- a/packages/readr/components/post/post-content.tsx
+++ b/packages/readr/components/post/post-content.tsx
@@ -6,7 +6,7 @@ import MediaLinkList from '~/components/shared/media-link'
 import { DONATION_PAGE_URL } from '~/constants/environment-variables'
 import type { PostDetail } from '~/graphql/query/post'
 
-import { Readr } from '../../draft-renderer/src/index'
+import { Readr } from '@mirrormedia/lilith-draft-renderer'
 
 const Container = styled.section`
   width: 100%;

--- a/packages/readr/components/post/post-content.tsx
+++ b/packages/readr/components/post/post-content.tsx
@@ -1,30 +1,25 @@
 import { DonateButton } from '@readr-media/react-component'
-import { useRouter } from 'next/router'
 import styled from 'styled-components'
 
 import Heading from '~/components/post/post-heading'
 import MediaLinkList from '~/components/shared/media-link'
+import { DONATION_PAGE_URL } from '~/constants/environment-variables'
 import type { PostDetail } from '~/graphql/query/post'
 
-const Content = styled.section`
+import { Readr } from '../../draft-renderer/src/index'
+
+const Container = styled.section`
   width: 100%;
   max-width: 568px;
   margin: 0 auto;
-  padding: 0 20px;
+  padding: 0px 20px;
 
   ${({ theme }) => theme.breakpoint.md} {
-    width: 568px;
     padding: 0;
   }
 
   ${({ theme }) => theme.breakpoint.xl} {
-    width: 600px;
-  }
-
-  #post {
-    height: 200vh;
-    line-height: 200vh;
-    text-align: center;
+    max-width: 600px;
   }
 
   #quote {
@@ -50,22 +45,148 @@ const QuoteAndMedia = styled.section`
   }
 `
 
+//重點摘要
+const Summary = styled.section`
+  width: 100%;
+  position: relative;
+  padding: 16px 0 0;
+  border: 2px solid #04295e;
+  border-radius: 2px;
+  margin: 0 0 24px;
+  padding: 48px 48px 32px 48px;
+  font-size: 16px;
+
+  .title {
+    font-size: 14px;
+    line-height: 21px;
+    color: #04295e;
+    margin: 0 0 4px;
+  }
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 16px;
+    background-color: #04295e;
+  }
+
+  .public-DraftStyleDefault-block {
+    font-size: 16px;
+    line-height: 1.6;
+  }
+
+  .public-DraftStyleDefault-unorderedListItem,
+  .public-DraftStyleDefault-orderedListItem {
+    line-height: 1.4;
+  }
+
+  div[data-contents='true'] > * + * {
+    margin: 12px 0 0 !important;
+  }
+`
+
+//內文
+const Content = styled.section`
+  margin: 0 0 32px 0;
+`
+
+//延伸議題
+const ActionList = styled.section`
+  .title {
+    font-style: normal;
+    font-weight: 700;
+    font-size: 28px;
+    line-height: 150%;
+    display: flex;
+    align-items: center;
+    letter-spacing: 0.032em;
+    color: rgba(0, 9, 40, 0.87);
+    margin-bottom: 16px;
+  }
+
+  div[data-contents='true'] > * + * {
+    margin: 0;
+  }
+`
+
+//引用數據
+const Citation = styled.section`
+  margin: 0 auto 48px;
+  max-width: 568px;
+  width: 100%;
+  border-radius: 2px;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    max-width: 600px;
+  }
+
+  .title {
+    text-align: center;
+    background-color: #04295e;
+    padding: 8px 0;
+
+    font-size: 18px;
+    font-weight: 700;
+    line-height: 27px;
+    letter-spacing: 0.03em;
+    color: #ebf02c;
+
+    ${({ theme }) => theme.breakpoint.md} {
+      font-size: 20px;
+      line-height: 30px;
+    }
+  }
+
+  .DraftEditor-root {
+    background-color: rgba(245, 235, 255, 0.5);
+    padding: 12px 24px;
+
+    ${({ theme }) => theme.breakpoint.md} {
+      padding: 16px 32px;
+    }
+  }
+
+  div[data-contents='true'] > * + * {
+    margin: 0;
+  }
+`
+
 interface PostProps {
   postData: PostDetail
 }
 
 export default function PostContent({ postData }: PostProps): JSX.Element {
-  const router = useRouter()
+  const { DraftRenderer } = Readr
+
   return (
-    <Content>
+    <Container>
       <Heading postData={postData} />
-      <section id="summary" />
-      <article id="post">文章頁 #{router?.query?.postId} 內文</article>
-      <DonateButton />
+      <article id="post">
+        <Summary>
+          <p className="title">報導重點摘要</p>
+          <DraftRenderer rawContentBlock={postData.summary} />
+        </Summary>
+
+        <Content>
+          <DraftRenderer rawContentBlock={postData.content} />
+        </Content>
+
+        <ActionList>
+          <p className="title">如果你關心這個議題</p>
+          <DraftRenderer rawContentBlock={postData.actionList} />
+        </ActionList>
+      </article>
+      <DonateButton href={DONATION_PAGE_URL} />
       <QuoteAndMedia>
         <MediaLinkList />
-        <section id="quote">#引用資料</section>
+        <Citation>
+          <p className="title">引用資料</p>
+          <DraftRenderer rawContentBlock={postData.citation} />
+        </Citation>
       </QuoteAndMedia>
-    </Content>
+    </Container>
   )
 }

--- a/packages/readr/graphql/query/post.ts
+++ b/packages/readr/graphql/query/post.ts
@@ -22,7 +22,7 @@ export type Photo = Pick<
 
 export type RelatedPost = Pick<
   Required<GenericPost>,
-  'id' | 'publishTime' | 'name' | 'readingTime'
+  'id' | 'publishTime' | 'name' | 'readingTime' | 'heroImage'
 >
 
 export type PostDetail = Pick<
@@ -37,6 +37,10 @@ export type PostDetail = Pick<
   | 'content'
   | 'publishTime'
   | 'readingTime'
+  | 'summary'
+  | 'content'
+  | 'actionList'
+  | 'citation'
 > & {
   categories: Category[]
 } & Record<'dataAnalysts' | 'writers' | 'designers', Author[]> & {
@@ -47,6 +51,10 @@ export type PostDetail = Pick<
 const post = gql`
   query ($id: ID!) {
     post(where: { id: $id }) {
+      summary
+      content
+      actionList
+      citation
       id
       slug
       name
@@ -85,6 +93,16 @@ const post = gql`
         name
         publishTime
         readingTime
+        heroImage {
+          id
+          name
+          imageFile {
+            url
+          }
+          resized {
+            ...ResizedImagesField
+          }
+        }
       }
     }
   }

--- a/packages/readr/types/common.ts
+++ b/packages/readr/types/common.ts
@@ -58,6 +58,9 @@ export type GenericPost = {
   ogImage?: GenericPhoto | null
   heroCaption?: string
   content?: unknown // it is hard to describe JSON type
+  summary?: unknown // it is hard to describe JSON type
+  actionList?: unknown // it is hard to describe JSON type
+  citation?: unknown // it is hard to describe JSON type
   dataAnalysts?: GenericAuthor[]
   writers?: GenericAuthor[]
   designers?: GenericAuthor[]


### PR DESCRIPTION
### 調整
- 調整 `[postId]` 頁面中特殊區塊的 draft-style：「報導重點摘要」「如果你關心這個議題」「引用資料」。
- 更新 `summary / actionList / citation / content` 的 typescript 定義。

### 新增
- import `@mirrormedia/lilith-draft-renderer` （version: 1.0.0-beta.1）