### PR TITLE
refactor(post): parse `leadingEmbeddedCode` by `node-html-parser`

### DIFF
--- a/packages/readr/components/post/article-type/blank.tsx
+++ b/packages/readr/components/post/article-type/blank.tsx
@@ -1,5 +1,4 @@
 import { Readr } from '@mirrormedia/lilith-draft-renderer'
-import { useState } from 'react'
 import styled from 'styled-components'
 
 import Footer from '~/components/layout/footer'
@@ -15,7 +14,6 @@ const BlankWrapper = styled.article`
   left: 0;
   right: 0;
   z-index: ${({ theme }) => theme.zIndex.articleType};
-
   //modify the style of <Footer />.
   .layout-footer {
     background: #ffffff;
@@ -46,20 +44,12 @@ export default function Blank({ postData }: BlankProps): JSX.Element {
   } = Readr
 
   const shouldShowLeadingEmbedded = Boolean(postData?.leadingEmbeddedCode)
-  const shouldShowContentBlock =
-    !shouldShowLeadingEmbedded && hasContentInRawContentBlock(postData?.content)
-
-  const [isEmbeddedFinish, setIsEmbeddedFinish] = useState<boolean>(
-    !shouldShowLeadingEmbedded
-  )
+  const shouldShowContentBlock = hasContentInRawContentBlock(postData?.content)
 
   return (
     <BlankWrapper>
       {shouldShowLeadingEmbedded && (
-        <LeadingEmbeddedCode
-          embeddedCode={postData?.leadingEmbeddedCode}
-          setState={setIsEmbeddedFinish}
-        />
+        <LeadingEmbeddedCode embeddedCode={postData?.leadingEmbeddedCode} />
       )}
 
       {shouldShowContentBlock && (
@@ -68,12 +58,8 @@ export default function Blank({ postData }: BlankProps): JSX.Element {
         />
       )}
 
-      {isEmbeddedFinish && (
-        <>
-          <Footer />
-          <HiddenAnchor ref={anchorRef} />
-        </>
-      )}
+      <Footer />
+      <HiddenAnchor ref={anchorRef} />
     </BlankWrapper>
   )
 }

--- a/packages/readr/components/post/article-type/frame.tsx
+++ b/packages/readr/components/post/article-type/frame.tsx
@@ -1,7 +1,6 @@
 import { Logo } from '@readr-media/react-component'
 import SharedImage from '@readr-media/react-image'
 import { ShareButton } from '@readr-media/share-button'
-import { useState } from 'react'
 import styled from 'styled-components'
 
 import Footer from '~/components/layout/footer'
@@ -30,24 +29,20 @@ const HeroImage = styled.figure`
   width: 100%;
   margin: auto;
   height: calc(100vh - 72px);
-
   ${({ theme }) => theme.breakpoint.md} {
     height: calc(100vh - 88px);
   }
