### PR TITLE
feat(readr): add GA event ( post / category / tag )

### DIFF
--- a/packages/readr/components/post/article-type/blank.tsx
+++ b/packages/readr/components/post/article-type/blank.tsx
@@ -3,6 +3,8 @@ import styled from 'styled-components'
 
 import Footer from '~/components/layout/footer'
 import type { PostDetail } from '~/graphql/query/post'
+import useScrollToEnd from '~/hooks/useScrollToEnd'
+import * as gtag from '~/utils/gtag'
 
 const BlankWrapper = styled.article`
   background: transparent;
@@ -17,11 +19,23 @@ const BlankWrapper = styled.article`
     background: #ffffff;
   }
 `
+
+const HiddenAnchor = styled.div`
+  display: block;
+  width: 100%;
+  height: 0;
+  padding: 0;
+  margin: 0;
+`
 interface BlankProps {
   postData: PostDetail
 }
 
 export default function Blank({ postData }: BlankProps): JSX.Element {
+  const anchorRef = useScrollToEnd(() =>
+    gtag.sendEvent('post', 'scroll', 'scroll to end')
+  )
+
   const { DraftRenderer } = Readr
 
   //remove blocks[0] to avoid extra empty blank before embedded-code
@@ -34,6 +48,7 @@ export default function Blank({ postData }: BlankProps): JSX.Element {
     <BlankWrapper>
       <DraftRenderer rawContentBlock={contentWithoutEmptyBlank} />
       <Footer />
+      <HiddenAnchor ref={anchorRef} />
     </BlankWrapper>
   )
 }

--- a/packages/readr/components/post/article-type/frame.tsx
+++ b/packages/readr/components/post/article-type/frame.tsx
@@ -10,6 +10,8 @@ import SubscribeButton from '~/components/post/subscribe-button'
 import { DEFAULT_POST_IMAGE_PATH } from '~/constants/constant'
 import type { Post } from '~/graphql/fragments/post'
 import type { PostDetail } from '~/graphql/query/post'
+import useScrollToEnd from '~/hooks/useScrollToEnd'
+import * as gtag from '~/utils/gtag'
 import { formatPostDate } from '~/utils/post'
 
 const FrameWrapper = styled.div`
@@ -143,6 +145,14 @@ const CreditLists = styled.ul`
   }
 `
 
