### PR TITLE
feat(post): add `data-full-screen` conditional judgment

### DIFF
--- a/packages/readr/components/post/article-type/blank.tsx
+++ b/packages/readr/components/post/article-type/blank.tsx
@@ -1,5 +1,4 @@
 import { Readr } from '@mirrormedia/lilith-draft-renderer'
-import { useState } from 'react'
 import styled from 'styled-components'
 
 import Footer from '~/components/layout/footer'
@@ -46,20 +45,12 @@ export default function Blank({ postData }: BlankProps): JSX.Element {
   } = Readr
 
   const shouldShowLeadingEmbedded = Boolean(postData?.leadingEmbeddedCode)
-  const shouldShowContentBlock =
-    !shouldShowLeadingEmbedded && hasContentInRawContentBlock(postData?.content)
-
-  const [isEmbeddedFinish, setIsEmbeddedFinish] = useState<boolean>(
-    !shouldShowLeadingEmbedded
-  )
+  const shouldShowContentBlock = hasContentInRawContentBlock(postData?.content)
 
   return (
     <BlankWrapper>
       {shouldShowLeadingEmbedded && (
-        <LeadingEmbeddedCode
-          embeddedCode={postData?.leadingEmbeddedCode}
-          setState={setIsEmbeddedFinish}
-        />
+        <LeadingEmbeddedCode embeddedCode={postData?.leadingEmbeddedCode} />
       )}
 
       {shouldShowContentBlock && (
@@ -68,12 +59,8 @@ export default function Blank({ postData }: BlankProps): JSX.Element {
         />
       )}
 
-      {isEmbeddedFinish && (
-        <>
-          <Footer />
-          <HiddenAnchor ref={anchorRef} />
-        </>
-      )}
+      <Footer />
+      <HiddenAnchor ref={anchorRef} />
     </BlankWrapper>
   )
 }

--- a/packages/readr/components/post/article-type/frame.tsx
+++ b/packages/readr/components/post/article-type/frame.tsx
@@ -1,7 +1,6 @@
 import { Logo } from '@readr-media/react-component'
 import SharedImage from '@readr-media/react-image'
 import { ShareButton } from '@readr-media/share-button'
-import { useState } from 'react'
 import styled from 'styled-components'
 
 import Footer from '~/components/layout/footer'
@@ -97,12 +96,6 @@ const Header = styled.header`
   }
 `
 
-const LeadingBlock = styled.section`
-  position: relative;
-  background-color: #f6f6f5;
-  z-index: ${({ theme }) => theme.zIndex.articleType};
-`
-
 const CreditLists = styled.ul`
   width: 100%;
   max-width: 568px;
@@ -190,10 +183,6 @@ export default function Frame({
   const shouldShowHeroCaption = Boolean(postData?.heroCaption)
   const shouldShowCategory = postData?.categories?.length > 0
 
-  const [isEmbeddedFinish, setIsEmbeddedFinish] = useState<boolean>(
-    !shouldShowLeadingEmbedded
-  )
-
   //workaround: 特殊頁面需要客製化 credit 清單，在 cms Post 作者（其他）欄位中以星號開頭來啟用，以全形的'／'來產生換行效果
   //ref: https://github.com/readr-media/readr-nuxt/commit/98c4016587ebd4dddb5e92e74c1af24c477d32f7
   //change string to [ {title:..., name:...}, {title:..., name:...} ...]
@@ -216,16 +205,6 @@ export default function Frame({
     )
   })
 
-  let PostCategoryJsx = null
-
-  if (shouldShowCategory) {
-    PostCategoryJsx = (
-      <PostHeading>
-        <PostCategory category={postData?.categories} />
-      </PostHeading>
-    )
-  }
-
   return (
     <FrameWrapper>
       <Header>
@@ -247,35 +226,31 @@ export default function Frame({
           </HeroImage>
         )}
         {shouldShowLeadingEmbedded && (
-          <LeadingBlock>
-            <LeadingEmbeddedCode
-              embeddedCode={postData?.leadingEmbeddedCode}
-              setState={setIsEmbeddedFinish}
-            />
-          </LeadingBlock>
-        )}
-        {isEmbeddedFinish && (
-          <>
-            {PostCategoryJsx}
-            <PostContent postData={postData} />
-          </>
-        )}
-      </Article>
-      {isEmbeddedFinish && (
-        <>
-          <SubscribeButton />
-          <RelatedPosts
-            relatedPosts={postData?.relatedPosts}
-            latestPosts={latestPosts}
+          <LeadingEmbeddedCode
+            embeddedCode={postData?.leadingEmbeddedCode}
+            backgroundColor="#f6f6f5"
           />
-          <FrameCredit className="frame-credit">
-            <CreditLists>{frameCreditLists}</CreditLists>
-            <div className="publish-time">{date}</div>
-          </FrameCredit>
-          <HiddenAnchor ref={anchorRef} />
-          <Footer />
-        </>
-      )}
+        )}
+
+        {shouldShowCategory && (
+          <PostHeading>
+            <PostCategory category={postData?.categories} />
+          </PostHeading>
+        )}
+        <PostContent postData={postData} />
+      </Article>
+
+      <SubscribeButton />
+      <RelatedPosts
+        relatedPosts={postData?.relatedPosts}
+        latestPosts={latestPosts}
+      />
+      <FrameCredit className="frame-credit">
+        <CreditLists>{frameCreditLists}</CreditLists>
+        <div className="publish-time">{date}</div>
+      </FrameCredit>
+      <HiddenAnchor ref={anchorRef} />
+      <Footer />
     </FrameWrapper>
   )
 }

--- a/packages/readr/components/post/article-type/scrollable-video.tsx
+++ b/packages/readr/components/post/article-type/scrollable-video.tsx
@@ -1,6 +1,5 @@
 import { Readr } from '@mirrormedia/lilith-draft-renderer'
 import SharedImage from '@readr-media/react-image'
-import { useState } from 'react'
 import styled from 'styled-components'
 
 import HeaderGeneral from '~/components/layout/header/header-general'
@@ -30,12 +29,6 @@ const HeroImage = styled.picture`
   z-index: ${({ theme }) => theme.zIndex.articleType};
   margin-top: 0;
 `
-
-const ScrollVideo = styled.section`
-  margin-bottom: 20px;
-  position: relative;
-  z-index: ${({ theme }) => theme.zIndex.articleType};
-`
 const ScrollTitle = styled.h1`
   position: absolute;
   top: 50%;
