### PR TITLE
fix(post): get manual-order data & fix `latestPosts`

### DIFF
--- a/packages/readr/components/post/post-credit.tsx
+++ b/packages/readr/components/post/post-credit.tsx
@@ -100,13 +100,19 @@ interface PostProps {
 }
 
 export default function PostCredit({ postData }: PostProps): JSX.Element {
-  function renderNames(people: Author[]) {
-    return people?.map((person) => <span key={person.id}>{person.name}</span>)
+  function renderNames(authors: Author[]) {
+    return authors?.map((author) => <span key={author.id}>{author.name}</span>)
   }
 
-  const writers = renderNames(postData?.writers)
-  const designers = renderNames(postData?.designers)
-  const dataAnalysts = renderNames(postData?.dataAnalysts)
+  const writers = renderNames(
+    postData?.manualOrderOfWriters ?? postData?.writers
+  )
+  const designers = renderNames(
+    postData?.manualOrderOfDesigners ?? postData?.designers
+  )
+  const dataAnalysts = renderNames(
+    postData?.manualOrderOfDataAnalysts ?? postData?.dataAnalysts
+  )
 
   return (
     <Container>

--- a/packages/readr/graphql/query/post.ts
+++ b/packages/readr/graphql/query/post.ts
@@ -118,11 +118,13 @@ const latestPosts = gql`
   query  (
     $first: Int! = 3, 
     $skip: Int! = 0
+    $skipId: ID!
   ) {
     latestPosts: posts(
       take: $first
       skip: $skip
       where: {
+        id: { not: { equals: $skipId } }
         state: { equals: "published" }
         style: {
           in: [${convertToStringList(postStyles)}]

--- a/packages/readr/graphql/query/post.ts
+++ b/packages/readr/graphql/query/post.ts
@@ -28,6 +28,9 @@ export type PostDetail = Override<
       | 'summary'
       | 'actionList'
       | 'citation'
+      | 'manualOrderOfDataAnalysts'
+      | 'manualOrderOfWriters'
+      | 'manualOrderOfDesigners'
       | 'dataAnalysts'
       | 'writers'
       | 'designers'
@@ -41,6 +44,9 @@ export type PostDetail = Override<
   {
     heroImage: PhotoWithResizedOnly | null
     ogImage: PhotoWithResizedOnly | null
+    manualOrderOfDataAnalysts: Author[]
+    manualOrderOfWriters: Author[]
+    manualOrderOfDesigners: Author[]
     dataAnalysts: Author[]
     writers: Author[]
     designers: Author[]
@@ -69,6 +75,9 @@ const post = gql`
         title
         slug
       }
+      manualOrderOfDataAnalysts
+      manualOrderOfWriters
+      manualOrderOfDesigners
       dataAnalysts {
         ...AuthorFields
       }

--- a/packages/readr/pages/post/[id].tsx
+++ b/packages/readr/pages/post/[id].tsx
@@ -15,7 +15,6 @@ import { post } from '~/graphql/query/post'
 import { latestPosts as latestPostsQuery } from '~/graphql/query/post'
 import type { NextPageWithLayout } from '~/pages/_app'
 import { ResizedImages, ValidPostStyle } from '~/types/common'
-import * as gtag from '~/utils/gtag'
 
 type PageProps = {
   postData: PostDetail
@@ -136,9 +135,12 @@ Post.getLayout = function getLayout(page: ReactElement<PageProps>) {
   const { props } = page
 
   function convertDraftToText(blocks: RawDraftContentBlock[]) {
-    const text = blocks.map((block) => block.text).join('')
-    const ogDescription = text.length > 160 ? text.slice(0, 160) + '...' : text
-    return ogDescription
+    if (blocks) {
+      const text = blocks.map((block) => block.text).join('')
+      const ogDescription =
+        text && text.length > 160 ? text.slice(0, 160) + '...' : text
+      return ogDescription
+    }
   }
 
   function getResizedUrl(
@@ -157,9 +159,9 @@ Post.getLayout = function getLayout(page: ReactElement<PageProps>) {
   const ogTitle = props.postData.title
 
   const ogDescription =
-    props.postData.ogDescription ||
-    convertDraftToText(props.postData.summary.blocks) ||
-    convertDraftToText(props.postData.content.blocks)
+    props.postData?.ogDescription ||
+    convertDraftToText(props.postData?.summary?.blocks) ||
+    convertDraftToText(props.postData?.content?.blocks)
 
   const ogImageUrl =
     getResizedUrl(props.postData?.ogImage?.resized) ||

--- a/packages/readr/pages/post/[id].tsx
+++ b/packages/readr/pages/post/[id].tsx
@@ -85,12 +85,14 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
 
     {
       // fetch the latest 4 reports
+      const postId = params?.id
       const { data, errors: gqlErrors } = await client.query<{
         latestPosts: Post[]
       }>({
         query: latestPostsQuery,
         variables: {
           first: 4,
+          skipId: postId,
         },
       })
 

--- a/packages/readr/types/common.ts
+++ b/packages/readr/types/common.ts
@@ -68,6 +68,9 @@ export type GenericPost = {
   writers: GenericAuthor[]
   designers: GenericAuthor[]
   categories: GenericCategory[]
+  manualOrderOfDataAnalysts: GenericAuthor[] // JSON
+  manualOrderOfWriters: GenericAuthor[] // JSON
+  manualOrderOfDesigners: GenericAuthor[] // JSON
   otherByline: string
   relatedPosts: GenericPost[]
   manualOrderOfRelatedPosts: unknown // it is hard to describe JSON type


### PR DESCRIPTION
### 驗收修改
- 文章頁：作者欄位改優先抓排序過後的 JSON 資料。
- 文章頁：「最新報導」資料應排除自身 `[postId]` 。