### PR TITLE
feat(readr/member): show related works if author has posts

### DIFF
--- a/packages/readr/components/about/members.tsx
+++ b/packages/readr/components/about/members.tsx
@@ -552,7 +552,7 @@ export default function Members({
                   })}
                 </Number>
               </InfoWrapper>
-              {/* {member.projects?.length === 0 ? (
+              {member.posts?.length === 0 ? (
                 <Work
                   style={{
                     backgroundColor: '#E5E5E5',
@@ -566,7 +566,7 @@ export default function Members({
                 <Work onClick={(e) => e.stopPropagation()}>
                   <Link href={`/author/${member.id}`}>相關作品</Link>
                 </Work>
-              )} */}
+              )}
             </CardFront>
             <CardBack className="card-back">
               <ArrowLeft className="arr-left" />

--- a/packages/readr/graphql/query/member.ts
+++ b/packages/readr/graphql/query/member.ts
@@ -13,7 +13,7 @@ export type Member = Override<
     | 'special_number'
     | 'number_desc'
     | 'number_desc_en'
-    | 'projects'
+    | 'posts'
   >,
   {
     id: string
@@ -31,7 +31,7 @@ const members = gql`
       special_number
       number_desc
       number_desc_en
-      projects {
+      posts {
         id
         name
       }

--- a/packages/readr/pages/_error.tsx
+++ b/packages/readr/pages/_error.tsx
@@ -154,11 +154,10 @@ const PostsContainer = styled.div`
   max-width: 320px;
 
   ${({ theme }) => theme.breakpoint.sm} {
-    height: 320px;
+    height: 300px;
     max-width: 522px;
   }
   ${({ theme }) => theme.breakpoint.md} {
-    height: 350px;
     max-width: 672px;
   }
 
@@ -168,7 +167,6 @@ const PostsContainer = styled.div`
 
   ${({ theme }) => theme.breakpoint.xl} {
     max-width: 1096px;
-    height: 300px;
   }
 `
 

--- a/packages/readr/types/common.ts
+++ b/packages/readr/types/common.ts
@@ -66,7 +66,7 @@ export type GenericAuthor = {
   special_number: string
   number_desc: string
   number_desc_en: string
-  projects: GenericProject[]
+  posts: GenericPost[]
 }
 
 export type GenericProject = {


### PR DESCRIPTION
原本是用 `projects` 欄位判斷是否顯示團隊成員相關作品，現在改為 `posts`。
用 posts 判斷的話，記者都會自動帶入相關 posts，但工程師、PM、設計都不會有，如果手動從 CMS 為工程師建立 posts 連結，但該篇文章作者又會出現該工程師
<img width="754" alt="Screen Shot 2023-05-04 at 12 56 19 PM" src="https://user-images.githubusercontent.com/66411169/236116008-911378da-d5ae-4144-9355-f5baf5ef579d.png">

<img width="391" alt="Screen Shot 2023-05-04 at 12 56 29 PM" src="https://user-images.githubusercontent.com/66411169/236116159-b5fa51fe-d3b3-4c0d-aa15-5b8bc5bee55d.png">


<img width="383" alt="Screen Shot 2023-05-04 at 12 56 36 PM" src="https://user-images.githubusercontent.com/66411169/236116177-d0030b1a-59ca-4321-b03f-bff0a6b04a45.png">
<img width="862" alt="Screen Shot 2023-05-04 at 12 56 50 PM" src="https://user-images.githubusercontent.com/66411169/236116187-023e3260-e52b-44c5-a3f3-6c27637b2b71.png">
