### PR TITLE
feat(readr): add google `Adsense` ad

### DIFF
--- a/packages/readr/components/ad/google-adsense/adsense-ad.tsx
+++ b/packages/readr/components/ad/google-adsense/adsense-ad.tsx
@@ -1,0 +1,122 @@
+import React, { useEffect, useState } from 'react'
+import styled from 'styled-components'
+
+import { GOOGLE_ADSENSE_AD_CLIENT } from '~/constants/environment-variables'
+import { ENV } from '~/constants/environment-variables'
+import { getAdParam, getAdParamBySlot } from '~/utils/ad'
+
+declare global {
+  // eslint-disable-next-line no-unused-vars
+  interface Window {
+    adsbygoogle: { [key: string]: unknown }[]
+  }
+}
+
+type StyleProps = {
+  $adSize?: number[]
+}
+
+const Ad = styled.ins<StyleProps>`
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  width: ${({ $adSize }) => ($adSize ? `${$adSize[0]}px` : 'unset')};
+  height: ${({ $adSize }) => ($adSize ? `${$adSize[1]}px` : 'unset')};
+
+  /**
+  * Hide Ad when no ads were returned and the ad unit is empty.
+  * ref: https://support.google.com/adsense/answer/10762946?hl=en
+  */
+  &[data-ad-status='unfilled'] {
+    display: none !important;
+  }
+`
+
+type AdsenseProps = {
+  pageKey?: string
+  adKey?: string
+  slot?: string
+  className?: string
+  layout?: string
+  layoutKey?: string
+  format?: string
+  responsive?: 'true' | 'false'
+}
+export default function Adsense({
+  pageKey,
+  adKey,
+  slot,
+  className,
+  format = '',
+  responsive = 'false',
+  layout = '',
+  layoutKey = '',
+  ...rest
+}: AdsenseProps) {
+  const [adUnit, setAdUnit] = useState('')
+  const [adSlot, setAdSlot] = useState('')
+  const [adSize, setAdSize] = useState([0, 0])
+  const [adTest, setAdTest] = useState('off')
+
+  if (ENV === 'dev') {
+    setAdTest('on')
+  }
+
+  useEffect(() => {
+    if (pageKey && adKey) {
+      // get adParam by pageKey & adKey
+      const width = window.innerWidth
+      const adParam = getAdParam(pageKey, adKey, width)
+      if (!adParam) {
+        return
+      }
+
+      const { adSlot, adSize, adUnit } = adParam
+      setAdSlot(adSlot)
+      setAdSize(adSize)
+      setAdUnit(adUnit)
+    } else if (slot) {
+      // get adParam by slot
+      const adParam = getAdParamBySlot(slot)
+      if (!adParam) {
+        return
+      }
+      const { adSize, adUnit } = adParam
+      setAdSlot(slot)
+      setAdSize(adSize)
+      setAdUnit(adUnit)
+    } else {
+      console.error(
+        `Adsense not receive necessary pageKey '${pageKey}' and adKey '${adKey}' or '${slot}'`
+      )
+      return
+    }
+  }, [adKey, pageKey, slot])
+
+  useEffect(() => {
+    try {
+      if (typeof window === 'object' && adSize && adSlot) {
+        ;((window as Window).adsbygoogle =
+          (window as Window).adsbygoogle || []).push({})
+      }
+    } catch (err) {
+      // console.log(err)
+    }
+  }, [adSize, adSlot])
+
+  return (
+    <Ad
+      id={adUnit}
+      className={`adsbygoogle ${className}`}
+      data-ad-client={GOOGLE_ADSENSE_AD_CLIENT}
+      data-ad-slot={adSlot}
+      data-ad-format={format}
+      data-full-width-responsive={responsive}
+      data-adtest={adTest}
+      data-ad-layout={layout}
+      data-ad-layout-key={layoutKey}
+      $adSize={adSize}
+      {...rest}
+    />
+  )
+}

