### PR TITLE
fix(post): `project3` redirect error handle

### DIFF
--- a/packages/readr/components/post/article-type/frame.tsx
+++ b/packages/readr/components/post/article-type/frame.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 
 import Footer from '~/components/layout/footer'
 import PostContent from '~/components/post/post-content'
-import Report from '~/components/post/report'
+import RelatedPosts from '~/components/post/related-post'
 import SubscribeButton from '~/components/post/subscribe-button'
 import { DEFAULT_POST_IMAGE_PATH } from '~/constants/constant'
 import type { Post } from '~/graphql/fragments/post'
@@ -211,7 +211,10 @@ export default function Frame({
         <PostContent postData={postData} />
       </article>
       <SubscribeButton />
-      <Report relatedPosts={postData?.relatedPosts} latestPosts={latestPosts} />
+      <RelatedPosts
+        relatedPosts={postData?.relatedPosts}
+        latestPosts={latestPosts}
+      />
       <FrameCredit className="frame-credit">
         <CreditLists>{frameCreditLists}</CreditLists>
         <div className="publish-time">{date}</div>

--- a/packages/readr/components/post/article-type/news.tsx
+++ b/packages/readr/components/post/article-type/news.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import PostContent from '~/components/post/post-content'
 import PostCredit from '~/components/post/post-credit'
 import PostTitle from '~/components/post/post-title'
-import Report from '~/components/post/report'
+import RelatedPosts from '~/components/post/related-post'
 import SubscribeButton from '~/components/post/subscribe-button'
 import { DEFAULT_POST_IMAGE_PATH } from '~/constants/constant'
 import type { Post } from '~/graphql/fragments/post'
@@ -101,7 +101,10 @@ export default function News({
 
       <SubscribeButton />
 
-      <Report relatedPosts={postData?.relatedPosts} latestPosts={latestPosts} />
+      <RelatedPosts
+        relatedPosts={postData?.relatedPosts}
+        latestPosts={latestPosts}
+      />
       <HiddenAnchor ref={anchorRef} />
     </>
   )

--- a/packages/readr/components/post/article-type/scrollable-video.tsx
+++ b/packages/readr/components/post/article-type/scrollable-video.tsx
@@ -5,7 +5,7 @@ import LeadingEmbeddedCode from '~/components/post/leadingEmbeddedCode'
 import PostContent from '~/components/post/post-content'
 import PostCredit from '~/components/post/post-credit'
 import PostTitle from '~/components/post/post-title'
-import Report from '~/components/post/report'
+import RelatedPosts from '~/components/post/related-post'
 import SubscribeButton from '~/components/post/subscribe-button'
 import { DEFAULT_POST_IMAGE_PATH } from '~/constants/constant'
 import type { Post } from '~/graphql/fragments/post'
@@ -117,7 +117,10 @@ export default function ScrollableVideo({
 
       <SubscribeButton />
 
-      <Report relatedPosts={postData?.relatedPosts} latestPosts={latestPosts} />
+      <RelatedPosts
+        relatedPosts={postData?.relatedPosts}
+        latestPosts={latestPosts}
+      />
       <HiddenAnchor ref={anchorRef} />
     </>
   )

--- a/packages/readr/components/post/related-post.tsx
+++ b/packages/readr/components/post/related-post.tsx
@@ -33,15 +33,15 @@ type RelatedReport = Pick<
   images: ResizedImages | null
 }
 
-interface Props {
+type RelatedPostProps = {
   relatedPosts?: Post[]
   latestPosts?: Post[]
 }
 
-export default function Report({
+export default function RelatedPost({
   relatedPosts,
   latestPosts,
-}: Props): JSX.Element {
+}: RelatedPostProps): JSX.Element {
   function addLinkInPosts(posts: Post[]) {
     const dataWithLink: RelatedReport[] = posts?.map((post: Post) => ({
       ...post,
@@ -53,6 +53,7 @@ export default function Report({
         slug: post.slug,
       }),
     }))
+
     return dataWithLink
   }
 

--- a/packages/readr/graphql/query/post.ts
+++ b/packages/readr/graphql/query/post.ts
@@ -61,7 +61,13 @@ export const postStyles = [...POST_STYLES, ...REPORT_STYLES]
 
 const post = gql`
   query ($id: ID!) {
-    post (where: { id: $id }) {
+    posts ( where: {
+      state: { equals: "published" }
+      id: { equals: $id }  
+      style: {
+        in: [${convertToStringList(postStyles)}]
+      }       
+      })  {
       ...PostFields
       
       state

--- a/packages/readr/utils/post.ts
+++ b/packages/readr/utils/post.ts
@@ -25,9 +25,9 @@ export function getHref({
     case ValidPostStyle.BLANK:
       return `/post/${id}`
     case ValidPostStyle.REPORT:
-      return `${SITE_URL}/project/${slug}`
+      return `https://${SITE_URL}/project/${slug}`
     case ValidPostStyle.PROJECT3:
-      return `${SITE_URL}/project/3/${slug}`
+      return `https://${SITE_URL}/project/3/${slug}`
     default:
       // undefined value can't be serialized, so set default value to '/'
       return '/'


### PR DESCRIPTION
#### 修正
- 文章類型為：Qa、Card、Dummy、Memo、Reviews 時，導向 404。
- 文章類型為：project3、report 時，如透過 url 直接拜訪文章 id，導向 project 頁面。