### PR TITLE
refactor(readr): update image loading order

### DIFF
--- a/packages/readr/components/layout/header/header-general.tsx
+++ b/packages/readr/components/layout/header/header-general.tsx
@@ -189,7 +189,7 @@ export default function HeaderGeneral({
       const relatedList =
         item.posts?.map((post) => {
           const { heroImage, ogImage } = post
-          const images = heroImage?.resized ?? ogImage?.resized ?? {}
+          const images = ogImage?.resized ?? heroImage?.resized ?? {}
           return convertPostToArticleCard(post, images)
         }) ?? []
 

--- a/packages/readr/pages/_error.tsx
+++ b/packages/readr/pages/_error.tsx
@@ -210,7 +210,8 @@ const Error: NextPageWithLayout<ErrorPageProps> = ({
 
   const articleItems: ReactElement[] | undefined = latestPosts?.map(
     (article) => {
-      const images = article.heroImage?.resized ?? {}
+      const images =
+        article.ogImage?.resized ?? article.heroImage?.resized ?? {}
       const articleCard = convertPostToArticleCard(article, images)
 
       // Only show the date if it's a valid date

--- a/packages/readr/pages/index.tsx
+++ b/packages/readr/pages/index.tsx
@@ -175,8 +175,8 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async () => {
 
         const images =
           editorChoice.heroImage?.resized ??
-          heroImage?.resized ??
           ogImage?.resized ??
+          heroImage?.resized ??
           {}
 
         return convertPostToArticleCard(editorChoice?.choices, images)
@@ -186,7 +186,7 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async () => {
     {
       const postConvertFunc = (post: Post): ArticleCard => {
         const { heroImage, ogImage } = post
-        const images = heroImage?.resized ?? ogImage?.resized ?? {}
+        const images = ogImage?.resized ?? heroImage?.resized ?? {}
         return convertPostToArticleCard(post, images)
       }
 
@@ -301,7 +301,7 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async () => {
         const { description } = feature
         const { subtitle = '', heroImage, ogImage } = feature.featurePost ?? {}
 
-        const images = heroImage?.resized ?? ogImage?.resized ?? {}
+        const images = ogImage?.resized ?? heroImage?.resized ?? {}
 
         const article = convertPostToArticleCard(feature?.featurePost, images)
 


### PR DESCRIPTION
## 更新內容
* 調整列表文章圖片物件的使用順序
  * 一般情況，順序：og image > hero image
  *` EditorChoice` 的情況下，因為圖片物件有三個，分別是 `EditorChoice` 自己的 hero image， choice 文章的 hero image 和 choice 文章的 og image，順序會是 `EditorChoice` hero image > `EditorChoice.choice` og image > `EditorChoice.choice` hero image