--- a/packages/readr/components/ad/google-adsense/adsense-script.tsx
+++ b/packages/readr/components/ad/google-adsense/adsense-script.tsx
@@ -1,0 +1,11 @@
+import { GOOGLE_ADSENSE_AD_CLIENT } from '~/constants/environment-variables'
+
+export default function AdsenseScript() {
+  return (
+    <script
+      async
+      src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${GOOGLE_ADSENSE_AD_CLIENT}`}
+      crossOrigin="anonymous"
+    />
+  )
+}

--- a/packages/readr/constants/ad.ts
+++ b/packages/readr/constants/ad.ts
@@ -1,0 +1,694 @@
+import type { AdsenseUnits } from '~/types/ad'
+
+import { CATEGORY_SLUGS } from './constant'
+
+const {
+  breakingnews,
+  education,
+  politics,
+  humanrights,
+  environment,
+  omt,
+  data,
+  note,
+  covid19,
+  culture,
+  international,
+  traffic,
+} = CATEGORY_SLUGS
+
+const ADSENSE_UNITS: AdsenseUnits = {
+  // page key: 首頁, hp
+  home: {
+    MB_HD: {
+      adUnit: 'READr_m_hp_300x250_HD',
+      adSlot: '1436907699',
+      adSize: [300, 250],
+    },
+    MB_FT: {
+      adUnit: 'READr_m_hp_300x250_FT',
+      adSlot: '6497662681',
+      adSize: [300, 250],
+    },
+    PC_HD: {
+      adUnit: 'READr_pc_hp_970x250_HD',
+      adSlot: '8684008170',
+      adSize: [970, 250],
+    },
+    PC_FT: {
+      adUnit: 'READr_pc_hp_970x250_FT',
+      adSlot: '7865433293',
+      adSize: [970, 250],
+    },
+  },
+
+  // page key: 時事, breakingnews
+  [breakingnews]: {
+    MB_HD: {
+      adUnit: 'READr_m_breakingnews_300x250_HD',
+      adSlot: '6904856795',
+      adSize: [300, 250],
+    },
+    MB_FT: {
+      adUnit: 'READr_m_breakingnews_300x250_FT',
+      adSlot: '2555328495',
+      adSize: [300, 250],
+    },
+    MB_AT1: {
+      adUnit: 'READr_m_breakingnews_300x250_AT1',
+      adSlot: '4250773297',
+      adSize: [300, 250],
+    },
+    MB_AT2: {
+      adUnit: 'READr_m_breakingnews_300x250_AT2',
+      adSlot: '2734511646',
+      adSize: [300, 250],
+    },
+    MB_E1: {
+      adUnit: 'READr_m_breakingnews_300x250_E1',
+      adSlot: '8174223355',
+      adSize: [300, 250],
+    },
+    PC_HD: {
+      adUnit: 'READr_pc_breakingnews_970x250_HD',
+      adSlot: '4605162366',
+      adSize: [970, 250],
+    },
+    PC_FT: {
+      adUnit: 'READr_pc_breakingnews_970x250_FT',
+      adSlot: '5068977047',
+      adSize: [970, 250],
+    },
+    PC_AT1: {
+      adUnit: 'READr_pc_breakingnews_640x390_AT1',
+      adSlot: '5032537777',
+      adSize: [640, 390],
+    },
+    PC_AT2: {
+      adUnit: 'READr_pc_breakingnews_640x390_AT2',
+      adSlot: '2842268952',
+      adSize: [640, 390],
+    },
+    PC_E1: {
+      adUnit: 'READr_pc_breakingnews_640x390_E1',
+      adSlot: '2266456402',
+      adSize: [640, 390],
+    },
+  },
+
+  // page key: 教育, education
+  [education]: {
+    MB_HD: {
+      adUnit: 'READr_m_education_300x250_HD',
+      adSlot: '3784649683',
+      adSize: [300, 250],
+    },
+    MB_FT: {
+      adUnit: 'READr_m_education_300x250_FT',
+      adSlot: '6303001817',
+      adSize: [300, 250],
+    },
+    MB_AT1: {
+      adUnit: 'READr_m_education_300x250_AT1',
+      adSlot: '8325749679',
+      adSize: [300, 250],
+    },
+    MB_AT2: {
+      adUnit: 'READr_m_education_300x250_AT2',
+      adSlot: '7594804704',
+      adSize: [300, 250],
+    },
+    MB_E1: {
+      adUnit: 'READr_m_education_300x250_E1',
+      adSlot: '1079429440',
+      adSize: [300, 250],
+    },
+    PC_HD: {
+      adUnit: 'READr_pc_education_970x250_HD ',
+      adSlot: '8680918995',
+      adSize: [970, 250],
+    },
+    PC_FT: {
+      adUnit: 'READr_pc_education_970x250_FT',
+      adSlot: '3045448931',
+      adSize: [970, 250],
+    },
+    PC_AT1: {
+      adUnit: 'READr_pc_education_640x390_AT1',
+      adSlot: '3719456107',
+      adSize: [640, 390],
+    },
+    PC_AT2: {
+      adUnit: 'READr_pc_education_640x390_AT2',
+      adSlot: '8348649029',
+      adSize: [640, 390],
+    },
+    PC_E1: {
+      adUnit: 'READr_pc_education_640x390_E1',
+      adSlot: '9730013455',
+      adSize: [640, 390],
+    },
+  },
+
+  // page key: 政治, politics
+  [politics]: {
+    MB_HD: {
+      adUnit: 'READr_m_politics_300x250_HD',
+      adSlot: '8932254339',
+      adSize: [300, 250],
+    },
+    MB_FT: {
+      adUnit: 'READr_m_politics_300x250_FT',
+      adSlot: '1050675130',
+      adSize: [300, 250],
+    },
+    MB_AT1: {
+      adUnit: 'READr_m_politics_300x250_AT1',
+      adSlot: '1613001664',
+      adSize: [300, 250],
+    },
+    MB_AT2: {
+      adUnit: 'READr_m_politics_300x250_AT2',
+      adSlot: '3463988007',
+      adSize: [300, 250],
+    },
+    MB_E1: {
+      adUnit: 'READr_m_politics_300x250_E1',
+      adSlot: '1122881221',
+      adSize: [300, 250],
+    },
+    PC_HD: {
+      adUnit: 'READr_pc_politics_970x250_HD',
+      adSlot: '2948148534',
+      adSize: [970, 250],
+    },
+    PC_FT: {
+      adUnit: 'READr_pc_politics_970x250_FT',
+      adSlot: '9419285598',
+      adSize: [970, 250],
+    },
+    PC_AT1: {
+      adUnit: 'READr_pc_politics_640x390_AT1',
+      adSlot: '5566573013',
+      adSize: [640, 390],
+    },
+    PC_AT2: {
+      adUnit: 'READr_pc_politics_640x390_AT2',
+      adSlot: '5404853118',
+      adSize: [640, 390],
+    },
+    PC_E1: {
+      adUnit: 'READr_pc_politics_640x390_E1',
+      adSlot: '5946998340',
+      adSize: [640, 390],
+    },
+  },
+
+  // page key: 人權, humanrights
+  [humanrights]: {
+    MB_HD: {
+      adUnit: 'READr_m_humanrights_300x250_HD',
+      adSlot: '1158486344',
+      adSize: [300, 250],
+    },
+    MB_FT: {
+      adUnit: 'READr_m_humanrights_300x250_FT',
+      adSlot: '5208631742',
+      adSize: [300, 250],
+    },
+    MB_AT1: {
+      adUnit: 'READr_m_humanrights_300x250_AT1',
+      adSlot: '5943909168',
+      adSize: [300, 250],
+    },
+    MB_AT2: {
+      adUnit: 'READr_m_humanrights_300x250_AT2',
+      adSlot: '6482184960',
+      adSize: [300, 250],
+    },
+    MB_E1: {
+      adUnit: 'READr_m_humanrights_300x250_E1',
+      adSlot: '7261694415',
+      adSize: [300, 250],
+    },
+    PC_HD: {
+      adUnit: 'READr_pc_humanrights_970x250_HD',
+      adSlot: '9745808409',
+      adSize: [970, 250],
+    },
+    PC_FT: {
+      adUnit: 'READr_pc_humanrights_970x250_FT',
+      adSlot: '9088113100',
+      adSize: [970, 250],
+    },
+    PC_AT1: {
+      adUnit: 'READr_pc_humanrights_640x390_AT1 ',
+      adSlot: '6516692605',
+      adSize: [640, 390],
+    },
+    PC_AT2: {
+      adUnit: 'READr_pc_humanrights_640x390_AT2',
+      adSlot: '1465608106',
+      adSize: [640, 390],
+    },
+    PC_E1: {
+      adUnit: 'READr_pc_humanrights_640x390_E1',
+      adSlot: '9694671662',
+      adSize: [640, 390],
+    },
+  },
+
+  // page key: 環境, environment
+  [environment]: {
+    MB_HD: {
+      adUnit: 'READr_m_environment_300x250_HD',
+      adSlot: '6090468571',
+      adSize: [300, 250],
+    },
+    MB_FT: {
+      adUnit: 'READr_m_environment_300x250_FT',
+      adSlot: '8357539260',
+      adSize: [300, 250],
+    },
+    MB_AT1: {
+      adUnit: 'READr_m_environment_300x250_AT1',
+      adSlot: '6980878415',
+      adSize: [300, 250],
+    },
+    MB_AT2: {
+      adUnit: 'READr_m_environment_300x250_AT2',
+      adSlot: '1229858289',
+      adSize: [300, 250],
+    },
+    MB_E1: {
+      adUnit: 'READr_m_environment_300x250_E1 ',
+      adSlot: '8422786742',
+      adSize: [300, 250],
+    },
+    PC_HD: {
+      adUnit: 'READr_pc_environment_970x250_HD',
+      adSlot: '3017528778',
+      adSize: [970, 250],
+    },
+    PC_FT: {
+      adUnit: 'READr_pc_environment_970x250_FT',
+      adSlot: '5480040587',
+      adSize: [970, 250],
+    },
+    PC_AT1: {
+      adUnit: 'READr_pc_environment_640x390_AT1',
+      adSlot: '6696973239',
+      adSize: [640, 390],
+    },
+    PC_AT2: {
+      adUnit: 'READr_pc_environment_640x390_AT2',
+      adSlot: '1274036414',
+      adSize: [640, 390],
+    },
+    PC_E1: {
+      adUnit: 'READr_pc_environment_640x390_E1',
+      adSlot: '1074725869',
+      adSize: [640, 390],
+    },
+  },
+
+  // page key: 新鮮事, omt
+  [omt]: {
+    MB_HD: {
+      adUnit: 'READr_m_omt_300x250_HD',
+      adSlot: '8845404678',
+      adSize: [300, 250],
+    },
+    MB_FT: {
+      adUnit: 'READr_m_omt_300x250_FT',
+      adSlot: '5731375924',
+      adSize: [300, 250],
+    },
+    MB_AT1: {
+      adUnit: 'READr_m_omt_300x250_AT1',
+      adSlot: '5911339326',
+      adSize: [300, 250],
+    },
+    MB_AT2: {
+      adUnit: 'READr_m_omt_300x250_AT2',
+      adSlot: '9646252970',
+      adSize: [300, 250],
+    },
+    MB_E1: {
+      adUnit: 'READr_m_omt_300x250_E1',
+      adSlot: '4351679797',
+      adSize: [300, 250],
+    },
+    PC_HD: {
+      adUnit: 'READr_pc_omt_970x250_HD',
+      adSlot: '4069658513',
+      adSize: [970, 250],
+    },
+    PC_FT: {
+      adUnit: 'READr_pc_omt_970x250_FT',
+      adSlot: '2331133064',
+      adSize: [970, 250],
+    },
+    PC_AT1: {
+      adUnit: 'READr_pc_omt_640x390_AT1',
+      adSlot: '5383891567',
+      adSize: [640, 390],
+    },
+    PC_AT2: {
+      adUnit: 'READr_pc_omt_640x390_AT2',
+      adSlot: '5021709736',
+      adSize: [640, 390],
+    },
+    PC_E1: {
+      adUnit: 'READr_pc_omt_640x390_E1',
+      adSlot: '1085236678',
+      adSize: [640, 390],
+    },
+  },
+
+  // page key: 資料專欄, omt
+  [data]: {
+    MB_HD: {
+      adUnit: 'READr_m_data_300x250_HD',
+      adSlot: '9838141899',
+      adSize: [300, 250],
+    },
+    MB_FT: {
+      adUnit: 'READr_m_data_300x250_FT',
+      adSlot: '1792130917',
+      adSize: [300, 250],
+    },
+    MB_AT1: {
+      adUnit: 'READr_m_data_300x250_AT1',
+      adSlot: '1972094311',
+      adSize: [300, 250],
+    },
+    MB_AT2: {
+      adUnit: 'READr_m_data_300x250_AT2',
+      adSlot: '1931414484',
+      adSize: [300, 250],
+    },
+    MB_E1: {
+      adUnit: 'READr_m_data_300x250_E1',
+      adSlot: '7756518437',
+      adSize: [300, 250],
+    },
+    PC_HD: {
+      adUnit: 'READr_pc_data_970x250_HD',
+      adSlot: '7482289918',
+      adSize: [970, 250],
+    },
+    PC_FT: {
+      adUnit: 'READr_pc_data_970x250_FT',
+      adSlot: '3181180307',
+      adSize: [970, 250],
+    },
+    PC_AT1: {
+      adUnit: 'READr_pc_data_640x390_AT1',
+      adSlot: '2757728224',
+      adSize: [640, 390],
+    },
+    PC_AT2: {
+      adUnit: 'READr_pc_data_640x390_AT2',
+      adSlot: '9470159003',
+      adSize: [640, 390],
+    },
+    PC_E1: {
+      adUnit: 'READr_pc_data_640x390_E1',
+      adSlot: '2196235845',
+      adSize: [640, 390],
+    },
+  },
+
+  // page key: 新聞幕後, note
+  [note]: {
+    MB_HD: {
+      adUnit: 'READr_m_note_300x250_HD',
+      adSlot: '9964983024',
+      adSize: [300, 250],
+    },
+    MB_FT: {
+      adUnit: 'READr_m_note_300x250_FT',
+      adSlot: '2606519131',
+      adSize: [300, 250],
+    },
+    MB_AT1: {
+      adUnit: 'READr_m_note_300x250_AT1',
+      adSlot: '9415470065',
+      adSize: [300, 250],
+    },
+    MB_AT2: {
+      adUnit: 'READr_m_note_300x250_AT2',
+      adSlot: '6729596979',
+      adSize: [300, 250],
+    },
+    MB_E1: {
+      adUnit: 'READr_m_note_300x250_E1',
+      adSlot: '5070645340',
+      adSize: [300, 250],
+    },
+    PC_HD: {
+      adUnit: 'READr_pc_note_970x250_HD',
+      adSlot: '7886712075',
+      adSize: [970, 250],
+    },
+    PC_FT: {
+      adUnit: 'READr_pc_note_970x250_FT',
+      adSlot: '6928853620',
+      adSize: [970, 250],
+    },
+    PC_AT1: {
+      adUnit: 'READr_pc_note_640x390_AT1',
+      adSlot: '9131564887',
+      adSize: [640, 390],
+    },
+    PC_AT2: {
+      adUnit: 'READr_pc_note_640x390_AT2',
+      adSlot: '4830138041',
+      adSize: [640, 390],
+    },
+    PC_E1: {
+      adUnit: 'READr_pc_note_640x390_E1',
+      adSlot: '7267501645',
+      adSize: [640, 390],
+    },
+  },
+
+  // page key: COVID-19, covid19
+  [covid19]: {
+    MB_HD: {
+      adUnit: 'READr_m_covid19_300x250_HD',
+      adSlot: '4585815215',
+      adSize: [300, 250],
+    },
+    MB_FT: {
+      adUnit: 'READr_m_covid19_300x250_FT',
+      adSlot: '4798348457',
+      adSize: [300, 250],
+    },
+    MB_AT1: {
+      adUnit: 'READr_m_covid19_300x250_AT1',
+      adSlot: '1536980040',
+      adSize: [300, 250],
+    },
+    MB_AT2: {
+      adUnit: 'READr_m_covid19_300x250_AT2',
+      adSlot: '5416515307',
+      adSize: [300, 250],
+    },
+    MB_E1: {
+      adUnit: 'READr_m_covid19_300x250_E1',
+      adSlot: '7740260465',
+      adSize: [300, 250],
+    },
+    PC_HD: {
+      adUnit: 'READr_pc_covid19_970x250_HD',
+      adSlot: '3878086825',
+      adSize: [970, 250],
+    },
+    PC_FT: {
+      adUnit: 'READr_pc_covid19_970x250_FT',
+      adSlot: '9606987857',
+      adSize: [970, 250],
+    },
+    PC_AT1: {
+      adUnit: 'READr_pc_covid19_640x390_AT1',
+      adSlot: '6505401541',
+      adSize: [640, 390],
+    },
+    PC_AT2: {
+      adUnit: 'READr_pc_covid19_640x390_AT2',
+      adSlot: '9890893031',
+      adSize: [640, 390],
+    },
+    PC_E1: {
+      adUnit: 'READr_pc_covid19_640x390_E1',
+      adSlot: '3930891860',
+      adSize: [640, 390],
+    },
+  },
+
+  // page key: 文化, culture
+  [culture]: {
+    MB_HD: {
+      adUnit: 'READr_m_culture_300x250_HD',
+      adSlot: '6219241338',
+      adSize: [300, 250],
+    },
+    MB_FT: {
+      adUnit: 'READr_m_culture_300x250_FT',
+      adSlot: '8980355792',
+      adSize: [300, 250],
+    },
+    MB_AT1: {
+      adUnit: 'READr_m_culture_300x250_AT1',
+      adSlot: '5284653365',
+      adSize: [300, 250],
+    },
+    MB_AT2: {
+      adUnit: 'READr_m_culture_300x250_AT2',
+      adSlot: '4103433633',
+      adSize: [300, 250],
+    },
+    MB_E1: {
+      adUnit: 'READr_m_culture_300x250_E1',
+      adSlot: '7927962727',
+      adSize: [300, 250],
+    },
+    PC_HD: {
+      adUnit: 'READr_pc_culture_970x250_HD',
+      adSlot: '6273467250',
+      adSize: [970, 250],
+    },
+    PC_FT: {
+      adUnit: 'READr_pc_culture_970x250_FT',
+      adSlot: '1947989684',
+      adSize: [970, 250],
+    },
+    PC_AT1: {
+      adUnit: 'READr_pc_culture_640x390_AT1',
+      adSlot: '2385875908',
+      adSize: [640, 390],
+    },
+    PC_AT2: {
+      adUnit: 'READr_pc_culture_640x390_AT2',
+      adSlot: '9890893031',
+      adSize: [640, 390],
+    },
+    PC_E1: {
+      adUnit: 'READr_pc_culture_640x390_E1',
+      adSlot: '3325484681',
+      adSize: [640, 390],
+    },
+  },
+
+  // page key: 國際, international
+  [international]: {
+    MB_HD: {
+      adUnit: 'READr_m_international_300x250_HD',
+      adSlot: '3272733547',
+      adSize: [300, 250],
+    },
+    MB_FT: {
+      adUnit: 'READr_m_international_300x250_FT',
+      adSlot: '6469742526',
+      adSize: [300, 250],
+    },
+    MB_AT1: {
+      adUnit: 'READr_m_international_300x250_AT1',
+      adSlot: '7719245017',
+      adSize: [300, 250],
+    },
+    MB_AT2: {
+      adUnit: 'READr_m_international_300x250_AT2',
+      adSlot: '3679610422',
+      adSize: [300, 250],
+    },
+    MB_E1: {
+      adUnit: 'READr_m_international_300x250_E1',
+      adSlot: '6427178795',
+      adSize: [300, 250],
+    },
+    PC_HD: {
+      adUnit: 'READr_pc_international_970x250_HD',
+      adSlot: '7290718225',
+      adSize: [970, 250],
+    },
+    PC_FT: {
+      adUnit: 'READr_pc_international_970x250_FT',
+      adSlot: '1728497833',
+      adSize: [970, 250],
+    },
+    PC_AT1: {
+      adUnit: 'READr_pc_international_640x390_AT1',
+      adSlot: '1072794231',
+      adSize: [640, 390],
+    },
+    PC_AT2: {
+      adUnit: 'READr_pc_international_640x390_AT2',
+      adSlot: '9985481559',
+      adSize: [640, 390],
+    },
+    PC_E1: {
+      adUnit: 'READr_pc_international_640x390_E1',
+      adSlot: '4449766617',
+      adSize: [640, 390],
+    },
+  },
+
+  // page key: 交通, traffic
+  [traffic]: {
+    MB_HD: {
+      adUnit: 'READr_m_traffic_300x250_HD',
+      adSlot: '2279996326',
+      adSize: [300, 250],
+    },
+    MB_FT: {
+      adUnit: 'READr_m_traffic_300x250_FT',
+      adSlot: '8788784106',
+      adSize: [300, 250],
+    },
+    MB_AT1: {
+      adUnit: 'READr_m_traffic_300x250_AT1',
+      adSlot: '7048009798',
+      adSize: [300, 250],
+    },
+    MB_AT2: {
+      adUnit: 'READr_m_traffic_300x250_AT2',
+      adSlot: '7751034608',
+      adSize: [300, 250],
+    },
+    MB_E1: {
+      adUnit: 'READr_m_traffic_300x250_E1',
+      adSlot: '6192155322',
+      adSize: [300, 250],
+    },
+    PC_HD: {
+      adUnit: 'READr_pc_traffic_970x250_HD',
+      adSlot: '4664554889',
+      adSize: [970, 250],
+    },
+    PC_FT: {
+      adUnit: 'READr_pc_traffic_970x250_FT',
+      adSlot: '8321826348',
+      adSize: [970, 250],
+    },
+    PC_AT1: {
+      adUnit: 'READr_pc_traffic_640x390_AT1',
+      adSlot: '4538494005',
+      adSize: [640, 390],
+    },
+    PC_AT2: {
+      adUnit: 'READr_pc_traffic_640x390_AT2',
+      adSlot: '7073158008',
+      adSize: [640, 390],
+    },
+    PC_E1: {
+      adUnit: 'READr_pc_traffic_640x390_E1',
+      adSlot: '1823603275',
+      adSize: [640, 390],
+    },
+  },
+}
+
+export { ADSENSE_UNITS }

--- a/packages/readr/constants/constant.ts
+++ b/packages/readr/constants/constant.ts
@@ -11,6 +11,21 @@ const DEFAULT_CATEGORY: NavigationCategory = {
   slug: 'all',
 }
 
+const CATEGORY_SLUGS = {
+  breakingnews: 'breakingnews',
+  education: 'education',
+  politics: 'politics',
+  humanrights: 'humanrights',
+  environment: 'environment',
+  omt: 'omt',
+  data: 'data',
+  note: 'note',
+  covid19: 'covid19',
+  culture: 'culture',
+  international: 'international',
+  traffic: 'traffic',
+}
+
 const POST_STYLES: string[] = [
   ValidPostStyle.NEWS,
   ValidPostStyle.FRAME,
@@ -24,6 +39,7 @@ const REPORT_STYLES: string[] = [
 ]
 
 export {
+  CATEGORY_SLUGS,
   DEFAULT_CATEGORY,
   DEFAULT_POST_IMAGE_PATH,
   POST_STYLES,

--- a/packages/readr/constants/environment-variables.ts
+++ b/packages/readr/constants/environment-variables.ts
@@ -6,6 +6,7 @@ let GTM_ID: string
 let DONATION_PAGE_URL: string
 let QA_RECORD_CONFIG: { variables: Record<string, string> }
 let GLOBAL_CACHE_SETTING: string
+let GOOGLE_ADSENSE_AD_CLIENT: string
 
 switch (ENV) {
   case 'prod':
@@ -15,6 +16,7 @@ switch (ENV) {
     DONATION_PAGE_URL = 'https://readr.oen.tw/good'
     QA_RECORD_CONFIG = { variables: { id1: '6', id2: '7' } }
     GLOBAL_CACHE_SETTING = 'public, max-age=300'
+    GOOGLE_ADSENSE_AD_CLIENT = 'ca-pub-9990785780499264'
     break
 
   case 'staging':
@@ -24,6 +26,7 @@ switch (ENV) {
     DONATION_PAGE_URL = 'https://readr.oen.tw/good'
     QA_RECORD_CONFIG = { variables: { id1: '6', id2: '7' } }
     GLOBAL_CACHE_SETTING = 'public, max-age=300'
+    GOOGLE_ADSENSE_AD_CLIENT = 'ca-pub-9990785780499264'
     break
 
   case 'dev':
@@ -33,6 +36,7 @@ switch (ENV) {
     DONATION_PAGE_URL = 'https://readr.testing.oen.tw/good'
     QA_RECORD_CONFIG = { variables: { id1: '8', id2: '9' } }
     GLOBAL_CACHE_SETTING = 'no-store'
+    GOOGLE_ADSENSE_AD_CLIENT = 'ca-pub-9990785780499264'
     break
 
   default:
@@ -42,6 +46,7 @@ switch (ENV) {
     DONATION_PAGE_URL = 'https://readr.testing.oen.tw/good'
     QA_RECORD_CONFIG = { variables: { id1: '8', id2: '9' } }
     GLOBAL_CACHE_SETTING = 'no-store'
+    GOOGLE_ADSENSE_AD_CLIENT = 'ca-pub-9990785780499264'
     break
 }
 
@@ -50,6 +55,7 @@ export {
   ENV,
   GA_TRACKING_ID,
   GLOBAL_CACHE_SETTING,
+  GOOGLE_ADSENSE_AD_CLIENT,
   GTM_ID,
   QA_RECORD_CONFIG,
   SITE_URL,

--- a/packages/readr/pages/_document.tsx
+++ b/packages/readr/pages/_document.tsx
@@ -8,8 +8,8 @@ import Document, {
 import Script from 'next/script'
 import { ServerStyleSheet } from 'styled-components'
 
+import AdsenseScript from '~/components/ad/google-adsense/adsense-script'
 import { GTM_ID } from '~/constants/environment-variables'
-
 export default class MyDocument extends Document {
   /* ref:
    *   1. https://styled-components.com/docs/advanced#with-swc
@@ -84,6 +84,7 @@ export default class MyDocument extends Document {
             name="google-site-verification"
             content="-MwBO0YdSWdyXLTCRzvcfKr-xpY1nBddINN0pGnc7SI"
           />
+
           <Script
             id="google-tag-manager"
             strategy="afterInteractive"
@@ -96,11 +97,8 @@ export default class MyDocument extends Document {
               })(window,document,'script','dataLayer','${GTM_ID}');`,
             }}
           />
