### PR TITLE
feat(readr): add OG info of `tag` & `post` page

### DIFF
--- a/packages/readr/components/layout/custom-head.tsx
+++ b/packages/readr/components/layout/custom-head.tsx
@@ -79,6 +79,7 @@ const OpenGraph = ({ properties }: { properties: OGProperties }) => {
 type HeadProps = {
   title?: string
   description?: string
+  imageUrl?: string
 }
 
 export default function CustomHead(props: HeadProps): JSX.Element {
@@ -94,7 +95,7 @@ export default function CustomHead(props: HeadProps): JSX.Element {
       width: '1200',
       height: '630',
       type: 'images/jpeg',
-      url: `${SITE_URL}/og.jpg`,
+      url: props.imageUrl ?? `${SITE_URL}/og.jpg`,
     },
     card: 'summary_large_image',
   }

--- a/packages/readr/components/layout/layout-general.tsx
+++ b/packages/readr/components/layout/layout-general.tsx
@@ -17,6 +17,7 @@ const Main = styled.main`
 type LayoutProps = {
   title?: string
   description?: string
+  imageUrl?: string
   children: React.ReactNode
   onCompleteReadingHandle?: () => void
 }
@@ -25,13 +26,18 @@ export default function LayoutGeneral({
   children,
   title,
   description,
+  imageUrl,
   onCompleteReadingHandle,
 }: LayoutProps) {
   const pageTitle = title ? `${title} - ${SITE_TITLE}` : title
 
   return (
     <>
-      <CustomHead title={pageTitle} description={description}></CustomHead>
+      <CustomHead
+        title={pageTitle}
+        description={description}
+        imageUrl={imageUrl}
+      ></CustomHead>
       <HeaderGeneral onCompleteReadingHandle={onCompleteReadingHandle} />
       <Main>{children}</Main>
     </>

--- a/packages/readr/graphql/query/post.ts
+++ b/packages/readr/graphql/query/post.ts
@@ -36,6 +36,7 @@ export type PostDetail = Override<
       | 'categories'
       | 'tags'
       | 'state'
+      | 'ogDescription'
     >,
   {
     heroImage: PhotoWithResizedOnly | null
@@ -62,6 +63,7 @@ const post = gql`
       actionList
       citation
       heroCaption
+      ogDescription
       categories {
         id
         title

--- a/packages/readr/pages/tag/[name].tsx
+++ b/packages/readr/pages/tag/[name].tsx
@@ -75,6 +75,7 @@ const Item = styled.li`
 
 type PageProps = {
   tagRelatedPosts?: ArticleCard[]
+  tagName?: string | string[]
 }
 
 const Tag: NextPageWithLayout<PageProps> = ({ tagRelatedPosts }) => {
@@ -177,14 +178,15 @@ const Tag: NextPageWithLayout<PageProps> = ({ tagRelatedPosts }) => {
 }
 
 export const getServerSideProps: GetServerSideProps<PageProps> = async ({
-  query,
+  params,
 }) => {
   let tagRelatedPosts: ArticleCard[] | undefined
+  let tagName: string | string[] | undefined
 
   try {
     {
       // fetch tag and related 12 posts
-      const { name } = query
+      const name = params?.name
       const {
         data: { tags },
         error: gqlErrors,
@@ -215,6 +217,7 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
         return { notFound: true }
       }
 
+      tagName = name // open graph title
       tagRelatedPosts = tags[0]?.posts?.map(postConvertFunc) || []
     }
   } catch (err) {
@@ -238,12 +241,16 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
   return {
     props: {
       tagRelatedPosts,
+      tagName,
     },
   }
 }
 
-Tag.getLayout = function getLayout(page: ReactElement) {
-  return <LayoutGeneral>{page}</LayoutGeneral>
+Tag.getLayout = function getLayout(page: ReactElement<PageProps>) {
+  const { props } = page
+  const ogTitle = `搜尋：${props.tagName}`
+
+  return <LayoutGeneral title={ogTitle}>{page}</LayoutGeneral>
 }
 
 export default Tag

--- a/packages/readr/types/common.ts
+++ b/packages/readr/types/common.ts
@@ -58,6 +58,7 @@ export type GenericPost = {
   sortOrder: number
   heroImage: GenericPhoto | null
   ogImage: GenericPhoto | null
+  ogDescription: string | null
   heroCaption: string
   content: RawDraftContentState // draft-renderer JSON
   summary: RawDraftContentState // draft-renderer JSON
@@ -82,6 +83,8 @@ export type GenericCategory = {
   title: string
   posts: GenericPost[]
   reports: GenericPost[]
+  ogImage: GenericPhoto | null
+  ogDescription: string | null
 }
 
 export type GenericTag = {


### PR DESCRIPTION
- 新增「標籤頁」、「文章頁」OG 資訊。
- `layout/custom-head.tsx` 新增 props `imageUrl`：提供頁面設定特定 og image。
- 調整相關 type 設定。
- 註：[READr3.0 OG 文件](https://paper.dropbox.com/doc/READr-OG--B2PvWahSGezjDaF7OR72c8OBAg-gkrrvudUsprQQZvCoCd1N)