### PR TITLE
fix(post): `og-title`、`og-desc` error handle & modify `frame` type content padding

### DIFF
--- a/packages/readr/components/post/article-type/frame.tsx
+++ b/packages/readr/components/post/article-type/frame.tsx
@@ -205,7 +205,7 @@ export default function Frame({
           />
         )}
 
-        <PostContent postData={postData} articleAType={ValidPostStyle.FRAME} />
+        <PostContent postData={postData} articleType={ValidPostStyle.FRAME} />
       </Article>
 
       <SubscribeButton />

--- a/packages/readr/components/post/article-type/frame.tsx
+++ b/packages/readr/components/post/article-type/frame.tsx
@@ -12,6 +12,7 @@ import { DEFAULT_POST_IMAGE_PATH } from '~/constants/constant'
 import type { Post } from '~/graphql/fragments/post'
 import type { PostDetail } from '~/graphql/query/post'
 import useScrollToEnd from '~/hooks/useScrollToEnd'
+import { ValidPostStyle } from '~/types/common'
 import * as gtag from '~/utils/gtag'
 import { formatPostDate } from '~/utils/post'
 
@@ -136,7 +137,6 @@ const FrameCredit = styled.div`
   }
 `
 
-
 type PostProps = {
   postData: PostDetail
   latestPosts: Post[]
@@ -205,7 +205,7 @@ export default function Frame({
           />
         )}
 
-        <PostContent postData={postData} />
+        <PostContent postData={postData} articleAType={ValidPostStyle.FRAME} />
       </Article>
 
       <SubscribeButton />

--- a/packages/readr/components/post/article-type/news.tsx
+++ b/packages/readr/components/post/article-type/news.tsx
@@ -114,7 +114,7 @@ export default function News({
             <PostCredit postData={postData} />
           </PostHeading>
 
-          <PostContent postData={postData} articleAType={ValidPostStyle.NEWS} />
+          <PostContent postData={postData} articleType={ValidPostStyle.NEWS} />
         </article>
 
         <SubscribeButton />

--- a/packages/readr/components/post/article-type/news.tsx
+++ b/packages/readr/components/post/article-type/news.tsx
@@ -11,6 +11,7 @@ import { DEFAULT_POST_IMAGE_PATH } from '~/constants/constant'
 import type { Post } from '~/graphql/fragments/post'
 import type { PostDetail } from '~/graphql/query/post'
 import useScrollToEnd from '~/hooks/useScrollToEnd'
+import { ValidPostStyle } from '~/types/common'
 import * as gtag from '~/utils/gtag'
 
 const NewsContainer = styled.div`
@@ -113,7 +114,7 @@ export default function News({
             <PostCredit postData={postData} />
           </PostHeading>
 
-          <PostContent postData={postData} />
+          <PostContent postData={postData} articleAType={ValidPostStyle.NEWS} />
         </article>
 
         <SubscribeButton />

--- a/packages/readr/components/post/article-type/scrollable-video.tsx
+++ b/packages/readr/components/post/article-type/scrollable-video.tsx
@@ -13,6 +13,7 @@ import { DEFAULT_POST_IMAGE_PATH } from '~/constants/constant'
 import type { Post } from '~/graphql/fragments/post'
 import type { PostDetail } from '~/graphql/query/post'
 import useScrollToEnd from '~/hooks/useScrollToEnd'
+import { ValidPostStyle } from '~/types/common'
 import * as gtag from '~/utils/gtag'
 
 const Article = styled.article`
@@ -151,6 +152,7 @@ export default function ScrollableVideo({
         </PostHeading>
 
         <PostContent
+          articleAType={ValidPostStyle.SCROLLABLE_VIDEO}
           postData={
             shouldShowLeadingEmbedded
               ? postData

--- a/packages/readr/components/post/article-type/scrollable-video.tsx
+++ b/packages/readr/components/post/article-type/scrollable-video.tsx
@@ -152,7 +152,7 @@ export default function ScrollableVideo({
         </PostHeading>
 
         <PostContent
-          articleAType={ValidPostStyle.SCROLLABLE_VIDEO}
+          articleType={ValidPostStyle.SCROLLABLE_VIDEO}
           postData={
             shouldShowLeadingEmbedded
               ? postData

--- a/packages/readr/components/post/post-content.tsx
+++ b/packages/readr/components/post/post-content.tsx
@@ -22,7 +22,7 @@ const Container = styled.article<StyleProps>`
   max-width: 568px;
   margin: 0 auto;
   padding: ${(props) =>
-    props.shouldPaddingTop ? '24px 20px 0px' : '0px 20px'};
+    props.shouldPaddingTop ? '32px 20px 0px' : '0px 20px'};
 
   .mobile-media-link {
     display: flex;
@@ -32,7 +32,7 @@ const Container = styled.article<StyleProps>`
   }
 
   ${({ theme }) => theme.breakpoint.md} {
-    padding: ${(props) => (props.shouldPaddingTop ? '24px 0px 0px' : '0px')};
+    padding: ${(props) => (props.shouldPaddingTop ? '32px 0px 0px' : '0px')};
 
     .mobile-media-link {
       display: none;
@@ -44,7 +44,6 @@ const Container = styled.article<StyleProps>`
   }
   ${({ theme }) => theme.breakpoint.xl} {
     max-width: 600px;
-    padding: ${(props) => (props.shouldPaddingTop ? '48px 0px 0px' : '0px')};
   }
 `
 

--- a/packages/readr/components/post/post-content.tsx
+++ b/packages/readr/components/post/post-content.tsx
@@ -6,17 +6,23 @@ import PostTag from '~/components/post/tag'
 import MediaLinkList from '~/components/shared/media-link'
 import { DONATION_PAGE_URL } from '~/constants/environment-variables'
 import type { PostDetail } from '~/graphql/query/post'
+import { ValidPostStyle } from '~/types/common'
 import * as gtag from '~/utils/gtag'
 
 const defaultMarginBottom = css`
   margin-bottom: 32px;
 `
 
-const Container = styled.article`
+type StyleProps = {
+  shouldPaddingTop: boolean
+}
+
+const Container = styled.article<StyleProps>`
   width: 100%;
   max-width: 568px;
   margin: 0 auto;
-  padding: 0px 20px;
+  padding: ${(props) =>
+    props.shouldPaddingTop ? '24px 20px 0px' : '0px 20px'};
 
   .mobile-media-link {
     display: flex;
@@ -26,7 +32,7 @@ const Container = styled.article`
   }
 
   ${({ theme }) => theme.breakpoint.md} {
-    padding: 0;
+    padding: ${(props) => (props.shouldPaddingTop ? '24px 0px 0px' : '0px')};
 
     .mobile-media-link {
       display: none;
@@ -38,6 +44,7 @@ const Container = styled.article`
   }
   ${({ theme }) => theme.breakpoint.xl} {
     max-width: 600px;
+    padding: ${(props) => (props.shouldPaddingTop ? '48px 0px 0px' : '0px')};
   }
 `
 
@@ -240,9 +247,13 @@ const TagGroup = styled.div`
 
 type PostProps = {
   postData: PostDetail
+  articleType: string
 }
 
-export default function PostContent({ postData }: PostProps): JSX.Element {
+export default function PostContent({
+  postData,
+  articleType,
+}: PostProps): JSX.Element {
   const {
     DraftRenderer,
     hasContentInRawContentBlock,
@@ -254,8 +265,21 @@ export default function PostContent({ postData }: PostProps): JSX.Element {
   const shouldShowActionList = hasContentInRawContentBlock(postData?.actionList)
   const shouldShowCitation = hasContentInRawContentBlock(postData?.citation)
 
+  //When the article type is "frame", and has "summary" or first block of "content" is not an "EMBEDDEDCODE" , "Container" requires "padding-top".
+  const contentWithoutEmpty = removeEmptyContentBlock(postData?.content)
+
+  let firstContentType
+  if (contentWithoutEmpty) {
+    firstContentType = contentWithoutEmpty?.entityMap[0]?.type
+  }
+
+  const shouldPaddingTop =
+    articleType === ValidPostStyle.FRAME &&
+    (shouldShowSummary ||
+      (!shouldShowSummary && firstContentType !== 'EMBEDDEDCODE'))
+
   return (
-    <Container>
+    <Container shouldPaddingTop={shouldPaddingTop}>
       {shouldShowSummary && (
         <Summary>
           <div>

--- a/packages/readr/pages/post/[id].tsx
+++ b/packages/readr/pages/post/[id].tsx
@@ -8,6 +8,7 @@ import Blank from '~/components/post/article-type/blank'
 import Frame from '~/components/post/article-type/frame'
 import News from '~/components/post/article-type/news'
 import ScrollableVideo from '~/components/post/article-type/scrollable-video'
+import { SITE_TITLE } from '~/constants/constant'
 import { SITE_URL } from '~/constants/environment-variables'
 import type { Post } from '~/graphql/fragments/post'
 import type { PostDetail } from '~/graphql/query/post'
@@ -79,7 +80,9 @@ const Post: NextPageWithLayout<PageProps> = ({ postData, latestPosts }) => {
   //   )
   // }
 
-  const ogTitle = postData.title
+  const ogTitle = postData?.title
+    ? `${postData?.title} - ${SITE_TITLE}`
+    : SITE_TITLE
 
   const ogDescription =
     postData?.ogDescription ||

--- a/packages/readr/pages/post/[id].tsx
+++ b/packages/readr/pages/post/[id].tsx
@@ -51,7 +51,9 @@ const Post: NextPageWithLayout<PageProps> = ({ postData, latestPosts }) => {
     if (blocks) {
       const text = blocks.map((block) => block.text).join('')
       const ogDescription =
-        text && text.length > 160 ? text.slice(0, 160) + '...' : text
+        text && text.length > 160
+          ? text.trim().slice(0, 160) + '...'
+          : text.trim()
       return ogDescription
     }
   }


### PR DESCRIPTION
### 新增
- 文章頁 `Frame` type 新增條件判定：

   - 內文區塊如首位 block 為 `EMBEDDEDCODE`，則上方無間距。
   - 內文區塊如有重點摘要：上方間距須為 32px。
   - 內文區塊如首位 block 非 `EMBEDDEDCODE`：上方間距須為 32px。
- 搭配上述更動，新增傳入 `post-content.tsx` 參數：`articleType`，需依照文章類型傳入對應的 article-type 類別，以達成上述條件判定。

### 調整
- 修正文章頁 og-title 資訊（補上 `- READr 讀+` ）。
- 移除 og-description 中的多餘空格。