@@ -59,12 +52,12 @@ const ScrollTitle = styled.h1`
 const PostHeading = styled.section`
   width: 100%;
   max-width: 568px;
-  margin: 0 auto 24px auto;
+  margin: 20px auto 24px;
 
   ${({ theme }) => theme.breakpoint.xl} {
     padding: 0;
     max-width: 600px;
-    margin: 0 auto 48px;
+    margin: 20px auto 48px;
   }
 `
 
@@ -76,7 +69,7 @@ const HiddenAnchor = styled.div`
   margin: 0;
 `
 
-interface PostProps {
+type PostProps = {
   postData: PostDetail
   latestPosts: Post[]
 }
@@ -90,10 +83,6 @@ export default function ScrollableVideo({
   )
 
   const shouldShowLeadingEmbedded = Boolean(postData?.leadingEmbeddedCode)
-
-  const [isEmbeddedFinish, setIsEmbeddedFinish] = useState<boolean>(
-    !shouldShowLeadingEmbedded
-  )
 
   const { DraftRenderer } = Readr
 
@@ -152,46 +141,33 @@ export default function ScrollableVideo({
           <ScrollTitle>{postData?.title}</ScrollTitle>
         </HeroImage>
 
-        <ScrollVideo>
-          {shouldShowLeadingEmbedded ? (
-            <LeadingEmbeddedCode
-              embeddedCode={postData?.leadingEmbeddedCode}
-              setState={setIsEmbeddedFinish}
-            />
-          ) : (
-            <DraftRenderer rawContentBlock={embeddedContentState} />
-          )}
-        </ScrollVideo>
-
-        {isEmbeddedFinish && (
-          <>
-            <PostHeading>
-              <PostTitle postData={postData} showTitle={false} />
-              <PostCredit postData={postData} />
-            </PostHeading>
-
-            <PostContent
-              postData={
-                shouldShowLeadingEmbedded
-                  ? postData
-                  : postDataWithoutFirstScrollVideo
-              }
-            />
-          </>
+        {shouldShowLeadingEmbedded ? (
+          <LeadingEmbeddedCode embeddedCode={postData?.leadingEmbeddedCode} />
+        ) : (
+          <DraftRenderer rawContentBlock={embeddedContentState} />
         )}
+
+        <PostHeading>
+          <PostTitle postData={postData} showTitle={false} />
+          <PostCredit postData={postData} />
+        </PostHeading>
+
+        <PostContent
+          postData={
+            shouldShowLeadingEmbedded
+              ? postData
+              : postDataWithoutFirstScrollVideo
+          }
+        />
       </Article>
 
-      {isEmbeddedFinish && (
-        <>
-          <SubscribeButton />
+      <SubscribeButton />
 
-          <RelatedPosts
-            relatedPosts={postData?.relatedPosts}
-            latestPosts={latestPosts}
-          />
-          <HiddenAnchor ref={anchorRef} />
-        </>
-      )}
+      <RelatedPosts
+        relatedPosts={postData?.relatedPosts}
+        latestPosts={latestPosts}
+      />
+      <HiddenAnchor ref={anchorRef} />
     </>
   )
 }


### PR DESCRIPTION
### 描述
- `leadingEmbeddedCode` 元件是否蓋過 Header，改為統一由 embeddedCode string 中 `data-full-screen` 參數值決定

   - 如為 `"true"`，則會蓋過 Header。（ z-index 為 `theme.zIndex.articleType` ）
   - 如為 `"false"`，則不會蓋過 Header。（ z-index 為 `auto` ）
   - 預設值：不蓋過 Header。

### 調整 - `leadingEmbeddedCode` 元件
- 重構元件架構，改為與 `lilith-draft-renderer` 同步，用 `node-html-parser` 處理 embeddedCode 內容。
- 延續上方調整，同步移除 `100vh` 設定 與 `isEmbeddedFinish` 判斷。
- 元件可傳入`backgroundColor` 參數，設定 `leadingEmbeddedCode` 底色。
   - 目前 `frame` type 設定傳入底色為 `#f6f6f5`，防止當 embeddedCode 底色為透明時，Header會露出的狀況。