### PR TITLE
feat(post): add `LeadingEmbeddedCode` component

### DIFF
--- a/packages/readr/components/post/article-type/blank.tsx
+++ b/packages/readr/components/post/article-type/blank.tsx
@@ -1,7 +1,7 @@
-import { Readr } from '@mirrormedia/lilith-draft-renderer'
 import styled from 'styled-components'
 
 import Footer from '~/components/layout/footer'
+import LeadingEmbeddedCode from '~/components/post/leadingEmbeddedCode'
 import type { PostDetail } from '~/graphql/query/post'
 import useScrollToEnd from '~/hooks/useScrollToEnd'
 import * as gtag from '~/utils/gtag'
@@ -36,17 +36,11 @@ export default function Blank({ postData }: BlankProps): JSX.Element {
     gtag.sendEvent('post', 'scroll', 'scroll to end')
   )
 
-  const { DraftRenderer } = Readr
-
-  //remove blocks[0] to avoid extra empty blank before embedded-code
-  const contentWithoutEmptyBlank = {
-    blocks: postData?.content.blocks.slice(1),
-    entityMap: postData?.content.entityMap,
-  }
-
   return (
     <BlankWrapper>
-      <DraftRenderer rawContentBlock={contentWithoutEmptyBlank} />
+      {postData?.leadingEmbeddedCode && (
+        <LeadingEmbeddedCode embeddedCode={postData?.leadingEmbeddedCode} />
+      )}
       <Footer />
       <HiddenAnchor ref={anchorRef} />
     </BlankWrapper>

--- a/packages/readr/components/post/article-type/scrollable-video.tsx
+++ b/packages/readr/components/post/article-type/scrollable-video.tsx
@@ -1,7 +1,7 @@
-import { Readr } from '@mirrormedia/lilith-draft-renderer'
 import SharedImage from '@readr-media/react-image'
 import styled from 'styled-components'
 
+import LeadingEmbeddedCode from '~/components/post/leadingEmbeddedCode'
 import PostContent from '~/components/post/post-content'
 import PostCredit from '~/components/post/post-credit'
 import PostTitle from '~/components/post/post-title'
@@ -88,49 +88,6 @@ export default function ScrollableVideo({
     gtag.sendEvent('post', 'scroll', 'scroll to end')
   )
 
-  const { DraftRenderer } = Readr
-
-  // get first Embedded-Video of `postData.content`.
-  const embeddedEntities = Object.values(postData?.content?.entityMap).find(
-    (entity) => entity.type === 'EMBEDDEDCODE'
-  )
-
-  const embeddedBlocks = postData?.content?.blocks.find((block) => {
-    return block.type === 'atomic' && block.entityRanges[0].key === 0
-  })
-
-  const embeddedContentState = {
-    entityMap: {
-      '0': { ...embeddedEntities },
-    },
-    blocks: [{ ...embeddedBlocks }],
-  }
-
-  // get first Embedded-Video key in `entityMap`
-  let scrollVideoIndex = 0
-
-  for (const key in postData?.content?.entityMap) {
-    if (postData?.content?.entityMap[key].type === 'EMBEDDEDCODE') {
-      scrollVideoIndex = parseInt(key, 10)
-      break
-    }
-  }
-
-  //remove first Embedded-Video block from postData?.content based on `scrollVideoIndex`
-  const remainBlocks = postData?.content?.blocks.filter((block) => {
-    return (
-      block.type !== 'atomic' || block.entityRanges[0].key !== scrollVideoIndex
-    )
-  })
-
-  const postDataWithoutFirstScrollVideo = {
-    ...postData,
-    content: {
-      ...postData.content,
-      blocks: remainBlocks,
-    },
-  }
-
   return (
     <>
       <Article>
@@ -144,18 +101,18 @@ export default function ScrollableVideo({
           <ScrollTitle>{postData?.title}</ScrollTitle>
         </HeroImage>
 
-        {/* first embedded-video of `postData.content` */}
-        <ScrollVideo>
-          <DraftRenderer rawContentBlock={embeddedContentState} />
-        </ScrollVideo>
+        {postData?.leadingEmbeddedCode && (
+          <ScrollVideo>
+            <LeadingEmbeddedCode embeddedCode={postData?.leadingEmbeddedCode} />
+          </ScrollVideo>
+        )}
 
         <PostHeading>
           <PostTitle postData={postData} showTitle={false} />
           <PostCredit postData={postData} />
         </PostHeading>
 
-        {/* `postData.content` without first embedded-video */}
-        <PostContent postData={postDataWithoutFirstScrollVideo} />
+        <PostContent postData={postData} />
       </Article>
 
       <SubscribeButton />

--- a/packages/readr/components/post/leadingEmbeddedCode.tsx
+++ b/packages/readr/components/post/leadingEmbeddedCode.tsx
@@ -1,0 +1,37 @@
+import { Helmet } from 'react-helmet'
+import styled from 'styled-components'
+
+const EmbeddedWrapper = styled.div`
+  background: white;
+`
+
+type FirstEmbeddedCodeProps = {
+  embeddedCode: string
+}
+
+export default function FirstEmbeddedCode({
+  embeddedCode,
+}: FirstEmbeddedCodeProps): JSX.Element {
+  const scriptRegex = /<script\b[^>]*>([\s\S]*?)<\/script>/gm
+  const srcRegex = /src="([^"]*)"/
+  const srcList = []
+
+  for (const scriptMatch of embeddedCode.matchAll(scriptRegex)) {
+    const srcMatch = scriptMatch?.[0].match(srcRegex)
+    const src = srcMatch?.[1]
+    if (src) {
+      srcList.push(src)
+    }
+  }
+
+  const srcLinks = srcList.map((src, index) => {
+    return <link rel="preload" href={src} as="script" key={index} />
+  })
+
+  return (
+    <EmbeddedWrapper>
+      <Helmet>{srcLinks}</Helmet>
+      <div dangerouslySetInnerHTML={{ __html: embeddedCode }} />
+    </EmbeddedWrapper>
+  )
+}

--- a/packages/readr/components/post/post-content.tsx
+++ b/packages/readr/components/post/post-content.tsx
@@ -155,7 +155,8 @@ const TagGroup = styled.div`
     margin: 0 auto 52px;
   }
 `
-interface PostProps {
+
+type PostProps = {
   postData: PostDetail
 }
 

--- a/packages/readr/graphql/query/post.ts
+++ b/packages/readr/graphql/query/post.ts
@@ -40,6 +40,7 @@ export type PostDetail = Override<
       | 'tags'
       | 'state'
       | 'ogDescription'
+      | 'leadingEmbeddedCode'
     >,
   {
     heroImage: PhotoWithResizedOnly | null
@@ -87,6 +88,7 @@ const post = gql`
       designers {
         ...AuthorFields
       }
+      leadingEmbeddedCode
       otherByline
       tags ( 
         where: { 

--- a/packages/readr/package.json
+++ b/packages/readr/package.json
@@ -29,6 +29,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-ga4": "^2.0.0",
+    "react-helmet": "^6.1.0",
     "sharp": "^0.31.3",
     "styled-components": "^5.3.6",
     "ts-import": "^4.0.0-beta.6"

--- a/packages/readr/react-helmet.d.ts
+++ b/packages/readr/react-helmet.d.ts
@@ -1,0 +1,1 @@
+declare module 'react-helmet'

--- a/packages/readr/types/common.ts
+++ b/packages/readr/types/common.ts
@@ -78,6 +78,7 @@ export type GenericPost = {
   readingTime: number
   tags: GenericTag[]
   state: string
+  leadingEmbeddedCode: string
 }
 
 export type GenericCategory = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8449,6 +8449,11 @@ react-dom@18.2.0, react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-fast-compare@^3.1.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.1.tgz#53933d9e14f364281d6cba24bfed7a4afb808b5f"
+  integrity sha512-xTYf9zFim2pEif/Fw16dBiXpe0hoy5PxcD8+OwBnTtNLfIm3g6WxhKNurY+6OmdH1u6Ta/W/Vl6vjbYP1MFnDg==
+
 react-ga4@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/react-ga4/-/react-ga4-2.0.0.tgz#d125807cc30b087a6aa24401ec5f1f1c2d176fe9"
@@ -8458,6 +8463,16 @@ react-ga@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-3.3.1.tgz#d8e1f4e05ec55ed6ff944dcb14b99011dfaf9504"
   integrity sha512-4Vc0W5EvXAXUN/wWyxvsAKDLLgtJ3oLmhYYssx+YzphJpejtOst6cbIHCIyF50Fdxuf5DDKqRYny24yJ2y7GFQ==
+
+react-helmet@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-6.1.0.tgz#a750d5165cb13cf213e44747502652e794468726"
+  integrity sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.7.2"
+    react-fast-compare "^3.1.1"
+    react-side-effect "^2.1.0"
 
 react-intersection-observer@^9.4.1:
   version "9.4.1"
@@ -8475,6 +8490,11 @@ react-resize-detector@^7.1.2:
   integrity sha512-zXnPJ2m8+6oq9Nn8zsep/orts9vQv3elrpA+R8XTcW7DVVUJ9vwDwMXaBtykAYjMnkCIaOoK9vObyR7ZgFNlOw==
   dependencies:
     lodash "^4.17.21"
+
+react-side-effect@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.2.tgz#dc6345b9e8f9906dc2eeb68700b615e0b4fe752a"
+  integrity sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==
 
 react-spinners@^0.13.6:
   version "0.13.6"


### PR DESCRIPTION
- 新增 `LeadingEmbeddedCode` 元件

   -  `dangerouslySetInnerHTML` + `react-helmet`：優先執行 script request + 預留高度。
   - 使用於文章類型：`blank`、`scrollable-video`。
   - 文章類型：frame 因為 embedded 需求非首屏，故無使用`LeadingEmbeddedCode`（改由 draft-renderer 內部處理）。