### PR TITLE
feat(category): add `category` page

### DIFF
--- a/packages/readr/components/post/post-title.tsx
+++ b/packages/readr/components/post/post-title.tsx
@@ -83,7 +83,7 @@ export default function PostTitle({
   const categoryItem = categories.map((item) => {
     return (
       <li key={item.id}>
-        <Link href={`/category/${item.title}`}>{item.title}</Link>
+        <Link href={`/category/${item.slug}`}>{item.title}</Link>
       </li>
     )
   })

--- a/packages/readr/graphql/query/category.ts
+++ b/packages/readr/graphql/query/category.ts
@@ -17,6 +17,7 @@ export type Category = Override<
 const categories = gql`
   query (
     $first: Int
+    $slug: String
     $relatedPostFirst: Int = 4
     $relatedReportFirst: Int = 1
     $postSkip: Int
@@ -28,7 +29,10 @@ const categories = gql`
   ) {
     categories(
       take: $first
-      where: { state: { equals: "true" } }
+      where: { 
+        state: { equals: "true" } 
+        slug: { equals: $slug }
+      }
       orderBy: { createdAt: asc }
     ) {
       id

--- a/packages/readr/graphql/query/post.ts
+++ b/packages/readr/graphql/query/post.ts
@@ -102,8 +102,7 @@ const post = gql`
 const latestPosts = gql`
   query  (
     $first: Int! = 3, 
-    $skip: Int! = 0, 
-    $category: [String!]
+    $skip: Int! = 0
   ) {
     latestPosts: posts(
       take: $first
@@ -113,10 +112,6 @@ const latestPosts = gql`
         style: {
           in: [${convertToStringList(postStyles)}]
         }
-        OR: [
-          { categories: { some: { slug: { in: $category } } } }
-          { categories:  {}  }
-        ]
       }
       orderBy: { publishTime: desc }
     ) {

--- a/packages/readr/graphql/query/post.ts
+++ b/packages/readr/graphql/query/post.ts
@@ -15,7 +15,7 @@ import { convertToStringList } from '~/utils/common'
 import { authorFragment } from '../fragments/author'
 import { resizeImagesFragment } from '../fragments/resized-images'
 
-export type Category = Pick<GenericCategory, 'id' | 'title'>
+export type Category = Pick<GenericCategory, 'id' | 'title' | 'slug'>
 export type Author = Pick<GenericAuthor, 'id' | 'name'>
 export type Tag = Pick<GenericTag, 'id' | 'name'>
 
@@ -49,7 +49,7 @@ export type PostDetail = Override<
   }
 >
 
-const postStyles = [...POST_STYLES, ...REPORT_STYLES]
+export const postStyles = [...POST_STYLES, ...REPORT_STYLES]
 
 const post = gql`
   query ($id: ID!) {
@@ -65,6 +65,7 @@ const post = gql`
       categories {
         id
         title
+        slug
       }
       dataAnalysts {
         ...AuthorFields
@@ -99,14 +100,23 @@ const post = gql`
 `
 
 const latestPosts = gql`
-  query ($first: Int! = 3) {
+  query  (
+    $first: Int! = 3, 
+    $skip: Int! = 0, 
+    $category: [String!]
+  ) {
     latestPosts: posts(
       take: $first
+      skip: $skip
       where: {
         state: { equals: "published" }
         style: {
           in: [${convertToStringList(postStyles)}]
         }
+        OR: [
+          { categories: { some: { slug: { in: $category } } } }
+          { categories:  {}  }
+        ]
       }
       orderBy: { publishTime: desc }
     ) {

--- a/packages/readr/hooks/useInfiniteScroll.ts
+++ b/packages/readr/hooks/useInfiniteScroll.ts
@@ -1,18 +1,12 @@
-import {
-  Dispatch,
-  MutableRefObject,
-  SetStateAction,
-  useEffect,
-  useRef,
-  useState,
-} from 'react'
+import type { Dispatch, MutableRefObject, SetStateAction } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 type InfiniteScrollProps = {
   root?: Element | null
   rootMargin?: string
   threshold?: number | number[]
   amount?: number
-  dependency?: any
+  dependency?: unknown
 }
 
 const useInfiniteScroll = ({
@@ -28,7 +22,6 @@ const useInfiniteScroll = ({
 ] => {
   const [isAtBottom, setIsAtBottom] = useState(false)
   const ref = useRef(null)
-  const element = ref.current
 
   const options = {
     root,
@@ -38,7 +31,7 @@ const useInfiniteScroll = ({
 
   const callback: IntersectionObserverCallback = (entries) => {
     for (const entry of entries) {
-      if (element && entry.isIntersecting) {
+      if (ref && entry.isIntersecting) {
         setIsAtBottom(true)
       } else {
         setIsAtBottom(false)
@@ -48,6 +41,7 @@ const useInfiniteScroll = ({
 
   useEffect(() => {
     const observer = new IntersectionObserver(callback, options)
+    const element = ref.current
 
     if (element) {
       observer.observe(element)
@@ -62,7 +56,7 @@ const useInfiniteScroll = ({
         observer.unobserve(element)
       }
     }
-  }, [element, dependency])
+  }, [dependency, amount])
 
   return [ref, isAtBottom, setIsAtBottom]
 }

--- a/packages/readr/hooks/useInfiniteScroll.ts
+++ b/packages/readr/hooks/useInfiniteScroll.ts
@@ -1,0 +1,42 @@
+import {
+  Dispatch,
+  MutableRefObject,
+  SetStateAction,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
+
+type InfiniteScrollProps = {
+  root?: Element | null
+  rootMargin?: string
+  threshold?: number | number[]
+}
+
+const useInfiniteScroll = (
+  options: InfiniteScrollProps
+): [MutableRefObject<null>, boolean, Dispatch<SetStateAction<boolean>>] => {
+  const [isAtBottom, setIsAtBottom] = useState(false)
+  const ref = useRef(null)
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(([entry]) => {
+      setIsAtBottom(entry.isIntersecting)
+    }, options)
+
+    const element = ref.current
+    if (element) {
+      observer.observe(element)
+    }
+
+    return () => {
+      if (element) {
+        observer.unobserve(element)
+      }
+    }
+  }, [ref, options])
+
+  return [ref, isAtBottom, setIsAtBottom]
+}
+
+export default useInfiniteScroll

--- a/packages/readr/hooks/useInfiniteScroll.ts
+++ b/packages/readr/hooks/useInfiniteScroll.ts
@@ -31,7 +31,7 @@ const useInfiniteScroll = ({
 
   const callback: IntersectionObserverCallback = (entries) => {
     for (const entry of entries) {
-      if (ref && entry.isIntersecting) {
+      if (ref.current && entry.isIntersecting) {
         setIsAtBottom(true)
       } else {
         setIsAtBottom(false)

--- a/packages/readr/pages/category/[slug].tsx
+++ b/packages/readr/pages/category/[slug].tsx
@@ -90,6 +90,7 @@ type PageProps = {
 const Category: NextPageWithLayout<PageProps> = ({ categories, latest }) => {
   //update title by router.query.slug
   const router = useRouter()
+  const slug = router?.query?.slug
 
   const [sectionTitle, setSectionTitle] = useState('所有報導')
 
@@ -97,9 +98,7 @@ const Category: NextPageWithLayout<PageProps> = ({ categories, latest }) => {
     useState<NavigationCategory>(DEFAULT_CATEGORY)
 
   useEffect(() => {
-    const matchedItem = categories.find(
-      (category) => category.slug === router?.query?.slug
-    )
+    const matchedItem = categories.find((category) => category.slug === slug)
 
     if (matchedItem) {
       setActiveCategory(matchedItem)
@@ -107,7 +106,7 @@ const Category: NextPageWithLayout<PageProps> = ({ categories, latest }) => {
         matchedItem.slug === 'all' ? '所有報導' : `所有${matchedItem.title}報導`
       )
     }
-  }, [])
+  }, [slug])
 
   const updateActiveCategory = (category: NavigationCategory) => {
     router.push(`/category/${category.slug}`, undefined, { shallow: true })

--- a/packages/readr/pages/category/[slug].tsx
+++ b/packages/readr/pages/category/[slug].tsx
@@ -155,21 +155,14 @@ const Category: NextPageWithLayout<PageProps> = ({ categories, latest }) => {
   const [dataAmount, setDataAmount] = useState(0)
 
   //infinite scroll: fetch more latest 12 posts
-  const fetchMoreLatestPosts = async (
-    activeCategory: NavigationCategoryWithArticleCards
-  ) => {
+  const fetchMoreLatestPosts = async () => {
     try {
       const variables: {
         first: number
         skip?: number
-        category?: string[]
       } = {
         first: 12,
         skip: currentItem?.posts?.length,
-      }
-
-      if (activeCategory.slug !== 'all') {
-        variables.category = [activeCategory.slug]
       }
 
       const {
@@ -266,7 +259,7 @@ const Category: NextPageWithLayout<PageProps> = ({ categories, latest }) => {
   useEffect(() => {
     if (isAtBottom) {
       activeCategory.slug === 'all'
-        ? fetchMoreLatestPosts(activeCategory)
+        ? fetchMoreLatestPosts()
         : fetchMoreCategoryPosts(activeCategory)
     }
   }, [isAtBottom])

--- a/packages/readr/pages/category/[slug].tsx
+++ b/packages/readr/pages/category/[slug].tsx
@@ -1,22 +1,377 @@
-// under construction
-
+// 列表頁
+import errors from '@twreporter/errors'
+import type { GetServerSideProps } from 'next'
 import { useRouter } from 'next/router'
 import type { ReactElement } from 'react'
-import styled from 'styled-components'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import styled, { css, useTheme } from 'styled-components'
 
+import client from '~/apollo-client'
+import type { NavigationCategoryWithArticleCards } from '~/components/index/latest-report-section'
 import LayoutGeneral from '~/components/layout/layout-general'
+import ArticleListCard from '~/components/shared/article-list-card'
+import CategoryNav from '~/components/shared/category-nav'
+import SectionHeading from '~/components/shared/section-heading'
+import { DEFAULT_CATEGORY } from '~/constants/constant'
+import type { Post } from '~/graphql/fragments/post'
+import type { Category } from '~/graphql/query/category'
+import { categories as categoriesQuery } from '~/graphql/query/category'
+import { latestPosts as latestPostsQuery } from '~/graphql/query/post'
+import { postStyles } from '~/graphql/query/post'
+import useInfiniteScroll from '~/hooks/useInfiniteScroll'
 import type { NextPageWithLayout } from '~/pages/_app'
-
-const Article = styled.article`
-  height: 100vh;
-  line-height: 100vh;
-  text-align: center;
+import type { NavigationCategory } from '~/types/component'
+import type { ArticleCard } from '~/types/component'
+import { convertPostToArticleCard } from '~/utils/post'
+const shareStyle = css`
+  width: 100%;
+  ${({ theme }) => theme.breakpoint.sm} {
+    width: calc((100% - 24px) / 2);
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    width: 256px;
+  }
 `
 
-const Category: NextPageWithLayout = () => {
+const CategoryWrapper = styled.div`
+  padding: 24px 20px;
+
+  ${({ theme }) => theme.breakpoint.sm} {
+    padding: 48px 20px;
+  }
+  ${({ theme }) => theme.breakpoint.md} {
+    padding: 48px;
+  }
+
+  ${({ theme }) => theme.breakpoint.lg} {
+    padding: 60px 72px;
+    max-width: 1240px;
+    margin: auto;
+  }
+`
+const ItemList = styled.div`
+  margin-top: 20px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 20px;
+  width: 100%;
+
+  ${({ theme }) => theme.breakpoint.sm} {
+    margin-top: 50px;
+  }
+`
+
+const Item = styled.li`
+  margin: 0 0 16px;
+  list-style: none;
+  ${({ theme }) => theme.breakpoint.sm} {
+    margin: 0 0 32px;
+  }
+  ${({ theme }) => theme.breakpoint.xl} {
+    margin: 0 0 60px;
+    &:nth-child(3),
+    &:nth-child(4) {
+      margin: 0;
+    }
+  }
+  ${shareStyle}
+`
+
+const postConvertFunc = (post: Post): ArticleCard => {
+  const { heroImage, ogImage } = post
+  const images = ogImage?.resized ?? heroImage?.resized ?? {}
+  return convertPostToArticleCard(post, images)
+}
+
+type PageProps = {
+  categories: NavigationCategoryWithArticleCards[]
+  latest: NavigationCategoryWithArticleCards
+}
+
+const Category: NextPageWithLayout<PageProps> = ({ categories, latest }) => {
+  //update title of `SectionHeading` & `CategoryNav` by router.query.slug
   const router = useRouter()
 
-  return <Article id="post">類別頁 #{router?.query?.slug}</Article>
+  const [activeCategory, setActiveCategory] =
+    useState<NavigationCategory>(DEFAULT_CATEGORY)
+
+  const [sectionTitle, setSectionTitle] = useState('所有報導')
+
+  useEffect(() => {
+    const matchedCategory = categories.find(
+      (category) => category.slug === router?.query?.slug
+    )
+
+    if (matchedCategory) {
+      setActiveCategory(matchedCategory)
+      setSectionTitle(
+        matchedCategory.slug === 'all'
+          ? '所有報導'
+          : `所有${matchedCategory.title}報導`
+      )
+    }
+  }, [])
+
+  const updateActiveCategory = (category: NavigationCategory) => {
+    setActiveCategory(category)
+    setSectionTitle(
+      category.slug === 'all' ? '所有報導' : `所有${category.title}報導`
+    )
+  }
+
+  const [categoryPosts, setCategoryPosts] = useState(categories)
+  const [allPosts, setAllPosts] = useState(latest)
+
+  const currentItem: NavigationCategoryWithArticleCards | undefined =
+    useMemo(() => {
+      if (activeCategory?.slug === 'all') {
+        return allPosts
+      }
+      const matchedItem = categoryPosts.find(
+        (category) => category.slug === activeCategory.slug
+      )
+
+      return matchedItem
+      /* eslint-disable-next-line react-hooks/exhaustive-deps */
+    }, [activeCategory.slug, allPosts])
+
+  // infinite-scroll
+  const [ref, isAtBottom, setIsAtBottom] = useInfiniteScroll({
+    root: null,
+    rootMargin: '0px',
+    threshold: 0.5,
+  })
+
+  //fetch more latest 12 posts
+  const fetchMorePosts = async (
+    activeCategory: NavigationCategoryWithArticleCards
+  ) => {
+    try {
+      const variables: {
+        first: number
+        skip?: number
+        category?: string[]
+      } = {
+        first: 12,
+      }
+      if (activeCategory.slug === 'all') {
+        variables.skip = allPosts?.posts?.length
+      } else {
+        variables.category = [activeCategory.slug]
+        variables.skip = currentItem?.posts?.length
+      }
+
+      const {
+        data: { latestPosts },
+        errors: gqlErrors,
+      } = await client.query<{ latestPosts: Post[] }>({
+        query: latestPostsQuery,
+        variables,
+      })
+
+      if (gqlErrors) {
+        const annotatingError = errors.helpers.wrap(
+          new Error('Errors returned in `latestPosts` query'),
+          'GraphQLError',
+          'failed to complete `latestPosts`',
+          { errors: gqlErrors }
+        )
+
+        throw annotatingError
+      }
+
+      if (activeCategory.slug === 'all') {
+        const newPosts = [
+          ...(allPosts.posts ?? []),
+          ...latestPosts.map(postConvertFunc),
+        ]
+        setAllPosts({
+          ...allPosts,
+          posts: newPosts,
+        })
+      } else {
+        const matchedItem = categoryPosts.find(
+          (category) => category.slug === activeCategory.slug
+        )
+        if (matchedItem) {
+          matchedItem.posts = [
+            ...(matchedItem.posts ?? []),
+            ...latestPosts.map(postConvertFunc),
+          ]
+
+          const updatedCategoryPosts = categoryPosts.map((category) => {
+            if (category.slug === activeCategory.slug) {
+              return matchedItem
+            }
+            return category
+          })
+          setCategoryPosts(updatedCategoryPosts)
+        }
+      }
+    } catch (err) {
+      console.error(
+        JSON.stringify({
+          severity: 'ERROR',
+          message: errors.helpers.printAll(
+            err,
+            {
+              withStack: true,
+              withPayload: true,
+            },
+            0,
+            0
+          ),
+        })
+      )
+      return { notFound: true }
+    }
+  }
+
+  useEffect(() => {
+    if (isAtBottom) {
+      setIsAtBottom(false)
+      fetchMorePosts(activeCategory)
+    }
+  }, [isAtBottom])
+
+  const theme = useTheme()
+  const articleItems = currentItem?.posts?.map((article) => {
+    return (
+      <Item key={article.id}>
+        <ArticleListCard
+          {...article}
+          isReport={article.isReport}
+          shouldHighlightReport={article.isReport}
+          shouldReverseInMobile={true}
+          rwd={{
+            mobile: '30vw',
+            tablet: '50vw',
+            default: '256px',
+          }}
+          breakpoint={{
+            mobile: `${theme.mediaSize.sm - 1}px`,
+            tablet: `${theme.mediaSize.xl - 1}px`,
+          }}
+        />
+      </Item>
+    )
+  })
+
+  return (
+    <CategoryWrapper aria-label={sectionTitle}>
+      <SectionHeading
+        title={sectionTitle}
+        highlightColor="#ebf02c"
+        headingLevel={2}
+        categorySlug={activeCategory.slug}
+      />
+      <CategoryNav
+        currentCategorySlug={activeCategory.slug}
+        categoryClickHandler={updateActiveCategory}
+      />
+      <ItemList>{articleItems}</ItemList>
+      <span ref={ref} id="scroll-to-bottom-anchor" />
+    </CategoryWrapper>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps<PageProps> = async () => {
+  let categories: NavigationCategoryWithArticleCards[] = []
+  let latest: NavigationCategoryWithArticleCards = {
+    id: DEFAULT_CATEGORY.id,
+    title: DEFAULT_CATEGORY.title,
+    slug: DEFAULT_CATEGORY.slug,
+  }
+
+  try {
+    {
+      // fetch categories and related 12 posts
+      const { data, error: gqlErrors } = await client.query<{
+        categories: Category[]
+      }>({
+        query: categoriesQuery,
+        variables: {
+          relatedPostFirst: 12,
+          shouldQueryRelatedPost: true,
+          shouldQueryRelatedReport: false,
+          relatedPostTypes: postStyles,
+        },
+      })
+
+      if (gqlErrors) {
+        const annotatingError = errors.helpers.wrap(
+          new Error('Errors returned in `categories` query'),
+          'GraphQLError',
+          'failed to complete `categories`',
+          { errors: gqlErrors }
+        )
+
+        throw annotatingError
+      }
+
+      categories = data.categories.map((category) => {
+        const posts = category.posts
+
+        return {
+          id: category.id,
+          title: category.title,
+          slug: category.slug,
+          posts: posts?.map(postConvertFunc),
+        }
+      })
+    }
+
+    {
+      // fetch latest 12 posts
+      const {
+        data: { latestPosts },
+        errors: gqlErrors,
+      } = await client.query<{ latestPosts: Post[] }>({
+        query: latestPostsQuery,
+        variables: {
+          first: 12,
+        },
+      })
+
+      if (gqlErrors) {
+        const annotatingError = errors.helpers.wrap(
+          new Error('Errors returned in `latestPosts` query'),
+          'GraphQLError',
+          'failed to complete `latestPosts`',
+          { errors: gqlErrors }
+        )
+
+        throw annotatingError
+      }
+
+      latest.posts = latestPosts.map(postConvertFunc)
+      latest.reports = []
+    }
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        severity: 'ERROR',
+        message: errors.helpers.printAll(
+          err,
+          {
+            withStack: true,
+            withPayload: true,
+          },
+          0,
+          0
+        ),
+      })
+    )
+    return { notFound: true }
+  }
+
+  return {
+    props: {
+      categories,
+      latest,
+    },
+  }
 }
 
 Category.getLayout = function getLayout(page: ReactElement) {

--- a/packages/readr/pages/index.tsx
+++ b/packages/readr/pages/index.tsx
@@ -41,6 +41,7 @@ import type { CollaborationItem } from '~/types/component'
 import { convertDataSet } from '~/utils/data-set'
 import * as gtag from '~/utils/gtag'
 import { convertPostToArticleCard } from '~/utils/post'
+import { postConvertFunc } from '~/utils/post'
 
 import type { NextPageWithLayout } from './_app'
 
@@ -184,12 +185,6 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async () => {
     }
 
     {
-      const postConvertFunc = (post: Post): ArticleCard => {
-        const { heroImage, ogImage } = post
-        const images = ogImage?.resized ?? heroImage?.resized ?? {}
-        return convertPostToArticleCard(post, images)
-      }
-
       {
         // fetch categories and related latest reports
         const { data, error: gqlErrors } = await client.query<{

--- a/packages/readr/utils/post.ts
+++ b/packages/readr/utils/post.ts
@@ -136,3 +136,9 @@ export function convertPostToArticleCard(
     images: images ?? {},
   }
 }
+
+export const postConvertFunc = (post: Post): ArticleCard => {
+  const { heroImage, ogImage } = post
+  const images = ogImage?.resized ?? heroImage?.resized ?? {}
+  return convertPostToArticleCard(post, images)
+}


### PR DESCRIPTION
### 新增
- 新增「列表頁」。
- 新增 `/hooks/useInfiniteScroll`，提供「列表頁」、「標籤頁」共同使用。

   - `root、rootMargin、threshold`：設定 IntersectionObserver options 的參數。
   - `amount`：剩餘的尚未 fetch 的報導數量，當數量為 0，則取消 observe。
   -  `dependency`：視需求提供 observer useEffect 使用，optional。

### 調整
- `postConvertFunc`：因「列表頁」、「標籤頁」會大量使用，改挪至 `utils/post` 作共用 function。
- `/query/category` 的 `categories`：
    - 新增變數 `$slug`。作為無限滾動時，針對特定 slug 的 category 去抓取更多 `relatedPosts`。

- `/query/post` 的 `latestPosts`：
    - 新增變數 `$skip`。作為無限滾動時，抓取新 `latestPosts` 資料使用。

- 修正：「文章頁」的 category 點擊後改為使用 `slug` 而非 `title`，一併調整相關 graphql 設定。