### PR TITLE
feat(readr/_app): fetch header data from static JSON file

### DIFF
--- a/packages/readr/constants/constant.ts
+++ b/packages/readr/constants/constant.ts
@@ -38,9 +38,61 @@ const REPORT_STYLES: string[] = [
   ValidPostStyle.REPORT,
 ]
 
+const DEFAULT_HEADER_CATEGORY_LIST = [
+  {
+    id: '1',
+    slug: 'breakingnews',
+    title: '時事',
+    posts: [],
+    ogDescription: '',
+    ogImage: null,
+  },
+  {
+    id: '2',
+    slug: 'education',
+    title: '教育',
+    posts: [],
+    ogDescription: '',
+    ogImage: null,
+  },
+  {
+    id: '3',
+    slug: 'politics',
+    title: '政治',
+    posts: [],
+    ogDescription: '',
+    ogImage: null,
+  },
+  {
+    id: '4',
+    slug: 'humanrights',
+    title: '人權',
+    posts: [],
+    ogDescription: '',
+    ogImage: null,
+  },
+  {
+    id: '5',
+    slug: 'environment',
+    title: '環境',
+    posts: [],
+    ogDescription: '',
+    ogImage: null,
+  },
+  {
+    id: '6',
+    slug: 'omt',
+    title: '新鮮事',
+    posts: [],
+    ogDescription: '',
+    ogImage: null,
+  },
+]
+
 export {
   CATEGORY_SLUGS,
   DEFAULT_CATEGORY,
+  DEFAULT_HEADER_CATEGORY_LIST,
   DEFAULT_POST_IMAGE_PATH,
   POST_STYLES,
   REPORT_STYLES,

--- a/packages/readr/constants/environment-variables.ts
+++ b/packages/readr/constants/environment-variables.ts
@@ -19,7 +19,7 @@ switch (ENV) {
     GLOBAL_CACHE_SETTING = 'public, max-age=300'
     GOOGLE_ADSENSE_AD_CLIENT = 'ca-pub-9990785780499264'
     HEADER_JSON_URL =
-      'https://storage.googleapis.com/statics-readr-tw-prod/json/sections.json'
+      'https://storage.googleapis.com/statics-readr-tw-prod/json/header.json'
     break
 
   case 'staging':
@@ -31,7 +31,7 @@ switch (ENV) {
     GLOBAL_CACHE_SETTING = 'public, max-age=300'
     GOOGLE_ADSENSE_AD_CLIENT = 'ca-pub-9990785780499264'
     HEADER_JSON_URL =
-      'https://storage.googleapis.com/statics-readr-tw-staging/json/sections.json'
+      'https://storage.googleapis.com/statics-readr-tw-staging/json/header.json'
     break
 
   case 'dev':
@@ -43,7 +43,7 @@ switch (ENV) {
     GLOBAL_CACHE_SETTING = 'no-store'
     GOOGLE_ADSENSE_AD_CLIENT = 'ca-pub-9990785780499264'
     HEADER_JSON_URL =
-      'https://storage.googleapis.com/statics-readr-tw-dev/json/sections.json'
+      'https://storage.googleapis.com/statics-readr-tw-dev/json/header.json'
     break
 
   default:
@@ -55,7 +55,7 @@ switch (ENV) {
     GLOBAL_CACHE_SETTING = 'no-store'
     GOOGLE_ADSENSE_AD_CLIENT = 'ca-pub-9990785780499264'
     HEADER_JSON_URL =
-      'https://storage.googleapis.com/statics-readr-tw-dev/json/sections.json'
+      'https://storage.googleapis.com/statics-readr-tw-dev/json/header.json'
     break
 }
 

--- a/packages/readr/constants/environment-variables.ts
+++ b/packages/readr/constants/environment-variables.ts
@@ -7,6 +7,7 @@ let DONATION_PAGE_URL: string
 let QA_RECORD_CONFIG: { variables: Record<string, string> }
 let GLOBAL_CACHE_SETTING: string
 let GOOGLE_ADSENSE_AD_CLIENT: string
+let HEADER_JSON_URL: string
 
 switch (ENV) {
   case 'prod':
@@ -17,6 +18,8 @@ switch (ENV) {
     QA_RECORD_CONFIG = { variables: { id1: '6', id2: '7' } }
     GLOBAL_CACHE_SETTING = 'public, max-age=300'
     GOOGLE_ADSENSE_AD_CLIENT = 'ca-pub-9990785780499264'
+    HEADER_JSON_URL =
+      'https://storage.googleapis.com/statics-readr-tw-prod/json/sections.json'
     break
 
   case 'staging':
@@ -27,6 +30,8 @@ switch (ENV) {
     QA_RECORD_CONFIG = { variables: { id1: '6', id2: '7' } }
     GLOBAL_CACHE_SETTING = 'public, max-age=300'
     GOOGLE_ADSENSE_AD_CLIENT = 'ca-pub-9990785780499264'
+    HEADER_JSON_URL =
+      'https://storage.googleapis.com/statics-readr-tw-staging/json/sections.json'
     break
 
   case 'dev':
@@ -37,6 +42,8 @@ switch (ENV) {
     QA_RECORD_CONFIG = { variables: { id1: '8', id2: '9' } }
     GLOBAL_CACHE_SETTING = 'no-store'
     GOOGLE_ADSENSE_AD_CLIENT = 'ca-pub-9990785780499264'
+    HEADER_JSON_URL =
+      'https://storage.googleapis.com/statics-readr-tw-dev/json/sections.json'
     break
 
   default:
@@ -47,6 +54,8 @@ switch (ENV) {
     QA_RECORD_CONFIG = { variables: { id1: '8', id2: '9' } }
     GLOBAL_CACHE_SETTING = 'no-store'
     GOOGLE_ADSENSE_AD_CLIENT = 'ca-pub-9990785780499264'
+    HEADER_JSON_URL =
+      'https://storage.googleapis.com/statics-readr-tw-dev/json/sections.json'
     break
 }
 
@@ -57,6 +66,7 @@ export {
   GLOBAL_CACHE_SETTING,
   GOOGLE_ADSENSE_AD_CLIENT,
   GTM_ID,
+  HEADER_JSON_URL,
   QA_RECORD_CONFIG,
   SITE_URL,
 }

--- a/packages/readr/graphql/query/category.ts
+++ b/packages/readr/graphql/query/category.ts
@@ -20,7 +20,6 @@ export type Category = Override<
     posts?: Post[]
     reports?: Post[]
     ogImage?: PhotoWithResizedOnly | null
-    relatedPostTypes?: Post[]
   }
 >
 

--- a/packages/readr/graphql/query/category.ts
+++ b/packages/readr/graphql/query/category.ts
@@ -21,7 +21,6 @@ export type Category = Override<
     reports?: Post[]
     ogImage?: PhotoWithResizedOnly | null
     relatedPostTypes?: Post[]
-    relatedReportTypes?: Post[]
   }
 >
 

--- a/packages/readr/graphql/query/category.ts
+++ b/packages/readr/graphql/query/category.ts
@@ -20,6 +20,8 @@ export type Category = Override<
     posts?: Post[]
     reports?: Post[]
     ogImage?: PhotoWithResizedOnly | null
+    relatedPostTypes?: Post[]
+    relatedReportTypes?: Post[]
   }
 >
 

--- a/packages/readr/pages/_app.tsx
+++ b/packages/readr/pages/_app.tsx
@@ -21,6 +21,8 @@ import theme from '~/styles/theme'
 import type { NavigationCategory } from '~/types/component'
 import * as gtag from '~/utils/gtag'
 
+import { DEFAULT_HEADER_CATEGORY_LIST } from '../constants/constant'
+
 export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
   getLayout?: (
     /* eslint-disable-line no-unused-vars */ page: ReactElement
@@ -53,6 +55,10 @@ const MyApp = ({ Component, pageProps, props }: AppPropsWithLayout) => {
   // Use the layout defined at the page level, if available
   const getLayout = Component.getLayout ?? ((page) => page)
 
+  // Use props.categoriesAndRelatedPosts if defined, otherwise use DEFAULT_HEADER_CATEGORY_LIST
+  const headerCategoriesAndRelatedPosts =
+    props.categoriesAndRelatedPosts || DEFAULT_HEADER_CATEGORY_LIST
+
   return (
     <>
       <NormalizeStyles />
@@ -60,7 +66,7 @@ const MyApp = ({ Component, pageProps, props }: AppPropsWithLayout) => {
       <ApolloProvider client={client}>
         <ThemeProvider theme={theme}>
           <HeaderCategoriesAndRelatePostsContext.Provider
-            value={props.categoriesAndRelatedPosts}
+            value={headerCategoriesAndRelatedPosts}
           >
             <CategoryListContext.Provider value={props.categoryList}>
               {getLayout(<Component {...pageProps} />)}
@@ -91,7 +97,7 @@ MyApp.getInitialProps = async (context: AppContext) => {
   const ctx = await App.getInitialProps(context)
 
   try {
-    // Fetch data from the JSON file
+    // Fetch header data from the JSON file
     const { data: jsonCategories } = await axios.get(
       'https://storage.googleapis.com/statics-readr-tw-dev/json/sections.json'
     )

--- a/packages/readr/pages/_app.tsx
+++ b/packages/readr/pages/_app.tsx
@@ -102,8 +102,9 @@ MyApp.getInitialProps = async (context: AppContext) => {
     const { data: jsonCategories } = await axios.get(HEADER_JSON_URL)
 
     // Combine relatedPostTypes and relatedReportTypes into posts for each category
-    const categoriesAndRelatedPosts: Category[] = jsonCategories.categories.map(
-      (category: Category) => {
+    const categoriesAndRelatedPosts: Category[] = jsonCategories.categories
+      .slice(0, 6)
+      .map((category: Category) => {
         const relatedPostTypes = category.relatedPostTypes || []
         const relatedReportTypes = category.relatedReportTypes || []
 
@@ -119,8 +120,7 @@ MyApp.getInitialProps = async (context: AppContext) => {
             })),
           ],
         }
-      }
-    )
+      })
 
     const categoryList: NavigationCategory[] = categoriesAndRelatedPosts
 

--- a/packages/readr/pages/_app.tsx
+++ b/packages/readr/pages/_app.tsx
@@ -22,6 +22,7 @@ import type { NavigationCategory } from '~/types/component'
 import * as gtag from '~/utils/gtag'
 
 import { DEFAULT_HEADER_CATEGORY_LIST } from '../constants/constant'
+import { HEADER_JSON_URL } from '../constants/environment-variables'
 
 export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
   getLayout?: (
@@ -98,9 +99,7 @@ MyApp.getInitialProps = async (context: AppContext) => {
 
   try {
     // Fetch header data from the JSON file
-    const { data: jsonCategories } = await axios.get(
-      'https://storage.googleapis.com/statics-readr-tw-dev/json/sections.json'
-    )
+    const { data: jsonCategories } = await axios.get(HEADER_JSON_URL)
 
     // Combine relatedPostTypes and relatedReportTypes into posts for each category
     const categoriesAndRelatedPosts: Category[] = jsonCategories.categories.map(

--- a/packages/readr/pages/_app.tsx
+++ b/packages/readr/pages/_app.tsx
@@ -104,16 +104,9 @@ MyApp.getInitialProps = async (context: AppContext) => {
     const categoriesAndRelatedPosts: Category[] = jsonCategories.categories
       .slice(0, 6)
       .map((category: Category) => {
-        const relatedPostTypes = category.relatedPostTypes || []
-
         return {
           ...category,
-          posts: [
-            ...(category.posts || []).slice(0, 5), // Limit to 5 existing posts
-            ...relatedPostTypes.map((postType) => ({
-              ...postType,
-            })),
-          ],
+          posts: [...(category.posts || []).slice(0, 5)],
         }
       })
 

--- a/packages/readr/pages/_app.tsx
+++ b/packages/readr/pages/_app.tsx
@@ -101,22 +101,17 @@ MyApp.getInitialProps = async (context: AppContext) => {
     // Fetch header data from the JSON file
     const { data: jsonCategories } = await axios.get(HEADER_JSON_URL)
 
-    // Combine relatedPostTypes and relatedReportTypes into posts for each category
     const categoriesAndRelatedPosts: Category[] = jsonCategories.categories
       .slice(0, 6)
       .map((category: Category) => {
         const relatedPostTypes = category.relatedPostTypes || []
-        const relatedReportTypes = category.relatedReportTypes || []
 
         return {
           ...category,
           posts: [
             ...(category.posts || []).slice(0, 5), // Limit to 5 existing posts
-            ...relatedPostTypes.slice(0, 4).map((postType) => ({
+            ...relatedPostTypes.map((postType) => ({
               ...postType,
-            })),
-            ...relatedReportTypes.slice(0, 1).map((reportType) => ({
-              ...reportType,
             })),
           ],
         }


### PR DESCRIPTION
- 需求描述：將`HeaderCategoriesAndRelatePostsContext`中的 gql data 來源替換成 static JSON file。
- 在 constant 中新增 `DEFAULT_HEADER_CATEGORY_LIST`，避免 header 沒抓到資料的狀況。
- 在 `environment-variables` 新增 `HEADER_JSON_URL` ，目前 prod 及 staging JSON 尚未生成。
- Category 篩選條件新增 `isFeatured`，需在CMS勾選「置頂」才會顯示。
- 每個類別的五篇 Related Posts，目前是抓取四篇 postType，一篇 reportType，可再根據需求做彈性調整。
