### PR TITLE
fix(post): scrollable/blank error handle

### DIFF
--- a/packages/readr/components/post/article-type/blank.tsx
+++ b/packages/readr/components/post/article-type/blank.tsx
@@ -1,3 +1,4 @@
+import { Readr } from '@mirrormedia/lilith-draft-renderer'
 import { useState } from 'react'
 import styled from 'styled-components'
 
@@ -37,16 +38,34 @@ export default function Blank({ postData }: BlankProps): JSX.Element {
     gtag.sendEvent('post', 'scroll', 'scroll to end')
   )
 
-  const [isEmbeddedFinish, setIsEmbeddedFinish] = useState<boolean>(false)
+  //if `leadingEmbeddedCode` is null, show embedded-code from `content`
+  const { DraftRenderer } = Readr
+
+  // remove blocks[0] to avoid extra empty blank before embedded-code
+  const contentWithoutEmptyBlank = {
+    blocks: postData?.content.blocks.slice(1),
+    entityMap: postData?.content.entityMap,
+  }
+
+  const shouldShowLeadingEmbedded = Boolean(postData?.leadingEmbeddedCode)
+
+  const [isEmbeddedFinish, setIsEmbeddedFinish] = useState<boolean>(
+    !shouldShowLeadingEmbedded
+  )
 
   return (
     <BlankWrapper>
-      {postData?.leadingEmbeddedCode && (
+      {shouldShowLeadingEmbedded && (
         <LeadingEmbeddedCode
           embeddedCode={postData?.leadingEmbeddedCode}
           setState={setIsEmbeddedFinish}
         />
       )}
+
+      {!shouldShowLeadingEmbedded && (
+        <DraftRenderer rawContentBlock={contentWithoutEmptyBlank} />
+      )}
+
       {isEmbeddedFinish && (
         <>
           <Footer />

--- a/packages/readr/pages/post/[id].tsx
+++ b/packages/readr/pages/post/[id].tsx
@@ -121,6 +121,10 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
         return { notFound: true }
       }
 
+      if (data.posts[0].style === ValidPostStyle.EMBEDDED) {
+        return { notFound: true }
+      }
+
       const postStyle = data.posts[0].style
       const postSlug = data.posts[0].slug
 


### PR DESCRIPTION
- 文章類型 `Embedded` ：目前都先導向 404。
- 文章類型 `scrollable/blank`：如果 `leadingEmbeddedCode` 無資料，改回用 2.0 方式 render。