### PR TITLE
feat(post): add `side-index` & bump version of `lilith-draft-renderer`

### DIFF
--- a/packages/readr/components/post/article-type/frame.tsx
+++ b/packages/readr/components/post/article-type/frame.tsx
@@ -1,12 +1,14 @@
 import { Logo } from '@readr-media/react-component'
 import SharedImage from '@readr-media/react-image'
 import { ShareButton } from '@readr-media/share-button'
+import { useState } from 'react'
 import styled from 'styled-components'
 
 import Footer from '~/components/layout/footer'
 import LeadingEmbeddedCode from '~/components/post/leadingEmbeddedCode'
 import PostContent from '~/components/post/post-content'
 import RelatedPosts from '~/components/post/related-post'
+import SideIndex from '~/components/post/side-index'
 import SubscribeButton from '~/components/post/subscribe-button'
 import { DEFAULT_POST_IMAGE_PATH } from '~/constants/constant'
 import type { Post } from '~/graphql/fragments/post'
@@ -137,6 +139,25 @@ const FrameCredit = styled.div`
   }
 `
 
+const ContentWrapper = styled.main`
+  display: block;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    display: flex;
+    justify-content: center;
+  }
+`
+
+const Aside = styled.aside`
+  display: none;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    display: block;
+    width: 100%;
+    padding-bottom: 250px;
+  }
+`
+
 type PostProps = {
   postData: PostDetail
   latestPosts: Post[]
@@ -149,6 +170,9 @@ export default function Frame({
   const anchorRef = useScrollToEnd(() =>
     gtag.sendEvent('post', 'scroll', 'scroll to end')
   )
+
+  //for Draft Style: side-index-block
+  const [currentSideIndex, setCurrentSideIndex] = useState('')
 
   const date = formatPostDate(postData?.publishTime)
 
@@ -205,7 +229,24 @@ export default function Frame({
           />
         )}
 
-        <PostContent postData={postData} articleType={ValidPostStyle.FRAME} />
+        <ContentWrapper>
+          <Aside>
+            <SideIndex
+              rawContentBlock={postData?.content}
+              currentIndex={currentSideIndex}
+              isAside={true}
+            />
+          </Aside>
+          <main>
+            <PostContent
+              postData={postData}
+              articleType={ValidPostStyle.FRAME}
+              currentSideIndex={currentSideIndex}
+              setCurrentSideIndex={setCurrentSideIndex}
+            />
+          </main>
+          <Aside />
+        </ContentWrapper>
       </Article>
 
       <SubscribeButton />

--- a/packages/readr/components/post/article-type/news.tsx
+++ b/packages/readr/components/post/article-type/news.tsx
@@ -1,11 +1,12 @@
 import SharedImage from '@readr-media/react-image'
+import { useState } from 'react'
 import styled from 'styled-components'
 
 import HeaderGeneral from '~/components/layout/header/header-general'
 import PostContent from '~/components/post/post-content'
-import PostCredit from '~/components/post/post-credit'
-import PostTitle from '~/components/post/post-title'
+import PostHeading from '~/components/post/post-heading'
 import RelatedPosts from '~/components/post/related-post'
+import SideIndex from '~/components/post/side-index'
 import SubscribeButton from '~/components/post/subscribe-button'
 import { DEFAULT_POST_IMAGE_PATH } from '~/constants/constant'
 import type { Post } from '~/graphql/fragments/post'
@@ -54,27 +55,31 @@ const HeroImage = styled.figure`
   }
 `
 
-const PostHeading = styled.section`
-  width: 100%;
-  max-width: 568px;
-  margin: 24px auto;
-
-  ${({ theme }) => theme.breakpoint.lg} {
-    margin: 60px auto 48px;
-  }
-
-  ${({ theme }) => theme.breakpoint.xl} {
-    padding: 0;
-    max-width: 600px;
-  }
-`
-
 const HiddenAnchor = styled.div`
   display: block;
   width: 100%;
   height: 0;
   padding: 0;
   margin: 0;
+`
+
+const ContentWrapper = styled.main`
+  display: block;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    display: flex;
+    justify-content: center;
+  }
+`
+
+const Aside = styled.aside`
+  display: none;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    display: block;
+    width: 100%;
+    padding-bottom: 250px;
+  }
 `
 
 type PostProps = {
@@ -91,6 +96,9 @@ export default function News({
   )
 
   const shouldShowHeroImage = Boolean(postData?.heroImage?.resized)
+
+  //for Draft Style: side-index-block
+  const [currentSideIndex, setCurrentSideIndex] = useState('')
 
   return (
     <>
@@ -109,12 +117,26 @@ export default function News({
             </HeroImage>
           )}
 
-          <PostHeading>
-            <PostTitle postData={postData} showTitle={true} />
-            <PostCredit postData={postData} />
-          </PostHeading>
+          <ContentWrapper>
+            <Aside>
+              <SideIndex
+                rawContentBlock={postData?.content}
+                currentIndex={currentSideIndex}
+                isAside={true}
+              />
+            </Aside>
+            <main>
+              <PostHeading showTitle={true} postData={postData} />
 
-          <PostContent postData={postData} articleType={ValidPostStyle.NEWS} />
+              <PostContent
+                postData={postData}
+                articleType={ValidPostStyle.NEWS}
+                currentSideIndex={currentSideIndex}
+                setCurrentSideIndex={setCurrentSideIndex}
+              />
+            </main>
+            <Aside />
+          </ContentWrapper>
         </article>
 
         <SubscribeButton />

--- a/packages/readr/components/post/article-type/scrollable-video.tsx
+++ b/packages/readr/components/post/article-type/scrollable-video.tsx
@@ -1,13 +1,14 @@
 import { Readr } from '@mirrormedia/lilith-draft-renderer'
 import SharedImage from '@readr-media/react-image'
+import { useState } from 'react'
 import styled from 'styled-components'
 
 import HeaderGeneral from '~/components/layout/header/header-general'
 import LeadingEmbeddedCode from '~/components/post/leadingEmbeddedCode'
 import PostContent from '~/components/post/post-content'
-import PostCredit from '~/components/post/post-credit'
-import PostTitle from '~/components/post/post-title'
+import PostHeading from '~/components/post/post-heading'
 import RelatedPosts from '~/components/post/related-post'
+import SideIndex from '~/components/post/side-index'
 import SubscribeButton from '~/components/post/subscribe-button'
 import { DEFAULT_POST_IMAGE_PATH } from '~/constants/constant'
 import type { Post } from '~/graphql/fragments/post'
@@ -49,23 +50,31 @@ const ScrollTitle = styled.h1`
   }
 `
 
-const PostHeading = styled.section`
-  width: 100%;
-  max-width: 568px;
-  margin: 20px auto 24px;
-  ${({ theme }) => theme.breakpoint.xl} {
-    padding: 0;
-    max-width: 600px;
-    margin: 20px auto 48px;
-  }
-`
-
 const HiddenAnchor = styled.div`
   display: block;
   width: 100%;
   height: 0;
   padding: 0;
   margin: 0;
+`
+
+const ContentWrapper = styled.main`
+  display: block;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    display: flex;
+    justify-content: center;
+  }
+`
+
+const Aside = styled.aside`
+  display: none;
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    display: block;
+    width: 100%;
+    padding-bottom: 250px;
+  }
 `
 
 type PostProps = {
@@ -126,6 +135,9 @@ export default function ScrollableVideo({
     },
   }
 
+  //for Draft Style: side-index-block
+  const [currentSideIndex, setCurrentSideIndex] = useState('')
+
   return (
     <>
       <HeaderGeneral />
@@ -146,19 +158,30 @@ export default function ScrollableVideo({
           <DraftRenderer rawContentBlock={embeddedContentState} />
         )}
 
-        <PostHeading>
-          <PostTitle postData={postData} showTitle={false} />
-          <PostCredit postData={postData} />
-        </PostHeading>
+        <ContentWrapper>
+          <Aside>
+            <SideIndex
+              rawContentBlock={postData?.content}
+              currentIndex={currentSideIndex}
+              isAside={true}
+            />
+          </Aside>
+          <main>
+            <PostHeading showTitle={true} postData={postData} />
 
-        <PostContent
-          articleType={ValidPostStyle.SCROLLABLE_VIDEO}
-          postData={
-            shouldShowLeadingEmbedded
-              ? postData
-              : postDataWithoutFirstScrollVideo
-          }
-        />
+            <PostContent
+              articleType={ValidPostStyle.SCROLLABLE_VIDEO}
+              currentSideIndex={currentSideIndex}
+              setCurrentSideIndex={setCurrentSideIndex}
+              postData={
+                shouldShowLeadingEmbedded
+                  ? postData
+                  : postDataWithoutFirstScrollVideo
+              }
+            />
+          </main>
+          <Aside />
+        </ContentWrapper>
       </Article>
 
       <SubscribeButton />

--- a/packages/readr/components/post/post-content.tsx
+++ b/packages/readr/components/post/post-content.tsx
@@ -1,12 +1,14 @@
 import { Readr } from '@mirrormedia/lilith-draft-renderer'
 import { DonateButton } from '@readr-media/react-component'
+import { useEffect, useRef } from 'react'
 import styled, { css } from 'styled-components'
 
+import SideIndex from '~/components/post/side-index'
 import PostTag from '~/components/post/tag'
 import MediaLinkList from '~/components/shared/media-link'
 import { DONATION_PAGE_URL } from '~/constants/environment-variables'
-import type { PostDetail } from '~/graphql/query/post'
-import { ValidPostStyle } from '~/types/common'
+import { PostDetail } from '~/graphql/query/post'
+import { ValidPostContentType, ValidPostStyle } from '~/types/common'
 import * as gtag from '~/utils/gtag'
 
 const defaultMarginBottom = css`
@@ -43,7 +45,8 @@ const Container = styled.article<StyleProps>`
     }
   }
   ${({ theme }) => theme.breakpoint.xl} {
-    max-width: 600px;
+    width: 600px;
+    max-width: none;
   }
 `
 
@@ -56,28 +59,11 @@ const Summary = styled.article`
   border-radius: 2px;
   ${defaultMarginBottom}
 
-  .DraftEditor-root {
-    font-size: 16px;
-    line-height: 1.6;
-
-    .public-DraftStyleDefault-block,
-    .public-DraftStyleDefault-ul,
-    .public-DraftStyleDefault-ol {
-      margin-top: 12px;
-    }
-
-    .public-DraftStyleDefault-unorderedListItem,
-    .public-DraftStyleDefault-orderedListItem {
-      .public-DraftStyleDefault-block {
-        margin-top: 4px;
-      }
-    }
-  }
-
   .title {
     font-size: 14px;
     line-height: 21px;
     color: #04295e;
+    margin-bottom: 4px;
   }
 
   ${({ theme }) => theme.breakpoint.md} {
@@ -93,6 +79,7 @@ const Content = styled.article`
 //延伸議題
 const ActionList = styled.article`
   ${defaultMarginBottom};
+
   .title {
     font-weight: 700;
     font-size: 24px;
@@ -140,89 +127,12 @@ const Citation = styled.article`
     }
   }
 
-  .DraftEditor-root {
-    font-size: 16px;
-    line-height: 1.6;
+  .content {
     background-color: rgba(245, 235, 255, 0.5);
     padding: 12px 24px;
 
-    .public-DraftStyleDefault-block,
-    .public-DraftStyleDefault-ul,
-    .public-DraftStyleDefault-ol {
-      margin-top: 12px;
-    }
-
-    .public-DraftStyleDefault-unorderedListItem,
-    .public-DraftStyleDefault-orderedListItem {
-      .public-DraftStyleDefault-block {
-        margin-top: 4px;
-      }
-    }
-
     ${({ theme }) => theme.breakpoint.md} {
       padding: 16px 32px;
-    }
-  }
-
-  //檔案下載
-  .public-DraftStyleDefault-ul {
-    padding: 0;
-
-    .public-DraftStyleDefault-unorderedListItem {
-      list-style-type: none;
-      padding: 8px 0;
-    }
-
-    a {
-      width: 100%;
-      border: none;
-      font-weight: 700;
-      font-size: 16px;
-      line-height: 1.5;
-      color: #04295e;
-      display: inline-block;
-      position: relative;
-      padding-right: 60px;
-
-      &:hover {
-        color: rgba(0, 9, 40, 0.87);
-      }
-
-      &::after {
-        content: '';
-        background-image: url('/icons/post-download.svg');
-        background-repeat: no-repeat;
-        background-position: center center;
-        position: absolute;
-        right: 0;
-        top: 50%;
-        width: 24px;
-        height: 24px;
-        transform: translate(0%, -12px);
-      }
-    }
-  }
-
-  .public-DraftStyleDefault-blockquote {
-    width: 100%;
-    color: rgba(0, 9, 40, 0.5);
-    font-size: 16px;
-    font-weight: 400;
-    line-height: 1.6;
-    padding: 0;
-
-    & + blockquote {
-      margin-top: 8px;
-    }
-
-    & + ul {
-      border-top: 1px solid rgba(0, 9, 40, 0.1);
-      padding-top: 4px;
-      margin-top: 4px;
-
-      ${({ theme }) => theme.breakpoint.md} {
-        margin-top: 8px;
-      }
     }
   }
 `
@@ -247,16 +157,20 @@ const TagGroup = styled.div`
 type PostProps = {
   postData: PostDetail
   articleType: string
+  currentSideIndex?: string
+  setCurrentSideIndex?: (id: string) => void
 }
 
 export default function PostContent({
   postData,
   articleType,
+  currentSideIndex = '',
+  setCurrentSideIndex = () => {},
 }: PostProps): JSX.Element {
   const {
     DraftRenderer,
     hasContentInRawContentBlock,
-    removeEmptyContentBlock,
+    getFirstBlockEntityType,
   } = Readr
 
   const shouldShowSummary = hasContentInRawContentBlock(postData?.summary)
@@ -264,26 +178,69 @@ export default function PostContent({
   const shouldShowActionList = hasContentInRawContentBlock(postData?.actionList)
   const shouldShowCitation = hasContentInRawContentBlock(postData?.citation)
 
-  //When the article type is "frame", and has "summary" or first block of "content" is not an "EMBEDDEDCODE" , "Container" requires "padding-top".
-  const contentWithoutEmpty = removeEmptyContentBlock(postData?.content)
-
-  let firstContentType
-  if (contentWithoutEmpty) {
-    firstContentType = contentWithoutEmpty?.entityMap[0]?.type
-  }
-
+  //WORKAROUND：
+  //when article type is `frame`, and has `summary` or first block of `content` is not an "EMBEDDEDCODE" , `<Container>` requires "padding-top".
   const shouldPaddingTop =
     articleType === ValidPostStyle.FRAME &&
     (shouldShowSummary ||
-      (!shouldShowSummary && firstContentType !== 'EMBEDDEDCODE'))
+      (!shouldShowSummary &&
+        getFirstBlockEntityType(postData?.content) !== 'EMBEDDEDCODE'))
+
+  const articleRef = useRef<HTMLElement>(null)
+
+  //Draft Style: add IntersectionObserver to detect side-index titles.
+  //`BLANK` type: hide side-index-block
+  useEffect(() => {
+    if (articleType === ValidPostStyle.BLANK) {
+      return
+    }
+
+    if (!articleRef.current) {
+      return
+    }
+
+    const selectorIdBeginWithHeader = '[id^="header"]'
+    const targets = [
+      ...articleRef.current.querySelectorAll(selectorIdBeginWithHeader),
+    ]
+
+    const indexObserver = new IntersectionObserver(
+      (entries) => {
+        entries.forEach(({ isIntersecting, target }) => {
+          if (isIntersecting) {
+            setCurrentSideIndex(target.id)
+          }
+        })
+      },
+      {
+        threshold: 1,
+        rootMargin: `150px 0px 0px 0px`,
+      }
+    )
+    targets.forEach((element) => {
+      indexObserver.observe(element)
+    })
+    return () => {
+      indexObserver.disconnect()
+    }
+  }, [articleRef, articleType])
 
   return (
-    <Container shouldPaddingTop={shouldPaddingTop}>
+    <Container shouldPaddingTop={shouldPaddingTop} ref={articleRef}>
+      <SideIndex
+        rawContentBlock={postData?.content}
+        currentIndex={currentSideIndex}
+        isAside={false}
+      />
+
       {shouldShowSummary && (
         <Summary>
           <div>
             <p className="title">報導重點摘要</p>
-            <DraftRenderer rawContentBlock={postData?.summary} />
+            <DraftRenderer
+              rawContentBlock={postData?.summary}
+              contentType={ValidPostContentType.SUMMARY}
+            />
           </div>
         </Summary>
       )}
@@ -293,6 +250,7 @@ export default function PostContent({
           <DraftRenderer
             rawContentBlock={postData?.content}
             insertRecommend={postData?.relatedPosts}
+            contentType={ValidPostContentType.NORMAL}
           />
         </Content>
       )}
@@ -300,7 +258,10 @@ export default function PostContent({
       {shouldShowActionList && (
         <ActionList>
           <p className="title">如果你關心這個議題</p>
-          <DraftRenderer rawContentBlock={postData?.actionList} />
+          <DraftRenderer
+            rawContentBlock={postData?.actionList}
+            contentType={ValidPostContentType.ACTIONLIST}
+          />
         </ActionList>
       )}
 
@@ -313,7 +274,12 @@ export default function PostContent({
       {shouldShowCitation && (
         <Citation>
           <p className="title">引用資料</p>
-          <DraftRenderer rawContentBlock={postData?.citation} />
+          <div className="content">
+            <DraftRenderer
+              rawContentBlock={postData?.citation}
+              contentType={ValidPostContentType.CITATION}
+            />
+          </div>
         </Citation>
       )}
 

--- a/packages/readr/components/post/post-heading.tsx
+++ b/packages/readr/components/post/post-heading.tsx
@@ -1,0 +1,37 @@
+import styled from 'styled-components'
+
+import PostCredit from '~/components/post/post-credit'
+import PostTitle from '~/components/post/post-title'
+import type { PostDetail } from '~/graphql/query/post'
+
+const HeadingWrapper = styled.section`
+  width: 100%;
+  max-width: 568px;
+  margin: 24px auto;
+
+  ${({ theme }) => theme.breakpoint.lg} {
+    margin: 60px auto 48px;
+  }
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    padding: 0;
+    max-width: 600px;
+  }
+`
+
+type PostProps = {
+  postData: PostDetail
+  showTitle: boolean
+}
+
+export default function PostHeading({
+  postData,
+  showTitle = true,
+}: PostProps): JSX.Element {
+  return (
+    <HeadingWrapper>
+      <PostTitle postData={postData} showTitle={showTitle} />
+      <PostCredit postData={postData} />
+    </HeadingWrapper>
+  )
+}

--- a/packages/readr/components/post/side-index.tsx
+++ b/packages/readr/components/post/side-index.tsx
@@ -1,0 +1,128 @@
+import { Readr } from '@mirrormedia/lilith-draft-renderer'
+import type { RawDraftContentState } from 'draft-js'
+import styled from 'styled-components'
+
+type WrapperProps = {
+  isAside: boolean
+  shouldShowSideIndex: boolean
+}
+
+const SideIndexWrapper = styled.div<WrapperProps>`
+  background: #f6f6fb;
+  border: 1px solid rgba(0, 9, 40, 0.1);
+  border-radius: 2px;
+  padding: 16px 0px;
+  margin-bottom: 24px;
+
+  .title {
+    padding: 0px 20px;
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 20px;
+    color: #04295e;
+    margin-bottom: 8px;
+  }
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    display: ${(props) => (props.isAside ? 'block' : 'none')};
+    position: sticky;
+    top: 146px;
+    max-width: 320px;
+    margin: 60px 40px auto 40px;
+  }
+`
+type StyleProps = {
+  isActive?: boolean
+}
+
+const SideIndexList = styled.li<StyleProps>`
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 20px;
+  cursor: pointer;
+  box-shadow: ${(props) =>
+    props.isActive ? 'inset 4px 0px 0px 0px black' : 'none'};
+  color: ${(props) =>
+    props.isActive ? 'rgba(0, 9, 40, 0.87)' : 'rgba(0, 9, 40, 0.5)'};
+
+  & + li {
+    margin-top: 12px;
+  }
+
+  &:hover {
+    color: rgba(0, 9, 40, 0.87);
+    box-shadow: inset 4px 0px 0px 0px black;
+  }
+
+  > a {
+    width: 100%;
+    padding: 0px 20px;
+    display: inline-block;
+  }
+`
+
+type SideIndexProps = {
+  rawContentBlock: RawDraftContentState
+  currentIndex?: string
+  isAside: boolean
+}
+
+export default function SideIndex({
+  rawContentBlock,
+  currentIndex,
+  isAside = false,
+}: SideIndexProps): JSX.Element {
+  const { getSideIndexEntityData } = Readr
+  const sideIndexList = getSideIndexEntityData(rawContentBlock)
+
+  function handleScrollIntoView(target: string) {
+    const targetElement = document.querySelector(`#${target}`)
+    targetElement &&
+      targetElement.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+        inline: 'center',
+      })
+  }
+
+  const sideIndexLists = sideIndexList?.map((list) => {
+    const { title, id, href } = list
+
+    if (href) {
+      return (
+        <SideIndexList key={id} isActive={currentIndex === id}>
+          <a href={href}>{title}</a>
+        </SideIndexList>
+      )
+    } else {
+      return (
+        <SideIndexList
+          key={id}
+          isActive={currentIndex === id}
+          onClick={(e) => {
+            e.preventDefault()
+            handleScrollIntoView(id)
+          }}
+        >
+          <a href={id}>{title}</a>
+        </SideIndexList>
+      )
+    }
+  })
+
+  const shouldShowSideIndex = Boolean(sideIndexList?.length)
+
+  return (
+    <>
+      {shouldShowSideIndex && (
+        <SideIndexWrapper
+          isAside={isAside}
+          shouldShowSideIndex={shouldShowSideIndex}
+        >
+          <p className="title">目錄</p>
+          <ul>{sideIndexLists}</ul>
+        </SideIndexWrapper>
+      )}
+    </>
+  )
+}

--- a/packages/readr/components/post/side-index.tsx
+++ b/packages/readr/components/post/side-index.tsx
@@ -61,6 +61,13 @@ const SideIndexList = styled.li<StyleProps>`
   }
 `
 
+type SideIndexList = {
+  title: string
+  id: string
+  href: string | null
+  isActive: boolean
+}
+
 type SideIndexProps = {
   rawContentBlock: RawDraftContentState
   currentIndex?: string
@@ -85,7 +92,7 @@ export default function SideIndex({
       })
   }
 
-  const sideIndexLists = sideIndexList?.map((list) => {
+  const sideIndexLists = sideIndexList?.map((list: SideIndexList) => {
     const { title, id, href } = list
 
     if (href) {

--- a/packages/readr/package.json
+++ b/packages/readr/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.3",
-    "@mirrormedia/lilith-draft-renderer": "^1.2.0-alpha.17",
+    "@mirrormedia/lilith-draft-renderer": "^1.2.0-alpha.19",
     "@readr-media/react-component": "^2.1.2",
     "@readr-media/react-image": "^1.5.1",
     "@readr-media/share-button": "^1.0.3",

--- a/packages/readr/pages/post/[id].tsx
+++ b/packages/readr/pages/post/[id].tsx
@@ -138,12 +138,12 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
         return { notFound: true }
       }
 
-      if (data.posts[0].style === ValidPostStyle.EMBEDDED) {
-        return { notFound: true }
-      }
-
       const postStyle = data.posts[0].style
       const postSlug = data.posts[0].slug
+
+      if (postStyle === ValidPostStyle.EMBEDDED) {
+        return { notFound: true }
+      }
 
       if (postStyle === ValidPostStyle.REPORT) {
         return {

--- a/packages/readr/public/icons/post-download.svg
+++ b/packages/readr/public/icons/post-download.svg
@@ -1,3 +1,0 @@
-<svg width="12" height="15" viewBox="0 0 12 15" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M0.179688 13H11.8203V14.6797H0.179688V13ZM11.8203 5.5L6 11.3203L0.179688 5.5H3.5V0.5H8.5V5.5H11.8203Z" fill="#04295E"/>
-</svg>

--- a/packages/readr/types/common.ts
+++ b/packages/readr/types/common.ts
@@ -55,6 +55,13 @@ export enum ValidJobTitles {
   PRODUCT_MANAGER = 'product manager',
 }
 
+export enum ValidPostContentType {
+  NORMAL = 'normal',
+  SUMMARY = 'summary',
+  ACTIONLIST = 'actionlist',
+  CITATION = 'citation',
+}
+
 /* eslint-enable no-unused-vars */
 
 export type GenericAuthor = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2237,10 +2237,10 @@
     npmlog "^6.0.2"
     write-file-atomic "^4.0.1"
 
-"@mirrormedia/lilith-draft-renderer@^1.2.0-alpha.17":
-  version "1.2.0-alpha.17"
-  resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-draft-renderer/-/lilith-draft-renderer-1.2.0-alpha.17.tgz#ba7bf0b2fac460c17620c779fc1fe33e3a8fda78"
-  integrity sha512-TQiVsGvOzkF5psceSsoyg8+lWaaso8Hpewz7yQKiMUGRSyjj1Xcrg6u6w0hc5YRMx6hEkkdZjjQ23nhzCpcNeg==
+"@mirrormedia/lilith-draft-renderer@^1.2.0-alpha.19":
+  version "1.2.0-alpha.19"
+  resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-draft-renderer/-/lilith-draft-renderer-1.2.0-alpha.19.tgz#48bc0f3863f4364887eec599e3ee50d07494aad3"
+  integrity sha512-717IANH35XItBFWQfJlufDznyyPmZcZ9JSk6y7f8shrZ2n2/gZjg3eKwbERApOP7JkkMPx48IGM8tSnltSHvRQ==
   dependencies:
     "@readr-media/react-image" "^1.5.1"
     body-scroll-lock "3.1.5"
@@ -4407,11 +4407,11 @@ create-require@^1.1.0:
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-fetch@^3.0.4:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
-  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.6.tgz#bae05aa31a4da760969756318feeee6e70f15d6c"
+  integrity sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==
   dependencies:
-    node-fetch "2.6.7"
+    node-fetch "^2.6.11"
 
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
@@ -7342,10 +7342,17 @@ node-addon-api@^5.0.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-5.1.0.tgz#49da1ca055e109a23d537e9de43c09cca21eb762"
   integrity sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==
 
-node-fetch@2.6.7, node-fetch@^2.6.1, node-fetch@^2.6.7:
+node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.6.11:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.11.tgz#cde7fc71deef3131ef80a738919f999e6edfff25"
+  integrity sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==
   dependencies:
     whatwg-url "^5.0.0"
 


### PR DESCRIPTION
## 調整
- `@mirrormedia/lilith-draft-renderer` 版本升至 `1.2.0-alpha.19`。
- 新增 `sideindex` 側欄索引元件。
- 調整文章頁樣式架構，將 `summary`、`citation` 樣式差異改為透過傳入 `contentType` 參數，在 `lilith-draft-renderer` 內處理。
- 新增 `ValidPostContentType`，管理文章頁區塊樣式。（ `summary`、`citation`、`actionlist`、`normal`）。