### PR TITLE
chore(readr): bump version of `@mirrormedia/lilith-draft-renderer`

### DIFF
--- a/packages/readr/components/post/post-content.tsx
+++ b/packages/readr/components/post/post-content.tsx
@@ -283,9 +283,7 @@ export default function PostContent({
         <Summary>
           <div>
             <p className="title">報導重點摘要</p>
-            <DraftRenderer
-              rawContentBlock={removeEmptyContentBlock(postData?.summary)}
-            />
+            <DraftRenderer rawContentBlock={postData?.summary} />
           </div>
         </Summary>
       )}
@@ -293,7 +291,8 @@ export default function PostContent({
       {shouldShowContent && (
         <Content>
           <DraftRenderer
-            rawContentBlock={removeEmptyContentBlock(postData?.content)}
+            rawContentBlock={postData?.content}
+            insertRecommend={postData?.relatedPosts}
           />
         </Content>
       )}
@@ -301,9 +300,7 @@ export default function PostContent({
       {shouldShowActionList && (
         <ActionList>
           <p className="title">如果你關心這個議題</p>
-          <DraftRenderer
-            rawContentBlock={removeEmptyContentBlock(postData?.actionList)}
-          />
+          <DraftRenderer rawContentBlock={postData?.actionList} />
         </ActionList>
       )}
 
@@ -316,9 +313,7 @@ export default function PostContent({
       {shouldShowCitation && (
         <Citation>
           <p className="title">引用資料</p>
-          <DraftRenderer
-            rawContentBlock={removeEmptyContentBlock(postData?.citation)}
-          />
+          <DraftRenderer rawContentBlock={postData?.citation} />
         </Citation>
       )}
 

--- a/packages/readr/package.json
+++ b/packages/readr/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.3",
-    "@mirrormedia/lilith-draft-renderer": "^1.2.0-alpha.15",
+    "@mirrormedia/lilith-draft-renderer": "^1.2.0-alpha.16",
     "@readr-media/react-component": "^2.1.2",
     "@readr-media/react-image": "^1.5.1",
     "@readr-media/share-button": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2237,10 +2237,10 @@
     npmlog "^6.0.2"
     write-file-atomic "^4.0.1"
 
-"@mirrormedia/lilith-draft-renderer@^1.2.0-alpha.15":
-  version "1.2.0-alpha.15"
-  resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-draft-renderer/-/lilith-draft-renderer-1.2.0-alpha.15.tgz#14d3a45be1d85c305851d7b015f5ebdcb41faf03"
-  integrity sha512-c1lvtgrgBsdwLouahMu9Ap8v7zZkSYSiwqxqJ1+m1nACmGSLQfsFY85PRo+dsm13874M1NpnIdOGMKoU+kg8mA==
+"@mirrormedia/lilith-draft-renderer@^1.2.0-alpha.16":
+  version "1.2.0-alpha.16"
+  resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-draft-renderer/-/lilith-draft-renderer-1.2.0-alpha.16.tgz#07545cdbcd10e823a75c4e8a36cdcd261c3cd7f3"
+  integrity sha512-cO/JXcCowFGUq1AHXoRvqMUnXDi9XIgOUt25AhUASTsS/B1Vq8ySUaHaQD3CMrWd+ZhWPnbI+FQllAnW/Gu+Pg==
   dependencies:
     "@readr-media/react-image" "^1.5.1"
     body-scroll-lock "3.1.5"


### PR DESCRIPTION
### 調整
- `mirrormedia/lilith-draft-renderer` 版本升至 `1.2.0-alpha.16`
- 配合 `draft-renderer` 升版，調整 `post-content` 架構：

   -  `removeEmptyContentBlock` 改為在 `draft-renderer` 內部處理。
   -  新增 optional props `insertRecommend`：如有穿插推薦閱讀需求，需傳入 relatedPosts 資料。