### PR TITLE
refactor(readr): replace some next/link with a tag temperarily

### DIFF
--- a/packages/readr/components/layout/header/categories-and-related-posts.tsx
+++ b/packages/readr/components/layout/header/categories-and-related-posts.tsx
@@ -3,7 +3,6 @@
  *
  */
 
-import NextLink from 'next/link'
 import { useState } from 'react'
 import styled from 'styled-components'
 
@@ -92,20 +91,15 @@ export default function CategoriesAndRelatedPosts({
       onFocus={() => openRelatedList(category.id)}
       onBlur={() => closeRelatedList()}
     >
-      <NextLink
-        href={{
-          pathname: '/category/[slug]',
-          query: {
-            slug: category.slug,
-          },
-        }}
-        shallow={isCategoryPage}
+      {/* TODO: replace with next/link after post with embedded code issues got fixed */}
+      <a
+        href={`/category/${category.slug}`}
         onClick={() =>
           gtag.sendEvent('header', 'click', `menu-${category.title}`)
         }
       >
         <span>{category.title}</span>
-      </NextLink>
+      </a>
       <RelatedListInHeader
         show={activeCatgoryId === category.id}
         relatedList={category.relatedList}

--- a/packages/readr/components/layout/header/hamburger-menu.tsx
+++ b/packages/readr/components/layout/header/hamburger-menu.tsx
@@ -3,7 +3,6 @@
  * 展開顯示畫面與類別清單
  */
 
-import NextLink from 'next/link'
 import { useEffect, useRef } from 'react'
 import styled from 'styled-components'
 
@@ -129,13 +128,13 @@ export default function HamburgerMenu({
 
   const categoryItems = categories.map((category) => (
     <CategoryItem key={category.id}>
-      <NextLink
-        href={{ pathname: '/category/[slug]', query: { slug: category.slug } }}
-        shallow={isCategoryPage}
+      {/* TODO: replace with next/link after post with embedded code issues got fixed */}
+      <a
+        href={`/category/${category.slug}`}
         onClick={() => clickHandle(category)}
       >
         <span>{category.title}</span>
-      </NextLink>
+      </a>
     </CategoryItem>
   ))
 

--- a/packages/readr/components/layout/header/header-logo.tsx
+++ b/packages/readr/components/layout/header/header-logo.tsx
@@ -1,12 +1,12 @@
 // TODO: replace it with share component
 
-import NextLink from 'next/link'
 import styled from 'styled-components'
 
 import ReadrLogo from '~/public/icons/readr-logo.svg'
 import * as gtag from '~/utils/gtag'
 
-const Link = styled(NextLink)`
+// TODO: replace with next/link after post with embedded code issues got fixed
+const Link = styled.a`
   display: block;
 `
 

--- a/packages/readr/components/post/post-title.tsx
+++ b/packages/readr/components/post/post-title.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link'
 import styled from 'styled-components'
 
 import type { PostDetail } from '~/graphql/query/post'
@@ -99,7 +98,8 @@ export default function PostTitle({
         key={item.id}
         onClick={() => gtag.sendEvent('post', 'click', `post-${item.title}`)}
       >
-        <Link href={`/category/${item.slug}`}>{item.title}</Link>
+        {/* TODO: replace with next/link after post with embedded code issues got fixed */}
+        <a href={`/category/${item.slug}`}>{item.title}</a>
       </li>
     )
   })


### PR DESCRIPTION
## 更新內容
* 暫時性將一些 `next/link` 用 `<a />` 取代，規避在含有 embeded code 文章頁面下，點選這些連結進行切換時，會出錯導致出現 500 錯誤的問題。

## 備註
* 待 embeded code 解析相關問題修正後，將此 PR 給 revert