### PR TITLE
chore(readr): bump version of `@mirrormedia/lilith-draft-renderer`

### DIFF
--- a/packages/readr/components/post/article-type/frame.tsx
+++ b/packages/readr/components/post/article-type/frame.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components'
 
 import Footer from '~/components/layout/footer'
 import LeadingEmbeddedCode from '~/components/post/leadingEmbeddedCode'
-import PostCategory from '~/components/post/post-category'
 import PostContent from '~/components/post/post-content'
 import RelatedPosts from '~/components/post/related-post'
 import SubscribeButton from '~/components/post/subscribe-button'
@@ -137,15 +136,6 @@ const FrameCredit = styled.div`
   }
 `
 
-const PostHeading = styled.section`
-  width: 100%;
-  max-width: 568px;
-  padding-top: 16px;
-  margin: auto;
-  ${({ theme }) => theme.breakpoint.xl} {
-    max-width: 600px;
-  }
-`
 
 type PostProps = {
   postData: PostDetail
@@ -165,7 +155,6 @@ export default function Frame({
   const shouldShowLeadingEmbedded = Boolean(postData?.leadingEmbeddedCode)
   const shouldShowHeroImage = Boolean(postData?.heroImage)
   const shouldShowHeroCaption = Boolean(postData?.heroCaption)
-  const shouldShowCategory = postData?.categories?.length > 0
 
   //workaround: 特殊頁面需要客製化 credit 清單，在 cms Post 作者（其他）欄位中以星號開頭來啟用，以全形的'／'來產生換行效果
   //ref: https://github.com/readr-media/readr-nuxt/commit/98c4016587ebd4dddb5e92e74c1af24c477d32f7
@@ -216,11 +205,6 @@ export default function Frame({
           />
         )}
 
-        {shouldShowCategory && (
-          <PostHeading>
-            <PostCategory category={postData?.categories} />
-          </PostHeading>
-        )}
         <PostContent postData={postData} />
       </Article>
 

--- a/packages/readr/package.json
+++ b/packages/readr/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.3",
-    "@mirrormedia/lilith-draft-renderer": "^1.2.0-alpha.13",
+    "@mirrormedia/lilith-draft-renderer": "^1.2.0-alpha.15",
     "@readr-media/react-component": "^2.1.2",
     "@readr-media/react-image": "^1.5.1",
     "@readr-media/share-button": "^1.0.3",

--- a/packages/readr/pages/post/[id].tsx
+++ b/packages/readr/pages/post/[id].tsx
@@ -94,7 +94,7 @@ const Post: NextPageWithLayout<PageProps> = ({ postData, latestPosts }) => {
         title={ogTitle}
         description={ogDescription}
         imageUrl={ogImageUrl}
-      ></CustomHead>
+      />
       {articleType}
     </>
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -2237,10 +2237,10 @@
     npmlog "^6.0.2"
     write-file-atomic "^4.0.1"
 
-"@mirrormedia/lilith-draft-renderer@^1.2.0-alpha.13":
-  version "1.2.0-alpha.13"
-  resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-draft-renderer/-/lilith-draft-renderer-1.2.0-alpha.13.tgz#8f20c0facbd9ed1744d19f56b7282108b4958b9f"
-  integrity sha512-24fHiSuC6OkeBhaMtCvGSVhbVaSPhwaeByEWHXntF2PY35onTbp/91nFna/IU4AAoJvWeoL47z6MW92nH8Tluw==
+"@mirrormedia/lilith-draft-renderer@^1.2.0-alpha.15":
+  version "1.2.0-alpha.15"
+  resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-draft-renderer/-/lilith-draft-renderer-1.2.0-alpha.15.tgz#14d3a45be1d85c305851d7b015f5ebdcb41faf03"
+  integrity sha512-c1lvtgrgBsdwLouahMu9Ap8v7zZkSYSiwqxqJ1+m1nACmGSLQfsFY85PRo+dsm13874M1NpnIdOGMKoU+kg8mA==
   dependencies:
     "@readr-media/react-image" "^1.5.1"
     body-scroll-lock "3.1.5"


### PR DESCRIPTION
- `@mirrormedia/lilith-draft-renderer` 使用版本升至 `1.2.0-alpha.15`。
- 文章類型 `frame` 移除 `categories` UI。