-
   figcaption {
     font-size: 14px;
     line-height: 21px;
     color: rgba(0, 9, 40, 0.5);
     padding: 0 20px;
     margin: 8px 0 0;
-
     ${({ theme }) => theme.breakpoint.md} {
       width: 568px;
       padding: 0;
       margin: 12px auto 0;
     }
-
     ${({ theme }) => theme.breakpoint.xl} {
       width: 960px;
     }
@@ -60,7 +55,6 @@ type ArticleProps = {
 const Article = styled.article<ArticleProps>`
   position: relative;
   padding-top: ${(props) => (props.shouldShowHeroImage ? '72px' : '0px')};
-
   ${({ theme }) => theme.breakpoint.md} {
     padding-top: ${(props) => (props.shouldShowHeroImage ? '88px' : '0px')};
   }
@@ -77,30 +71,20 @@ const Header = styled.header`
   justify-content: space-between;
   align-items: center;
   background-color: #f6f6f5;
-
   //shared-component of @readr-media/react-component
   .readr-logo {
     margin: 0;
   }
-
   //shared-component of @readr-media/share-button
   .share-button {
     width: 42px;
   }
-
   ${({ theme }) => theme.breakpoint.md} {
     padding: 20px 24px;
   }
-
   ${({ theme }) => theme.breakpoint.xl} {
     padding: 20px 32px;
   }
-`
-
-const LeadingBlock = styled.section`
-  position: relative;
-  background-color: #f6f6f5;
-  z-index: ${({ theme }) => theme.zIndex.articleType};
 `
 
 const CreditLists = styled.ul`
@@ -110,22 +94,18 @@ const CreditLists = styled.ul`
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
-
   > li {
     width: fit-content;
     font-size: 14px;
     line-height: 1.5;
     margin: 0 10px;
-
     ${({ theme }) => theme.breakpoint.md} {
       font-size: 16px;
     }
   }
-
   .credit-title {
     color: rgba(0, 9, 40, 0.66);
   }
-
   ${({ theme }) => theme.breakpoint.xl} {
     width: 600px;
     max-width: 600px;
@@ -149,11 +129,9 @@ const FrameCredit = styled.div`
   letter-spacing: 0.2px;
   color: #2b2b2b;
   text-align: center;
-
   .publish-time {
     margin-top: 16px;
   }
-
   ${({ theme }) => theme.breakpoint.md} {
     padding: 48px 32px;
   }
@@ -164,7 +142,6 @@ const PostHeading = styled.section`
   max-width: 568px;
   padding-top: 16px;
   margin: auto;
-
   ${({ theme }) => theme.breakpoint.xl} {
     max-width: 600px;
   }
@@ -190,10 +167,6 @@ export default function Frame({
   const shouldShowHeroCaption = Boolean(postData?.heroCaption)
   const shouldShowCategory = postData?.categories?.length > 0
 
-  const [isEmbeddedFinish, setIsEmbeddedFinish] = useState<boolean>(
-    !shouldShowLeadingEmbedded
-  )
-
   //workaround: 特殊頁面需要客製化 credit 清單，在 cms Post 作者（其他）欄位中以星號開頭來啟用，以全形的'／'來產生換行效果
   //ref: https://github.com/readr-media/readr-nuxt/commit/98c4016587ebd4dddb5e92e74c1af24c477d32f7
   //change string to [ {title:..., name:...}, {title:..., name:...} ...]
@@ -216,16 +189,6 @@ export default function Frame({
     )
   })
 
-  let PostCategoryJsx = null
-
-  if (shouldShowCategory) {
-    PostCategoryJsx = (
-      <PostHeading>
-        <PostCategory category={postData?.categories} />
-      </PostHeading>
-    )
-  }
-
   return (
     <FrameWrapper>
       <Header>
@@ -247,35 +210,31 @@ export default function Frame({
           </HeroImage>
         )}
         {shouldShowLeadingEmbedded && (
-          <LeadingBlock>
-            <LeadingEmbeddedCode
-              embeddedCode={postData?.leadingEmbeddedCode}
-              setState={setIsEmbeddedFinish}
-            />
-          </LeadingBlock>
-        )}
-        {isEmbeddedFinish && (
-          <>
-            {PostCategoryJsx}
-            <PostContent postData={postData} />
-          </>
-        )}
-      </Article>
-      {isEmbeddedFinish && (
-        <>
-          <SubscribeButton />
-          <RelatedPosts
-            relatedPosts={postData?.relatedPosts}
-            latestPosts={latestPosts}
+          <LeadingEmbeddedCode
+            embeddedCode={postData?.leadingEmbeddedCode}
+            backgroundColor="#f6f6f5"
           />
-          <FrameCredit className="frame-credit">
-            <CreditLists>{frameCreditLists}</CreditLists>
-            <div className="publish-time">{date}</div>
-          </FrameCredit>
-          <HiddenAnchor ref={anchorRef} />
-          <Footer />
-        </>
-      )}
+        )}
+
+        {shouldShowCategory && (
+          <PostHeading>
+            <PostCategory category={postData?.categories} />
+          </PostHeading>
+        )}
+        <PostContent postData={postData} />
+      </Article>
+
+      <SubscribeButton />
+      <RelatedPosts
+        relatedPosts={postData?.relatedPosts}
+        latestPosts={latestPosts}
+      />
+      <FrameCredit className="frame-credit">
+        <CreditLists>{frameCreditLists}</CreditLists>
+        <div className="publish-time">{date}</div>
+      </FrameCredit>
+      <HiddenAnchor ref={anchorRef} />
+      <Footer />
     </FrameWrapper>
   )
 }

--- a/packages/readr/components/post/article-type/scrollable-video.tsx
+++ b/packages/readr/components/post/article-type/scrollable-video.tsx
@@ -1,6 +1,5 @@
 import { Readr } from '@mirrormedia/lilith-draft-renderer'
 import SharedImage from '@readr-media/react-image'
-import { useState } from 'react'
 import styled from 'styled-components'
 
 import HeaderGeneral from '~/components/layout/header/header-general'
@@ -30,12 +29,6 @@ const HeroImage = styled.picture`
   z-index: ${({ theme }) => theme.zIndex.articleType};
   margin-top: 0;
 `
-
-const ScrollVideo = styled.section`
-  margin-bottom: 20px;
-  position: relative;
-  z-index: ${({ theme }) => theme.zIndex.articleType};
-`
 const ScrollTitle = styled.h1`
   position: absolute;
   top: 50%;
@@ -48,7 +41,6 @@ const ScrollTitle = styled.h1`
   letter-spacing: 0.04em;
   color: #fff;
   filter: drop-shadow(0 2px 2px rgba(0, 0, 0, 0.5));
-
   ${({ theme }) => theme.breakpoint.md} {
     font-size: 36px;
     line-height: 1.5;
@@ -59,12 +51,11 @@ const ScrollTitle = styled.h1`
 const PostHeading = styled.section`
   width: 100%;
   max-width: 568px;
-  margin: 0 auto 24px auto;
-
+  margin: 20px auto 24px;
   ${({ theme }) => theme.breakpoint.xl} {
     padding: 0;
     max-width: 600px;
-    margin: 0 auto 48px;
+    margin: 20px auto 48px;
   }
 `
 
@@ -76,7 +67,7 @@ const HiddenAnchor = styled.div`
   margin: 0;
 `
 
-interface PostProps {
+type PostProps = {
   postData: PostDetail
   latestPosts: Post[]
 }
@@ -90,10 +81,6 @@ export default function ScrollableVideo({
   )
 
   const shouldShowLeadingEmbedded = Boolean(postData?.leadingEmbeddedCode)
-
-  const [isEmbeddedFinish, setIsEmbeddedFinish] = useState<boolean>(
-    !shouldShowLeadingEmbedded
-  )
 
   const { DraftRenderer } = Readr
 
@@ -152,46 +139,33 @@ export default function ScrollableVideo({
           <ScrollTitle>{postData?.title}</ScrollTitle>
         </HeroImage>
 
-        <ScrollVideo>
-          {shouldShowLeadingEmbedded ? (
-            <LeadingEmbeddedCode
-              embeddedCode={postData?.leadingEmbeddedCode}
-              setState={setIsEmbeddedFinish}
-            />
-          ) : (
-            <DraftRenderer rawContentBlock={embeddedContentState} />
-          )}
-        </ScrollVideo>
-
-        {isEmbeddedFinish && (
-          <>
-            <PostHeading>
-              <PostTitle postData={postData} showTitle={false} />
-              <PostCredit postData={postData} />
-            </PostHeading>
-
-            <PostContent
-              postData={
-                shouldShowLeadingEmbedded
-                  ? postData
-                  : postDataWithoutFirstScrollVideo
-              }
-            />
-          </>
+        {shouldShowLeadingEmbedded ? (
+          <LeadingEmbeddedCode embeddedCode={postData?.leadingEmbeddedCode} />
+        ) : (
+          <DraftRenderer rawContentBlock={embeddedContentState} />
         )}
+
+        <PostHeading>
+          <PostTitle postData={postData} showTitle={false} />
+          <PostCredit postData={postData} />
+        </PostHeading>
+
+        <PostContent
+          postData={
+            shouldShowLeadingEmbedded
+              ? postData
+              : postDataWithoutFirstScrollVideo
+          }
+        />
       </Article>
 
-      {isEmbeddedFinish && (
-        <>
-          <SubscribeButton />
+      <SubscribeButton />
 
-          <RelatedPosts
-            relatedPosts={postData?.relatedPosts}
-            latestPosts={latestPosts}
-          />
-          <HiddenAnchor ref={anchorRef} />
-        </>
-      )}
+      <RelatedPosts
+        relatedPosts={postData?.relatedPosts}
+        latestPosts={latestPosts}
+      />
+      <HiddenAnchor ref={anchorRef} />
     </>
   )
 }

--- a/packages/readr/components/post/leadingEmbeddedCode.tsx
+++ b/packages/readr/components/post/leadingEmbeddedCode.tsx
@@ -1,10 +1,18 @@
-import { useEffect, useRef } from 'react'
+import { parse } from 'node-html-parser'
+import React, { useEffect, useMemo, useRef } from 'react'
 import styled from 'styled-components'
 
-export const Block = styled.div`
+type LeadingBlockProps = {
+  backgroundColor: string
+}
+const LeadingBlock = styled.section<LeadingBlockProps>`
   position: relative;
-  min-height: 100vh;
+  background-color: ${(props) => props.backgroundColor};
+  z-index: ${({ theme }) => theme.zIndex.articleType};
+`
 
+const Block = styled.div`
+  position: relative;
   img.img-responsive {
     margin: 0 auto;
     max-width: 100%;
@@ -13,88 +21,71 @@ export const Block = styled.div`
   }
 `
 
-export const Caption = styled.div`
-  line-height: 1.43;
-  letter-spacing: 0.4px;
-  font-size: 14px;
-  color: #808080;
-  padding: 15px 15px 0 15px;
-`
-
-type FirstEmbeddedCodeProps = {
+type LeadingEmbeddedCodeProps = {
   embeddedCode: string
-  setState?: (value: boolean) => void
+  backgroundColor?: string
 }
-
 export default function LeadingEmbeddedCode({
   embeddedCode,
-  setState,
-}: FirstEmbeddedCodeProps): JSX.Element {
-  const onEmbeddedFinish = () => {
-    setState && setState(true)
-  }
-
+  backgroundColor = 'transparent',
+}: LeadingEmbeddedCodeProps): JSX.Element {
   const embedded = useRef(null)
 
-  useEffect(() => {
-    if (!embedded.current) return
-    const node: HTMLElement = embedded.current
+  // `embeddedCode` is a string, which may includes
+  // multiple script tags and other html tags.
+  // Here we separate script tags and other html tags
+  // by using the isomorphic html parser 'node-html-parser'
+  // into scripts nodes and non-script nodes.
+  //
+  // For non-script nodes we simply put them into dangerouslySetInnerHtml.
+  //
+  // For scripts nodes we only append them on the client side. So we handle scripts
+  // nodes when useEffect is called.
+  // The reasons we don't insert script tags through dangerouslySetInnerHtml:
+  // 1. Since react use setInnerHtml to append the htmlStirng received from
+  //    dangerouslySetInnerHtml, scripts won't be triggered.
+  // 2. Although the setInnerhtml way won't trigger script tags, those script tags
+  //    will still show on the HTML provided from SSR. When the browser parse the
+  //    html it will run those script and produce unexpected behavior.
+  const nodes = useMemo(() => {
+    const ele = parse(`<div id="draft-embed">${embeddedCode}</div>`)
 
-    const fragment = document.createDocumentFragment()
-
-    // `embeddedCode` is a string, which may includes
-    // multiple '<script>' tags and other html tags.
-    // For executing '<script>' tags on the browser,
-    // we need to extract '<script>' tags from `embeddedCode` string first.
-    //
-    // The approach we have here is to parse html string into elements,
-    // and we could use DOM element built-in functions,
-    // such as `querySelectorAll` method, to query '<script>' elements,
-    // and other non '<script>' elements.
-    const parser = new DOMParser()
-    const ele = parser.parseFromString(
-      `<div id="draft-embed">${embeddedCode}</div>`,
-      'text/html'
-    )
     const scripts = ele.querySelectorAll('script')
-    const nonScripts = ele.querySelectorAll('div#draft-embed > :not(script)')
-
-    nonScripts.forEach((ele) => {
-      fragment.appendChild(ele)
-    })
-
     scripts.forEach((s) => {
-      //preload
-      const scriptHref = s.getAttribute('src')
-      const existingLink = document.querySelector(
-        `link[href="${scriptHref}"][rel="preload"]`
-      )
-      if (existingLink) {
-        return
-      } else {
-        const preloadLink = document.createElement('link')
-        preloadLink.href = scriptHref || ''
-        preloadLink.rel = 'preload'
-        preloadLink.as = 'script'
-        document.head.appendChild(preloadLink)
-      }
-
-      const scriptEle = document.createElement('script')
-
-      const attrs = s.attributes
-      for (let i = 0; i < attrs.length; i++) {
-        scriptEle.setAttribute(attrs[i].name, attrs[i].value)
-      }
-      scriptEle.text = s.text || ''
-      fragment.appendChild(scriptEle)
+      s.remove()
     })
+    const nonScripts = ele.querySelectorAll('div#draft-embed > :not(script)')
+    const nonScriptsHtml = nonScripts.reduce(
+      (prev, next) => prev + next.toString(),
+      ''
+    )
 
-    node.appendChild(fragment)
-    onEmbeddedFinish()
+    return { scripts, nonScripts, nonScriptsHtml }
   }, [embeddedCode])
+  const { scripts, nonScriptsHtml } = nodes
+
+  useEffect(() => {
+    if (embedded.current) {
+      const node: HTMLElement = embedded.current
+
+      const fragment = document.createDocumentFragment()
+
+      scripts.forEach((s) => {
+        const scriptEle = document.createElement('script')
+        const attrs = s.attributes
+        for (const key in attrs) {
+          scriptEle.setAttribute(key, attrs[key])
+        }
+        scriptEle.text = s.text || ''
+        fragment.appendChild(scriptEle)
+      })
+
+      node.appendChild(fragment)
+    }
+  }, [scripts])
 
   return (
-    <>
+    <LeadingBlock backgroundColor={backgroundColor}>
       {
         // WORKAROUND:
         // The following `<input>` is to solve [issue 153](https://github.com/mirror-media/openwarehouse-k6/issues/153).
@@ -105,7 +96,12 @@ export default function LeadingEmbeddedCode({
         // hijacking the users' cursors.
       }
       <input hidden disabled />
-      <Block ref={embedded} />
-    </>
+      <Block
+        ref={embedded}
+        dangerouslySetInnerHTML={{
+          __html: nonScriptsHtml,
+        }}
+      />
+    </LeadingBlock>
   )
 }


### PR DESCRIPTION
### 調整 
-  `leadingEmbeddedCode` 元件改為與 `lilith-draft-renderer` 同步，用 `node-html-parser` 處理 embeddedCode 內容。
- 延續上方調整，同步移除 `100vh` 設定 與 `isEmbeddedFinish` 判斷。
- 元件可傳入 `backgroundColor` 參數，設定 leadingEmbeddedCode 底色。
- 目前 `frame` type 設定傳入底色為 `#f6f6f5`，防止當 embeddedCode 底色為透明時，Header 會露出的狀況。
- 注意：目前 `leadingEmbeddedCode` 仍預設一定會蓋過 Header。