### PR TITLE
chore: update dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 
 # Install dependencies based on the preferred package manager
 COPY ["package.json", "yarn.lock", "./"]
-RUN yarn install --frozen-lockfile --production
+RUN yarn install --frozen-lockfile
 
 # Rebuild the source code only when needed
 FROM node:${NODE_VERSION} AS builder


### PR DESCRIPTION
## Reminders
調整 build 過程中，安裝 node package 的行為，避免型別檢查所需的 `@types/node`, `@types/react` 隨意跳動