### PR TITLE
fix(post): customize embedded-code style to remove empty block

### DIFF
--- a/packages/readr/components/post/article-type/frame.tsx
+++ b/packages/readr/components/post/article-type/frame.tsx
@@ -205,7 +205,9 @@ export default function Frame({
               alt={postData?.heroCaption}
               priority={false}
             />
-            <figcaption>{postData?.heroCaption}</figcaption>
+            {postData?.heroCaption && (
+              <figcaption>{postData?.heroCaption}</figcaption>
+            )}
           </HeroImage>
         )}
         <PostContent postData={postData} />

--- a/packages/readr/components/post/post-content.tsx
+++ b/packages/readr/components/post/post-content.tsx
@@ -85,6 +85,16 @@ const Summary = styled.article`
 //內文
 const Content = styled.article`
   margin: 0 0 32px 0;
+
+  //phase 1: resolve empty block before embedded-code
+  .embedded-code-container {
+    z-index: 1000;
+    transform: translateY(-36px);
+  }
+
+  .embedded-code-container-top {
+    margin-top: -105px;
+  }
 `
 
 //延伸議題

--- a/packages/readr/components/post/post-content.tsx
+++ b/packages/readr/components/post/post-content.tsx
@@ -88,7 +88,6 @@ const Content = styled.article`
 
   //phase 1: resolve empty block before embedded-code
   .embedded-code-container {
-    z-index: 1000;
     transform: translateY(-36px);
   }
 
@@ -273,7 +272,7 @@ export default function PostContent({ postData }: PostProps): JSX.Element {
 
   //檢查欄位內是否有資料（因為欄位無資料，依舊會回傳 blocks 和 entityMap）
   const shouldShowDraftBlock = (blocks: RawDraftContentBlock[]) => {
-    if (!blocks) {
+    if (!blocks || !blocks.length) {
       //if draft.blocks is undefined, return false
       return false
     } else if (

--- a/packages/readr/package.json
+++ b/packages/readr/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.3",
-    "@mirrormedia/lilith-draft-renderer": "^1.1.0-alpha.18",
+    "@mirrormedia/lilith-draft-renderer": "^1.1.0-alpha.20",
     "@readr-media/react-component": "^2.1.0",
     "@readr-media/react-image": "^1.5.1",
     "@readr-media/share-button": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2237,10 +2237,10 @@
     npmlog "^6.0.2"
     write-file-atomic "^4.0.1"
 
-"@mirrormedia/lilith-draft-renderer@^1.1.0-alpha.18":
-  version "1.1.0-alpha.18"
-  resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-draft-renderer/-/lilith-draft-renderer-1.1.0-alpha.18.tgz#c3899da9c1b1924d0c762b7c3f75f837a3e18d00"
-  integrity sha512-riizkpgZZAReWCseuVSQXPJ9NwofWMo1kPpAWYupx+Blvxnm2mBSCfDLn+Gwp8P9sVoqNDBiGWUPHSwH1+5KoQ==
+"@mirrormedia/lilith-draft-renderer@^1.1.0-alpha.20":
+  version "1.1.0-alpha.20"
+  resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-draft-renderer/-/lilith-draft-renderer-1.1.0-alpha.20.tgz#dca140a2bb09e1d3b0a3b4e7f285bc3bf4c8f4ba"
+  integrity sha512-4ze4wceqHfemSZxK7Um4jxEikUhpHJ/1Bi0Y8jLq1sT64QT6TXI3l6TD/hbRQV0bQ/Qlgc2j2BRKWn/L12Azkg==
   dependencies:
     "@readr-media/react-image" "^1.5.1"
     draft-js "^0.11.7"


### PR DESCRIPTION
- 問題說明：目前觀察透過 draft-renderer 處理後，`embedded-code` 前都固定會多一個 block 資料，導致畫面上會有一行白色空行（這個空行不會在 CMS 上稿區顯示、但  draft-renderer 回傳的資料會多一個 block）。
- 處理方式：目前是暫時在文章頁面透過調整 style，針對 `embedded-code` 區塊個案式調整 `transform`，以蓋掉 `block` 所造成的白色區塊。
- @mirrormedia/lilith-draft-renderer 套件版本升至 1.1.0-alpha.20