### PR TITLE
refactor(readr): update dataSets query to prevent duplicated result

### DIFF
--- a/packages/readr/graphql/query/dataset.ts
+++ b/packages/readr/graphql/query/dataset.ts
@@ -26,7 +26,7 @@ export type DataSetWithCount = {
 const dataSets = gql`
   query ($skip: Int, $first: Int = 3, $shouldQueryCount: Boolean! = true) {
     dataSets(
-      orderBy: { publishTime: desc }
+      orderBy: [{ publishTime: desc }, { id: desc }]
       take: $first
       skip: $skip
       where: { state: { equals: "published" } }


### PR DESCRIPTION
## 更新內容
* dataSets query 增加 id order，避免發布日期重複情況下，導致排序結果不穩定的問題。