-          <script
-            async
-            src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9990785780499264"
-            crossOrigin="anonymous"
-          ></script>
+
+          <AdsenseScript />
         </Head>
         <body>
           <noscript>

--- a/packages/readr/types/ad.tsx
+++ b/packages/readr/types/ad.tsx
@@ -1,0 +1,10 @@
+export type AdsenseParam = {
+  adSlot: string
+  adSize: number[]
+  adUnit: string
+}
+export type AdsenseUnits = {
+  [key: string]: {
+    [key: string]: AdsenseParam
+  }
+}

--- a/packages/readr/utils/ad.ts
+++ b/packages/readr/utils/ad.ts
@@ -1,0 +1,53 @@
+import { ADSENSE_UNITS } from '~/constants/ad'
+import { mediaSize } from '~/styles/theme'
+import type { AdsenseParam } from '~/types/ad'
+
+function getDevice(width: number): 'PC' | 'MB' {
+  const isDesktopWidth = width >= mediaSize.xl
+  return isDesktopWidth ? 'PC' : 'MB'
+}
+
+// Generate full key like 'PC_HD' if the component support dynamic device adKey like 'HD'
+function getAdFullKey(device: 'PC' | 'MB', adKey: string): string {
+  return adKey.includes('_') ? adKey : `${device}_${adKey}`
+}
+
+function getAdData(
+  pageKey: string,
+  adKey: string,
+  width: number
+): AdsenseParam | undefined {
+  const device = getDevice(width)
+  const adFullKey = getAdFullKey(device, adKey)
+  const adData = ADSENSE_UNITS[pageKey]?.[adFullKey]
+  if (!adData) {
+    console.error(
+      `Unable to find the AD data. Got the pageKey "${pageKey}" and adKey "${adFullKey}". Please provide a valid pageKey or adKey.`
+    )
+  }
+  return adData
+}
+
+export function getAdParam(
+  pageKey: string,
+  adKey: string,
+  width: number
+): AdsenseParam | undefined {
+  const adData = getAdData(pageKey, adKey, width)
+  if (!adData) {
+    return
+  }
+  const { adSlot, adSize, adUnit } = adData
+  return { adSlot, adSize, adUnit }
+}
+
+export function getAdParamBySlot(adSlot: string): AdsenseParam | null {
+  for (const [, pageUnits] of Object.entries(ADSENSE_UNITS)) {
+    for (const [, unit] of Object.entries(pageUnits)) {
+      if (unit.adSlot === adSlot) {
+        return { adUnit: unit.adUnit, adSize: unit.adSize, adSlot }
+      }
+    }
+  }
+  return null
+}


