### PR TITLE
refactor(readr): manage positive z-index with theme config

### DIFF
--- a/packages/readr/components/index/feature-card.tsx
+++ b/packages/readr/components/index/feature-card.tsx
@@ -33,7 +33,7 @@ const Container = styled(NextLink)<Pick<StyledProps, '$isFirst'>>`
       bottom: 0;
       left: 0;
       right: 0;
-      z-index: 10; // be above picture
+      z-index: ${({ theme }) => theme.zIndex.maskOfPicture};
       background: linear-gradient(
         180deg,
         rgba(0, 9, 40, 0) 0%,
@@ -81,7 +81,7 @@ const TextWrapper = styled.div<Pick<StyledProps, '$isFirst'>>`
   left: 8px;
   right: 8px;
   text-align: left;
-  z-index: 20; // be above <Container picture::before>
+  z-index: ${({ theme }) => theme.zIndex.maskOfPicture + 10};
   ${({ theme }) => theme.breakpoint.md} {
     bottom: 16px;
     left: 24px;
@@ -113,7 +113,7 @@ const DescWithEmoji = styled.div<Pick<StyledProps, '$shouldShow'>>`
   display: block;
   top: 0;
   left: 0;
-  z-index: 20; // be above <Container picture::before>
+  z-index: ${({ theme }) => theme.zIndex.maskOfPicture + 10};
   font-size: 16px;
   ${SharedDescWithEmojiStyles}
 

--- a/packages/readr/components/layout/gdpr-control.tsx
+++ b/packages/readr/components/layout/gdpr-control.tsx
@@ -17,7 +17,7 @@ const Container = styled.div`
   border-top-left-radius: 2px;
   border-top-left-radius: 2px;
   overflow: hidden;
-  z-index: 10000; // be the most top-level of the site
+  z-index: ${({ theme }) => theme.zIndex.top};
 
   ${({ theme }) => theme.breakpoint.md} {
     flex-direction: row;

--- a/packages/readr/components/layout/header/hamburger-menu.tsx
+++ b/packages/readr/components/layout/header/hamburger-menu.tsx
@@ -22,7 +22,7 @@ const Container = styled.div`
   right: 0;
   background-color: #fff;
   overflow-y: auto;
-  z-index: 550; // legency value, keep it for compatibility
+  z-index: ${({ theme }) => theme.zIndex.headerMobile};
 
   ${({ theme }) => theme.breakpoint.lg} {
     display: none;

--- a/packages/readr/components/layout/header/header-general.tsx
+++ b/packages/readr/components/layout/header/header-general.tsx
@@ -25,7 +25,7 @@ const Header = styled.header`
   top: 0;
   left: 0;
   background-color: #fff;
-  z-index: 499; // legency value, keep it for compatibility
+  z-index: ${({ theme }) => theme.zIndex.headerDesktop};
 `
 
 const Wrapper = styled.div`

--- a/packages/readr/styles/theme/index.ts
+++ b/packages/readr/styles/theme/index.ts
@@ -26,6 +26,12 @@ export const theme = {
     featuredEditorChoiceCard: '720px',
     editorChoiceCard: '296px',
   },
+  zIndex: {
+    top: 10000,
+    headerMobile: 550, // legency value, keep it for compatibility
+    headerDesktop: 499, // legency value, keep it for compatibility
+    maskOfPicture: 10,
+  },
 }
 
 export default theme


### PR DESCRIPTION
## 更新內容
* 使用 styled-components 主題來管理集中 `z-index` (主要針對正整數部份)
