### PR TITLE
feat(readr/ArticleListCard): add line-clamp for titles exceed 4 lines

### DIFF
--- a/packages/readr/components/shared/article-list-card.tsx
+++ b/packages/readr/components/shared/article-list-card.tsx
@@ -143,6 +143,12 @@ const TextWrapper = styled.div<Pick<StyledProps, '$shouldHighlightReport'>>`
         border-bottom: 1.5px solid #000928;
       }
     }
+
+    // Display an ellipsis (...) for titles that exceed 4 lines
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 4;
+    overflow: hidden;
   }
 
   // custom style for <DateAndReadTimeInfo />


### PR DESCRIPTION
- 在 `ArticleListCard` 元件新增 css `-webkit-line-clamp: 4;`，超過四行的 Title 省略為 ...
- 影響到的範圍有：`category-list`、`related-list-in-header`、`error page`
- 文章內頁下方的最新報導會需要另外設定