### PR DESCRIPTION
# Feature
- 新增 Google `Adsense` 廣告元件。
- 設定/修改 `Adsense` 全站設定（將 script 改於 `adsense-script.tsx` 元件中統一管理）。
- 新增 `Adsense Units` ：廣告名稱 (adUnit) / 尺寸 (adSize) / Slot (adSlot) 。
- 新增 ad utils 處理 `Adsense` 資料邏輯（大多沿用 GPT 廣告設定）。
- 新增 `Adsense` types 設定。

## 設定

- 埋設廣告內容可透過：

   1. 填入 `pageKey` + `adKey`。`adKey` 不一定需要有 `PC` or `MB` 資訊，元件會協助判斷（同 GPT 廣告設定）。
   2. 直接填入 `slot`。

- 當取得廣告內容後，`Adsense` 元件會自動生成對應的寬高（同 Adsense Units 裡 adSize 大小）。如需其他特殊樣式設定，需在埋設的頁面自行修改元件樣式。


## 開發
如需在 local 端查看 Adsense 廣告效果，可照以下步驟進行設定：
- 於 terminal 中輸入：`sudo vim /etc/hosts`
- 在 Host Database 中加入：「127.0.0.1   v3-dev.readr.tw」 或「127.0.0.1  dev.readr.tw」並儲存。
- 透過 http://v3-dev.readr.tw:3000/ 或 http://dev.readr.tw:3000/  即可於 local 查看網站中 Adsense 廣告內容。

## Follow up
- READr 3.0 因無會員功能，目前一律會顯示 `Adsense` 廣告。
- Adsense 廣告有 `adTest` 參數，用於設定廣告是否為測試 or 正式可獲利用。目前設定在 `ENV` 為 `dev` 時，adTest 為 `on`（測試用），其他狀態下皆為 `off`（正式可獲利）。[官方文件 ](https://developers.google.com/custom-search-ads/ios/reference?hl=zh-tw)


## Related PR
- [GPT ad 設定](https://github.com/mirror-media/Adam/pull/252)（部分設定沿用參考 GPT 廣告）

## Reference
- [READr 3.0 廣告工程指南](https://paper.dropbox.com/doc/READr-3.0--B~IhuFuYQc1cnPWW~NSKGIFeAg-swSDNJsiRqt5r5h6x0G7d)