+const HiddenAnchor = styled.div`
+  display: block;
+  width: 100%;
+  height: 0;
+  padding: 0;
+  margin: 0;
+`
+
 interface PostProps {
   postData: PostDetail
   latestPosts: Post[]
@@ -152,6 +162,10 @@ export default function Frame({
   postData,
   latestPosts,
 }: PostProps): JSX.Element {
+  const anchorRef = useScrollToEnd(() =>
+    gtag.sendEvent('post', 'scroll', 'scroll to end')
+  )
+
   const date = formatPostDate(postData?.publishTime)
 
   //workaround: 特殊頁面需要客製化 credit 清單，在 cms Post 作者（其他）欄位中以星號開頭來啟用，以全形的'／'來產生換行效果
@@ -203,6 +217,7 @@ export default function Frame({
         <div className="publish-time">{date}</div>
       </FrameCredit>
       <Footer />
+      <HiddenAnchor ref={anchorRef} />
     </FrameWrapper>
   )
 }

--- a/packages/readr/components/post/article-type/frame.tsx
+++ b/packages/readr/components/post/article-type/frame.tsx
@@ -216,8 +216,8 @@ export default function Frame({
         <CreditLists>{frameCreditLists}</CreditLists>
         <div className="publish-time">{date}</div>
       </FrameCredit>
-      <Footer />
       <HiddenAnchor ref={anchorRef} />
+      <Footer />
     </FrameWrapper>
   )
 }

--- a/packages/readr/components/post/article-type/news.tsx
+++ b/packages/readr/components/post/article-type/news.tsx
@@ -9,6 +9,8 @@ import SubscribeButton from '~/components/post/subscribe-button'
 import { DEFAULT_POST_IMAGE_PATH } from '~/constants/constant'
 import type { Post } from '~/graphql/fragments/post'
 import type { PostDetail } from '~/graphql/query/post'
+import useScrollToEnd from '~/hooks/useScrollToEnd'
+import * as gtag from '~/utils/gtag'
 
 const HeroImage = styled.figure`
   width: 100%;
@@ -55,6 +57,14 @@ const PostHeading = styled.section`
   }
 `
 
+const HiddenAnchor = styled.div`
+  display: block;
+  width: 100%;
+  height: 0;
+  padding: 0;
+  margin: 0;
+`
+
 interface PostProps {
   postData: PostDetail
   latestPosts: Post[]
@@ -64,6 +74,10 @@ export default function News({
   postData,
   latestPosts,
 }: PostProps): JSX.Element {
+  const anchorRef = useScrollToEnd(() =>
+    gtag.sendEvent('post', 'scroll', 'scroll to end')
+  )
+
   return (
     <>
       <article>
@@ -88,6 +102,7 @@ export default function News({
       <SubscribeButton />
 
       <Report relatedPosts={postData?.relatedPosts} latestPosts={latestPosts} />
+      <HiddenAnchor ref={anchorRef} />
     </>
   )
 }

--- a/packages/readr/components/post/article-type/scrollable-video.tsx
+++ b/packages/readr/components/post/article-type/scrollable-video.tsx
@@ -10,6 +10,8 @@ import SubscribeButton from '~/components/post/subscribe-button'
 import { DEFAULT_POST_IMAGE_PATH } from '~/constants/constant'
 import type { Post } from '~/graphql/fragments/post'
 import type { PostDetail } from '~/graphql/query/post'
+import useScrollToEnd from '~/hooks/useScrollToEnd'
+import * as gtag from '~/utils/gtag'
 
 const Article = styled.article`
   padding-top: calc(100vh - 72px);
@@ -65,6 +67,14 @@ const PostHeading = styled.section`
   }
 `
 
+const HiddenAnchor = styled.div`
+  display: block;
+  width: 100%;
+  height: 0;
+  padding: 0;
+  margin: 0;
+`
+
 interface PostProps {
   postData: PostDetail
   latestPosts: Post[]
@@ -74,6 +84,10 @@ export default function ScrollableVideo({
   postData,
   latestPosts,
 }: PostProps): JSX.Element {
+  const anchorRef = useScrollToEnd(() =>
+    gtag.sendEvent('post', 'scroll', 'scroll to end')
+  )
+
   const { DraftRenderer } = Readr
 
   // get first Embedded-Video of `postData.content`.
@@ -147,6 +161,7 @@ export default function ScrollableVideo({
       <SubscribeButton />
 
       <Report relatedPosts={postData?.relatedPosts} latestPosts={latestPosts} />
+      <HiddenAnchor ref={anchorRef} />
     </>
   )
 }

--- a/packages/readr/components/post/post-content.tsx
+++ b/packages/readr/components/post/post-content.tsx
@@ -7,6 +7,7 @@ import PostTag from '~/components/post/tag'
 import MediaLinkList from '~/components/shared/media-link'
 import { DONATION_PAGE_URL } from '~/constants/environment-variables'
 import type { PostDetail } from '~/graphql/query/post'
+import * as gtag from '~/utils/gtag'
 
 const Container = styled.article`
   width: 100%;
@@ -201,7 +202,10 @@ export default function PostContent({ postData }: PostProps): JSX.Element {
         </ActionList>
       )}
 
-      <DonateButton href={DONATION_PAGE_URL} />
+      <DonateButton
+        href={DONATION_PAGE_URL}
+        onClick={() => gtag.sendEvent('post', 'click', 'post-donate')}
+      />
       <MediaLinkList className={'mobile-media-link'} />
 
       {checkValue(postData?.citation?.blocks) && (

--- a/packages/readr/components/post/post-title.tsx
+++ b/packages/readr/components/post/post-title.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import styled from 'styled-components'
 
 import type { PostDetail } from '~/graphql/query/post'
+import * as gtag from '~/utils/gtag'
 import { formatPostDate, formatReadTime } from '~/utils/post'
 
 import DateAndReadTimeInfo from '../shared/date-and-read-time-info'
@@ -82,7 +83,10 @@ export default function PostTitle({
 }: PostProps): JSX.Element {
   const categoryItem = categories.map((item) => {
     return (
-      <li key={item.id}>
+      <li
+        key={item.id}
+        onClick={() => gtag.sendEvent('post', 'click', `post-${item.title}`)}
+      >
         <Link href={`/category/${item.slug}`}>{item.title}</Link>
       </li>
     )

--- a/packages/readr/components/post/report.tsx
+++ b/packages/readr/components/post/report.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components'
 import { DEFAULT_POST_IMAGE_PATH } from '~/constants/constant'
 import type { Post } from '~/graphql/fragments/post'
 import type { ResizedImages } from '~/types/common'
+import * as gtag from '~/utils/gtag'
 import { getHref } from '~/utils/post'
 
 const Wrapper = styled.div`
@@ -63,6 +64,9 @@ export default function Report({
             header="相關報導"
             postData={addLinkInPosts(relatedPosts)}
             defaultImage={DEFAULT_POST_IMAGE_PATH}
+            postClickHandler={(post: Post) =>
+              gtag.sendEvent('post', 'click', `post-related-${post.title}`)
+            }
           />
         )}
         {Array.isArray(latestPosts) && latestPosts.length > 0 && (
@@ -70,6 +74,9 @@ export default function Report({
             header="最新報導"
             postData={addLinkInPosts(latestPosts)}
             defaultImage={DEFAULT_POST_IMAGE_PATH}
+            postClickHandler={(post: Post) =>
+              gtag.sendEvent('post', 'click', `post-latest-${post.title}`)
+            }
           />
         )}
       </Wrapper>

--- a/packages/readr/components/post/subscribe-button.tsx
+++ b/packages/readr/components/post/subscribe-button.tsx
@@ -1,6 +1,8 @@
 import { SubscribeButton } from '@readr-media/react-component'
 import styled from 'styled-components'
 
+import * as gtag from '~/utils/gtag'
+
 const SubscribeWrapper = styled.div`
   width: 100%;
   display: flex;
@@ -13,7 +15,9 @@ const SubscribeWrapper = styled.div`
 export default function Subscribe(): JSX.Element {
   return (
     <SubscribeWrapper>
-      <SubscribeButton />
+      <SubscribeButton
+        onClick={() => gtag.sendEvent('post', 'click', 'post-mailsubscribe')}
+      />
     </SubscribeWrapper>
   )
 }

--- a/packages/readr/components/post/tag.tsx
+++ b/packages/readr/components/post/tag.tsx
@@ -2,6 +2,7 @@ import NextLink from 'next/link'
 import styled from 'styled-components'
 
 import type { GenericTag } from '~/types/common'
+import * as gtag from '~/utils/gtag'
 
 const TagWrapper = styled.ul`
   width: 100%;
@@ -49,7 +50,10 @@ export default function PostTag({ tags }: TagProps): JSX.Element {
     <TagWrapper>
       {tags.map((tag) => {
         return (
-          <li key={tag.id}>
+          <li
+            key={tag.id}
+            onClick={() => gtag.sendEvent('post', 'click', `post-${tag.name}`)}
+          >
             <NextLink href={`/tag/${tag.name}`} target="_blank">
               {tag.name}
             </NextLink>

--- a/packages/readr/components/shared/media-link.tsx
+++ b/packages/readr/components/shared/media-link.tsx
@@ -6,6 +6,7 @@ import IconFacebook from '~/public/icons/facebook-circle.svg'
 import IconLine from '~/public/icons/line-circle.svg'
 import IconLink from '~/public/icons/link-circle.svg'
 import IconTwitter from '~/public/icons/twitter-circle.svg'
+import * as gtag from '~/utils/gtag'
 
 const MediaLinkWrapper = styled.ul<{ className: string }>`
   width: 100%;
@@ -47,6 +48,7 @@ type ExternalLinkItem = {
   href: string
   svgIcon: any
   alt: string
+  click: () => void
 }
 
 export default function MediaLinkList({
@@ -64,18 +66,21 @@ export default function MediaLinkList({
       href: `https://www.facebook.com/share.php?u=${href}`,
       svgIcon: IconFacebook,
       alt: '分享至facebook',
+      click: () => gtag.sendEvent('post', 'click', 'post-share-fb'),
     },
     {
       name: 'Twitter',
       href: `https://twitter.com/intent/tweet?url=${href}`,
       svgIcon: IconTwitter,
       alt: '分享至twitter',
+      click: () => gtag.sendEvent('post', 'click', 'post-share-twitter'),
     },
     {
       name: 'Line',
       href: `https://social-plugins.line.me/lineit/share?url=${href}`,
       svgIcon: IconLine,
       alt: '分享至line',
+      click: () => gtag.sendEvent('post', 'click', 'post-share-line'),
     },
   ]
   function handleLinkClick() {
@@ -87,13 +92,14 @@ export default function MediaLinkList({
       .catch(() => {
         console.error('Failed to copy URL to clipboard')
       })
+    gtag.sendEvent('post', 'click', 'post-copylink')
   }
 
   return (
     <MediaLinkWrapper className={className}>
       {externalLinks.map((item) => {
         return (
-          <li key={item.name} aria-label={item.alt}>
+          <li key={item.name} aria-label={item.alt} onClick={item.click}>
             <NextLink
               href={item.href}
               target="_blank"

--- a/packages/readr/hooks/useInfiniteScroll.ts
+++ b/packages/readr/hooks/useInfiniteScroll.ts
@@ -41,19 +41,19 @@ const useInfiniteScroll = ({
 
   useEffect(() => {
     const observer = new IntersectionObserver(callback, options)
-    const element = ref.current
+    const target = ref.current
 
-    if (element) {
-      observer.observe(element)
+    if (target) {
+      observer.observe(target)
     }
 
-    if (element && isAtBottom && !amount) {
-      observer.unobserve(element)
+    if (target && isAtBottom && !amount) {
+      observer.unobserve(target)
     }
 
     return () => {
-      if (element) {
-        observer.unobserve(element)
+      if (target) {
+        observer.unobserve(target)
       }
     }
   }, [dependency, amount])

--- a/packages/readr/hooks/useScrollToEnd.ts
+++ b/packages/readr/hooks/useScrollToEnd.ts
@@ -1,0 +1,38 @@
+import { useEffect, useRef } from 'react'
+
+const useScrollToEnd = (callback: () => void) => {
+  const anchorRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const target = anchorRef.current
+    const observer = new IntersectionObserver(
+      (entries, observer) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            callback()
+            observer.unobserve(entry.target)
+          }
+        })
+      },
+      {
+        root: null,
+        rootMargin: '0px',
+        threshold: 1,
+      }
+    )
+
+    if (target) {
+      observer.observe(target)
+    }
+
+    return () => {
+      if (target) {
+        observer.unobserve(target)
+      }
+    }
+  }, [callback])
+
+  return anchorRef
+}
+
+export default useScrollToEnd

--- a/packages/readr/package.json
+++ b/packages/readr/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@apollo/client": "^3.7.3",
     "@mirrormedia/lilith-draft-renderer": "^1.1.0-alpha.3",
-    "@readr-media/react-component": "2.0.0-alpha.5",
+    "@readr-media/react-component": "^2.1.0-alpha.1",
     "@readr-media/react-image": "^1.5.1",
     "@readr-media/share-button": "^1.0.3",
     "@svgr/webpack": "^6.5.1",

--- a/packages/readr/pages/category/[slug].tsx
+++ b/packages/readr/pages/category/[slug].tsx
@@ -21,6 +21,7 @@ import { postStyles } from '~/graphql/query/post'
 import useInfiniteScroll from '~/hooks/useInfiniteScroll'
 import type { NextPageWithLayout } from '~/pages/_app'
 import type { NavigationCategory } from '~/types/component'
+import * as gtag from '~/utils/gtag'
 import { postConvertFunc } from '~/utils/post'
 
 const shareStyle = css`
@@ -35,14 +36,12 @@ const shareStyle = css`
 
 const CategoryWrapper = styled.div`
   padding: 24px 20px;
-
   ${({ theme }) => theme.breakpoint.sm} {
     padding: 48px 20px;
   }
   ${({ theme }) => theme.breakpoint.md} {
     padding: 48px;
   }
-
   ${({ theme }) => theme.breakpoint.lg} {
     padding: 60px 72px;
     max-width: 1240px;
@@ -55,11 +54,9 @@ const ItemList = styled.div`
   justify-content: space-between;
   width: 100%;
   margin-top: 20px;
-
   ${({ theme }) => theme.breakpoint.sm} {
     margin-top: 50px;
   }
-
   ${({ theme }) => theme.breakpoint.xl} {
     justify-content: flex-start;
     gap: calc((100% - 1024px) / 3);
@@ -115,6 +112,7 @@ const Category: NextPageWithLayout<PageProps> = ({ categories, latest }) => {
       category.slug === 'all' ? '所有報導' : `所有${category.title}報導`
     )
     setIsAtBottom(false) //infinite scroll: reset `isAtBottom` to false when change category
+    gtag.sendEvent('listing', 'click', `listing-${category.title}`)
   }
 
   //render posts based on `currentItem`
@@ -144,6 +142,9 @@ const Category: NextPageWithLayout<PageProps> = ({ categories, latest }) => {
             mobile: `${theme.mediaSize.sm - 1}px`,
             tablet: `${theme.mediaSize.xl - 1}px`,
           }}
+          onClick={() =>
+            gtag.sendEvent('listing', 'click', `listing-${article.title}`)
+          }
         />
       </Item>
     )

--- a/packages/readr/pages/index.tsx
+++ b/packages/readr/pages/index.tsx
@@ -3,8 +3,7 @@
 // @ts-ignore: no definition
 import errors from '@twreporter/errors'
 import type { GetServerSideProps } from 'next'
-import { ReactElement, useEffect } from 'react'
-import { useRef } from 'react'
+import { ReactElement } from 'react'
 import styled from 'styled-components'
 
 import client from '~/apollo-client'
@@ -31,6 +30,7 @@ import { features as featuresQuery } from '~/graphql/query/feature'
 import { latestPosts as latestPostsQuery } from '~/graphql/query/post'
 import type { Quote } from '~/graphql/query/quote'
 import { quotes as quotesQuery } from '~/graphql/query/quote'
+import useScrollToEnd from '~/hooks/useScrollToEnd'
 import { ValidPostStyle } from '~/types/common'
 import type {
   ArticleCard,
@@ -74,38 +74,9 @@ const Index: NextPageWithLayout<PageProps> = ({
   dataSetItems,
   dataSetCount,
 }) => {
-  const anchorRef = useRef<HTMLDivElement>(null)
-
-  const callback = (
-    entries: IntersectionObserverEntry[],
-    observer: IntersectionObserver
-  ) => {
-    entries.forEach((entry) => {
-      if (entry.isIntersecting) {
-        gtag.sendEvent('homepage', 'scroll', 'scroll to end')
-        observer.unobserve(entry.target)
-      }
-    })
-  }
-
-  useEffect(() => {
-    const target = anchorRef.current
-    const observer = new IntersectionObserver(callback, {
-      root: null,
-      rootMargin: '0px',
-      threshold: 1,
-    })
-
-    if (target) {
-      observer.observe(target)
-    }
-
-    return () => {
-      if (target) {
-        observer.unobserve(target)
-      }
-    }
-  }, [anchorRef])
+  const anchorRef = useScrollToEnd(() =>
+    gtag.sendEvent('homepage', 'scroll', 'scroll to end')
+  )
 
   const shouldShowEditorChoiceSection = editorChoices.length > 0
   const shouldShowLatestReportSection = categories.length > 0

--- a/packages/readr/pages/tag/[name].tsx
+++ b/packages/readr/pages/tag/[name].tsx
@@ -16,6 +16,7 @@ import { tags as tagQuery } from '~/graphql/query/tag'
 import useInfiniteScroll from '~/hooks/useInfiniteScroll'
 import type { NextPageWithLayout } from '~/pages/_app'
 import { ArticleCard } from '~/types/component'
+import * as gtag from '~/utils/gtag'
 import { postConvertFunc } from '~/utils/post'
 
 const shareStyle = css`
@@ -101,6 +102,7 @@ const Tag: NextPageWithLayout<PageProps> = ({ tagRelatedPosts }) => {
             mobile: `${theme.mediaSize.sm - 1}px`,
             tablet: `${theme.mediaSize.xl - 1}px`,
           }}
+          onClick={() => gtag.sendEvent('tag', 'click', `tag-${article.title}`)}
         />
       </Item>
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -2773,10 +2773,10 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
-"@readr-media/react-component@2.0.0-alpha.5":
-  version "2.0.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/@readr-media/react-component/-/react-component-2.0.0-alpha.5.tgz#2812445728d7a6ad7ba815f8647768e98e0a2b92"
-  integrity sha512-RbgZimW1RvsYkGj+v8tuHk9s8EtYgZa0tuBQBIsr+aljaQvJGPJyC0f0R9/c5ipsvnlYM1sdm9QIsOcCuThvXw==
+"@readr-media/react-component@^2.1.0-alpha.1":
+  version "2.1.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@readr-media/react-component/-/react-component-2.1.0-alpha.1.tgz#54ea53aba7b6773b532db224124641d8b3ee07d0"
+  integrity sha512-d14YNseuYz6zbinw4TALz+vl/PTRplvbUQIO7REusjEDXt/Oj0Rq0GqK8CukGOmzqdtjLmFyNoNjxEX64aezPg==
   dependencies:
     "@readr-media/react-image" "^1.5.1"
     dayjs "^1.11.7"


### PR DESCRIPTION
- 新增文章頁、標籤頁、列表頁 GA event。
- 新增 `useScrollToEnd` hooks

   - 因文章頁不同 article type 會重複使用到 `scroll to end` 的 IntersectionObserver，因此整理為 hooks 作使用。
   - 已同步更新 `index.tsx` 中 `scroll to end` 的寫法（改為 import useScrollToEnd ) 

- `@readr-media/react-component` 使用版本升至 `2.1.0-alpha.1`
    - 「相關報導 / 最新報導」區塊可透過傳入 `postClickHandler` ，設定針對單篇報導的 GA event。