### PR TITLE
feat(about): add section of more

### DIFF
--- a/packages/readr/components/about/more.tsx
+++ b/packages/readr/components/about/more.tsx
@@ -63,8 +63,6 @@ const ReportItem = styled.li`
   :hover {
     .title-with-link {
       text-decoration-line: underline;
-      font-size: 18px;
-      line-height: 26px;
     }
     .image-with-link {
       transform: scale(1.1);

--- a/packages/readr/components/about/more.tsx
+++ b/packages/readr/components/about/more.tsx
@@ -60,6 +60,7 @@ const ReportList = styled.ul`
     ${theme.breakpoint.xl} {
       width: 724px;
       display: flex;
+      flex-wrap: wrap;
     }
   `}
 `
@@ -129,7 +130,6 @@ const ReportDesc = styled.p`
   font-weight: 400;
   font-size: 14px;
   line-height: 20px;
-  text-align: justify;
   color: rgba(0, 9, 40, 0.5);
 `
 
@@ -195,7 +195,7 @@ export default function More({
                     />
                   </ImageWrapper>
                   <ReportInfo>
-                    <ReportTitle isLink={report.url}>{report.name}</ReportTitle>
+                    <ReportTitle>{report.name}</ReportTitle>
                     {description && <ReportDesc>{description}</ReportDesc>}
                   </ReportInfo>
                 </>

--- a/packages/readr/components/about/more.tsx
+++ b/packages/readr/components/about/more.tsx
@@ -7,29 +7,17 @@ import { PageVariable } from '~/graphql/query/page-variable'
 const Container = styled.div`
   position: relative;
   margin: 48px 20px;
-  .tail-arrow {
-    height: 37px;
-    margin-top: 44px;
-  }
   ${({ theme }) => `
     ${theme.breakpoint.md} {
       display: flex;
       justify-content: space-between;
       margin: 80px auto;
       max-width: 672px;
-      .tail-arrow {
-        position: absolute;
-        left: 0;
-        bottom: 0;
-      }
     }
   `}
   ${({ theme }) => `
     ${theme.breakpoint.xl} {
       max-width: 1096px;
-      .tail-arrow {
-        height: 73px;
-      }
     }
   `}
 `

--- a/packages/readr/components/about/more.tsx
+++ b/packages/readr/components/about/more.tsx
@@ -128,7 +128,6 @@ export default function More({
   title: string
   renderedMore: PageVariable[]
 }): JSX.Element {
-  console.log(renderedMore)
   const getDescText = (value: unknown) => {
     if (!value) return ''
     let pureText = ''

--- a/packages/readr/components/about/more.tsx
+++ b/packages/readr/components/about/more.tsx
@@ -1,0 +1,209 @@
+import Image from '@readr-media/react-image'
+import NextLink from 'next/link'
+import styled from 'styled-components'
+
+import { PageVariable } from '~/graphql/query/page-variable'
+
+const Container = styled.div`
+  position: relative;
+  margin: 48px 20px;
+  .tail-arrow {
+    height: 37px;
+    margin-top: 44px;
+  }
+  ${({ theme }) => `
+    ${theme.breakpoint.md} {
+      display: flex;
+      justify-content: space-between;
+      margin: 80px auto;
+      max-width: 672px;
+      .tail-arrow {
+        position: absolute;
+        left: 0;
+        bottom: 0;
+      }
+    }
+  `}
+  ${({ theme }) => `
+    ${theme.breakpoint.xl} {
+      max-width: 1096px;
+      .tail-arrow {
+        height: 73px;
+      }
+    }
+  `}
+`
+
+const Title = styled.h2`
+  font-family: 'Noto Sans TC';
+  font-weight: 900;
+  font-size: 24px;
+  letter-spacing: 0.03em;
+  color: rgba(255, 255, 255, 0.87);
+  margin-bottom: 20px;
+  min-width: fit-content;
+  ${({ theme }) => `
+    ${theme.breakpoint.xl} {
+      font-size: 36px;
+    }
+  `}
+`
+
+const ReportList = styled.ul`
+  width: 100%;
+  ${({ theme }) => `
+    ${theme.breakpoint.md} {
+      width: 441px;
+    }
+  `}
+  ${({ theme }) => `
+    ${theme.breakpoint.xl} {
+      width: 724px;
+      display: flex;
+    }
+  `}
+`
+
+const ReportItem = styled.li`
+  width: calc(100vw - 40px);
+  margin-top: 20px;
+  background: #ffffff;
+  box-shadow: 0px 4px 4px -2px rgba(0, 0, 0, 0.1);
+  border-radius: 6px;
+  overflow: hidden;
+  :hover {
+    .title-with-link {
+      text-decoration-line: underline;
+      font-size: 18px;
+      line-height: 26px;
+    }
+    .image-with-link {
+      transform: scale(1.1);
+    }
+  }
+  ${({ theme }) => `
+  ${theme.breakpoint.md} {
+    width: 100%;
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+  ${theme.breakpoint.xl} {
+    width: 352px;
+    margin-top: 0;
+    &:nth-child(2n) {
+      margin-left: 20px
+    }
+    &:nth-child(n + 3) {
+      margin-top: 20px
+    }
+  }
+`}
+`
+
+const ImageWrapper = styled.div`
+  poaition: relative;
+  width: 100%;
+  aspect-ratio: 352 / 198;
+  transition: all 0.3s ease;
+`
+
+const ReportInfo = styled.div`
+  padding: 12px 16px;
+`
+
+const ReportTitle = styled.h3`
+  font-family: 'Noto Sans TC';
+  font-style: normal;
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 23px;
+  letter-spacing: 0.03em;
+  color: rgba(0, 9, 40, 0.87);
+`
+
+const ReportDesc = styled.p`
+  margin-top: 8px;
+  font-family: 'Noto Sans TC';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 20px;
+  text-align: justify;
+  color: rgba(0, 9, 40, 0.5);
+`
+
+export default function More({
+  title,
+  renderedMore,
+}: {
+  title: string
+  renderedMore: PageVariable[]
+}): JSX.Element {
+  const getDescText = (value: unknown) => {
+    if (!value) return ''
+    let pureText = ''
+    value.blocks.forEach((paragraph) => {
+      pureText += paragraph.text
+    })
+    return pureText
+  }
+  return (
+    <Container>
+      <Title>{title}</Title>
+      <ReportList>
+        {renderedMore.map((report) => {
+          const description = getDescText(report.value)
+          return (
+            <ReportItem key={report.id}>
+              {report.url ? (
+                <NextLink
+                  href={report.url}
+                  target="_blank"
+                  rel="noopener noreferrer external nofollow"
+                  aria-label={report.name}
+                >
+                  <ImageWrapper className="image-with-link">
+                    <Image
+                      images={report.relatedImage?.resized}
+                      defaultImage={'/icons/default/collaboration.svg'}
+                      alt={report.name}
+                      objectFit="cover"
+                      rwd={{
+                        mobile: '441px',
+                      }}
+                    />
+                  </ImageWrapper>
+                  <ReportInfo>
+                    <ReportTitle className="title-with-link">
+                      {report.name}
+                    </ReportTitle>
+                    {description && <ReportDesc>{description}</ReportDesc>}
+                  </ReportInfo>
+                </NextLink>
+              ) : (
+                <>
+                  <ImageWrapper>
+                    <Image
+                      images={report.relatedImage?.resized}
+                      defaultImage={'/icons/default/collaboration.svg'}
+                      alt={report.name}
+                      objectFit="cover"
+                      rwd={{
+                        mobile: '352px',
+                      }}
+                    />
+                  </ImageWrapper>
+                  <ReportInfo>
+                    <ReportTitle isLink={report.url}>{report.name}</ReportTitle>
+                    {description && <ReportDesc>{description}</ReportDesc>}
+                  </ReportInfo>
+                </>
+              )}
+            </ReportItem>
+          )
+        })}
+      </ReportList>
+    </Container>
+  )
+}

--- a/packages/readr/components/about/more.tsx
+++ b/packages/readr/components/about/more.tsx
@@ -128,6 +128,7 @@ export default function More({
   title: string
   renderedMore: PageVariable[]
 }): JSX.Element {
+  console.log(renderedMore)
   const getDescText = (value: unknown) => {
     if (!value) return ''
     let pureText = ''
@@ -158,7 +159,9 @@ export default function More({
                       alt={report.name}
                       objectFit="cover"
                       rwd={{
+                        default: '100vw',
                         mobile: '441px',
+                        tablet: '352px',
                       }}
                     />
                   </ImageWrapper>
@@ -178,7 +181,9 @@ export default function More({
                       alt={report.name}
                       objectFit="cover"
                       rwd={{
-                        mobile: '352px',
+                        default: '100vw',
+                        mobile: '441px',
+                        tablet: '352px',
                       }}
                     />
                   </ImageWrapper>

--- a/packages/readr/graphql/query/page-variable.ts
+++ b/packages/readr/graphql/query/page-variable.ts
@@ -27,6 +27,8 @@ const pageVariablesByPage = gql`
           w480
           w800
           w1200
+          w1600
+          w2400
         }
       }
       value

--- a/packages/readr/graphql/query/page-variable.ts
+++ b/packages/readr/graphql/query/page-variable.ts
@@ -2,6 +2,8 @@ import gql from 'graphql-tag'
 
 import type { GenericPhoto } from '~/types/common'
 
+import { resizeImagesFragment } from '../fragments/resized-images'
+
 export type Photo = Pick<Required<GenericPhoto>, 'id' | 'resized'>
 
 export type PageVariable = {
@@ -23,18 +25,14 @@ const pageVariablesByPage = gql`
       relatedImage {
         id
         resized {
-          original
-          w480
-          w800
-          w1200
-          w1600
-          w2400
+          ...ResizedImagesField
         }
       }
       value
       url
     }
   }
+  ${resizeImagesFragment}
 `
 
 export { pageVariablesByPage }

--- a/packages/readr/graphql/query/page-variable.ts
+++ b/packages/readr/graphql/query/page-variable.ts
@@ -1,0 +1,42 @@
+import gql from 'graphql-tag'
+
+import type { GenericPhoto } from '~/types/common'
+
+export type Photo = Pick<
+  Required<GenericPhoto>,
+  'id' | 'name' | 'imageFile' | 'resized'
+>
+
+export type PageVariable = {
+  id: string
+  name: string
+  url?: string
+  relatedImage?: Photo
+  value?: unknown // it is hard to describe JSON type
+}
+
+const pageVariablesByPage = gql`
+  query ($page: String) {
+    pageVariables(
+      where: { page: { equals: $page } }
+      orderBy: { createdAt: desc }
+    ) {
+      id
+      page
+      name
+      relatedImage {
+        id
+        resized {
+          original
+          w480
+          w800
+          w1200
+        }
+      }
+      value
+      url
+    }
+  }
+`
+
+export { pageVariablesByPage }

--- a/packages/readr/graphql/query/page-variable.ts
+++ b/packages/readr/graphql/query/page-variable.ts
@@ -2,10 +2,7 @@ import gql from 'graphql-tag'
 
 import type { GenericPhoto } from '~/types/common'
 
-export type Photo = Pick<
-  Required<GenericPhoto>,
-  'id' | 'name' | 'imageFile' | 'resized'
->
+export type Photo = Pick<Required<GenericPhoto>, 'id' | 'resized'>
 
 export type PageVariable = {
   id: string
@@ -22,7 +19,6 @@ const pageVariablesByPage = gql`
       orderBy: { createdAt: desc }
     ) {
       id
-      page
       name
       relatedImage {
         id

--- a/packages/readr/pages/about.tsx
+++ b/packages/readr/pages/about.tsx
@@ -11,11 +11,10 @@ import Awards from '~/components/about/awards'
 import Landing from '~/components/about/landing'
 import More from '~/components/about/more'
 import LayoutWithLogoOnly from '~/components/layout/layout-with-logo-only'
-import { Award, awards as awardsGql } from '~/graphql/query/award'
-import {
-  PageVariable,
-  pageVariablesByPage,
-} from '~/graphql/query/page-variable'
+import type { Award } from '~/graphql/query/award'
+import { awards as awardsGql } from '~/graphql/query/award'
+import type { PageVariable } from '~/graphql/query/page-variable'
+import { pageVariablesByPage } from '~/graphql/query/page-variable'
 import type { Language, RenderedAward } from '~/types/about'
 
 import type { NextPageWithLayout } from './_app'

--- a/packages/readr/pages/about.tsx
+++ b/packages/readr/pages/about.tsx
@@ -3,7 +3,7 @@
 import { ApolloQueryResult } from '@apollo/client/core'
 import errors from '@twreporter/errors'
 import type { GetServerSideProps } from 'next'
-import { ReactElement, useMemo, useState } from 'react'
+import { ReactElement, useCallback, useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
 
 import client from '~/apollo-client'
@@ -119,6 +119,34 @@ const About: NextPageWithLayout<PageProps> = ({
       }
     })
   }, [awardsData, language])
+
+  const fetchENMore = useCallback(async () => {
+    let moreReportDataEn: PageVariable[] = []
+    try {
+      const result: ApolloQueryResult<{ pageVariables: PageVariable[] }> =
+        await client.query({
+          query: pageVariablesByPage,
+          variables: {
+            page: 'about-en',
+          },
+        })
+      moreReportDataEn = result.data.pageVariables
+    } catch (err) {
+      console.log(err)
+    }
+    setRenderedMore({
+      ...renderedMore,
+      en: moreReportDataEn,
+    })
+    return moreReportData
+  }, [])
+
+  useEffect(() => {
+    if (!renderedMore[language]?.length) {
+      fetchENMore()
+    }
+  }, [language, renderedMore, fetchENMore])
+
   return (
     <Page>
       <Landing
@@ -132,7 +160,7 @@ const About: NextPageWithLayout<PageProps> = ({
         title={wording[language].awardsTitle}
       />
       <More
-        title={wording[language].awardsTitle}
+        title={wording[language].moreTitle}
         renderedMore={renderedMore[language]}
       />
     </Page>

--- a/packages/readr/pages/about.tsx
+++ b/packages/readr/pages/about.tsx
@@ -82,7 +82,7 @@ const About: NextPageWithLayout<PageProps> = ({
     Record<Language, { data: PageVariable[]; hasFetched: boolean }>
   >({
     ch: { hasFetched: true, data: moreReportData },
-    en: { hasFetched: false, data: moreReportData },
+    en: { hasFetched: false, data: [] },
   })
   const renderedAwards: RenderedAward[] = useMemo(() => {
     return awardsData.map((awardItem: Award) => {

--- a/packages/readr/pages/about.tsx
+++ b/packages/readr/pages/about.tsx
@@ -9,8 +9,13 @@ import styled from 'styled-components'
 import client from '~/apollo-client'
 import Awards from '~/components/about/awards'
 import Landing from '~/components/about/landing'
+import More from '~/components/about/more'
 import LayoutWithLogoOnly from '~/components/layout/layout-with-logo-only'
 import { Award, awards as awardsGql } from '~/graphql/query/award'
+import {
+  PageVariable,
+  pageVariablesByPage,
+} from '~/graphql/query/page-variable'
 import type { Language, RenderedAward } from '~/types/about'
 
 import type { NextPageWithLayout } from './_app'
@@ -26,6 +31,7 @@ type languageWording = {
     content: string
   }
   awardsTitle: string
+  moreTitle: string
 }
 
 const wording: Record<Language, languageWording> = {
@@ -36,6 +42,7 @@ const wording: Record<Language, languageWording> = {
         'READr 是致力於以<b>資料</b>做<b>新聞</b>與<b>內容實驗</b>的媒體。於 2018 年正式創立，重視與各種專業者、讀者的協作，期望讓以往封閉的新聞編輯室有開放的可能。<b>資料分析、多媒體互動、理想的閱讀體驗、開放資料、開源工具</b>，都是我們提供的服務。',
     },
     awardsTitle: '獲獎經歷',
+    moreTitle: '更認識我們',
   },
   en: {
     landing: {
@@ -44,6 +51,7 @@ const wording: Record<Language, languageWording> = {
         'READr uses <b>data</b> for <b>news</b> and <b>content</b> <b>experimentation</b>. Collaboration with diverse professionals and readers opens the once-closed newsroom. We provide services like <b>data</b> <b>analysis,</b> <b>multimedia,</b> <b>ideal</b> <b>reading</b> <b>experiences,</b> <b>open</b> <b>data,</b> <b>and</b> <b>tools.</b>',
     },
     awardsTitle: 'Awards',
+    moreTitle: 'More',
   },
 }
 
@@ -63,10 +71,20 @@ const Page = styled.div`
 
 type PageProps = {
   awardsData: Award[]
+  moreReportData: PageVariable[]
 }
 
-const About: NextPageWithLayout<PageProps> = ({ awardsData }) => {
+const About: NextPageWithLayout<PageProps> = ({
+  awardsData,
+  moreReportData,
+}) => {
   const [language, setLanguage] = useState<Language>('ch')
+  const [renderedMore, setRenderedMore] = useState<
+    Record<Language, PageVariable[]>
+  >({
+    ch: moreReportData,
+    en: [],
+  })
   const renderedAwards: RenderedAward[] = useMemo(() => {
     return awardsData.map((awardItem: Award) => {
       const {
@@ -113,12 +131,17 @@ const About: NextPageWithLayout<PageProps> = ({ awardsData }) => {
         renderedAwards={renderedAwards}
         title={wording[language].awardsTitle}
       />
+      <More
+        title={wording[language].awardsTitle}
+        renderedMore={renderedMore[language]}
+      />
     </Page>
   )
 }
 
 export const getServerSideProps: GetServerSideProps<PageProps> = async ({}) => {
   let awardsData: Award[] = []
+  let moreReportData: PageVariable[] = []
   try {
     const result: ApolloQueryResult<{ awards: Award[] }> = await client.query({
       query: awardsGql,
@@ -140,9 +163,35 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({}) => {
       })
     )
   }
+  try {
+    const result: ApolloQueryResult<{ pageVariables: PageVariable[] }> =
+      await client.query({
+        query: pageVariablesByPage,
+        variables: {
+          page: 'about',
+        },
+      })
+    moreReportData = result.data.pageVariables
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        severity: 'ERROR',
+        message: errors.helpers.printAll(
+          err,
+          {
+            withStack: true,
+            withPayload: true,
+          },
+          0,
+          0
+        ),
+      })
+    )
+  }
   return {
     props: {
       awardsData,
+      moreReportData,
     },
   }
 }

--- a/packages/readr/pages/about.tsx
+++ b/packages/readr/pages/about.tsx
@@ -79,10 +79,10 @@ const About: NextPageWithLayout<PageProps> = ({
 }) => {
   const [language, setLanguage] = useState<Language>('ch')
   const [renderedMore, setRenderedMore] = useState<
-    Record<Language, PageVariable[]>
+    Record<Language, { data: PageVariable[]; hasFetched: boolean }>
   >({
-    ch: moreReportData,
-    en: [],
+    ch: { hasFetched: true, data: moreReportData },
+    en: { hasFetched: false, data: moreReportData },
   })
   const renderedAwards: RenderedAward[] = useMemo(() => {
     return awardsData.map((awardItem: Award) => {
@@ -119,7 +119,7 @@ const About: NextPageWithLayout<PageProps> = ({
     })
   }, [awardsData, language])
 
-  const fetchENMore = useCallback(async () => {
+  const fetchENMore = async () => {
     let moreReportDataEn: PageVariable[] = []
     try {
       const result: ApolloQueryResult<{ pageVariables: PageVariable[] }> =
@@ -135,16 +135,15 @@ const About: NextPageWithLayout<PageProps> = ({
     }
     setRenderedMore({
       ...renderedMore,
-      en: moreReportDataEn,
+      en: { data: moreReportDataEn, hasFetched: true },
     })
-    return moreReportData
-  }, [])
+  }
 
   useEffect(() => {
-    if (!renderedMore[language]?.length) {
+    if (!renderedMore[language]?.hasFetched) {
       fetchENMore()
     }
-  }, [language, renderedMore, fetchENMore])
+  }, [language, renderedMore])
 
   return (
     <Page>
@@ -160,7 +159,7 @@ const About: NextPageWithLayout<PageProps> = ({
       />
       <More
         title={wording[language].moreTitle}
-        renderedMore={renderedMore[language]}
+        renderedMore={renderedMore[language].data}
       />
     </Page>
   )


### PR DESCRIPTION
### 描述
- 新增「更認識我們」區塊
- 在 ssr 時先抓取中文版本（page 在 `about` 中）、替換語言時才抓取英文版（page 在 `about-en` 中）。

### 參考資料
- 設計稿：https://www.figma.com/file/RfJHjsr8rBa7iIC7ir41AZ/2021_READr_Website?node-id=3360-21270&t=TKEZZEBqh34T76vV-0