### PR TITLE
feat(pt/politics-detail): add `response` components

### DIFF
--- a/packages/politics-tracker/components/politics-detail/section-content.tsx
+++ b/packages/politics-tracker/components/politics-detail/section-content.tsx
@@ -4,12 +4,12 @@ import styled from 'styled-components'
 import ToggleItem from '~/components/politics-detail/shared/toggle-item'
 import Detail from '~/components/politics-detail/toggle-lists/detail'
 import Dispute from '~/components/politics-detail/toggle-lists/dispute'
-import ExpertPoint from '~/components/politics-detail/toggle-lists/expert-point/index'
-import FactCheck from '~/components/politics-detail/toggle-lists/fact-check/index'
-import PositionChange, {
-  PositionChangeIcon,
-} from '~/components/politics-detail/toggle-lists/position-change'
-import Repeat from '~/components/politics-detail/toggle-lists/repeat/index'
+import ExpertPoint from '~/components/politics-detail/toggle-lists/expert-point'
+import FactCheck from '~/components/politics-detail/toggle-lists/fact-check'
+import PositionChange from '~/components/politics-detail/toggle-lists/position-change'
+import PositionChangeIcon from '~/components/politics-detail/toggle-lists/position-change/position-icon'
+import Repeat from '~/components/politics-detail/toggle-lists/repeat'
+import Response from '~/components/politics-detail/toggle-lists/response'
 import TimeLine from '~/components/politics-detail/toggle-lists/timeline'
 
 const Wrapper = styled.div`
@@ -55,6 +55,7 @@ export default function SectionContent({
     factCheck,
     updatedAt,
     repeat,
+    response,
   } = politicData
 
   const toggleItems: ToggleItems[] = [
@@ -82,6 +83,11 @@ export default function SectionContent({
     {
       title: '相似政見',
       children: <Repeat repeats={repeat} />,
+      show: Boolean(repeat.length),
+    },
+    {
+      title: '候選人回應',
+      children: <Response responses={response} />,
       show: Boolean(repeat.length),
     },
     {

--- a/packages/politics-tracker/components/politics-detail/toggle-lists/expert-point/expert-item.tsx
+++ b/packages/politics-tracker/components/politics-detail/toggle-lists/expert-point/expert-item.tsx
@@ -25,7 +25,7 @@ const Header = styled.div`
 const Content = styled.div`
   margin-bottom: 15px;
 
-  .point {
+  > p {
     font-weight: 500;
     font-size: 16px;
     line-height: 1.8;
@@ -34,12 +34,6 @@ const Content = styled.div`
 
     & + * {
       margin-top: 12px;
-    }
-  }
-
-  ${({ theme }) => theme.breakpoint.md} {
-    .point {
-      font-size: 18px;
     }
   }
 `
@@ -53,6 +47,7 @@ const ExpertImage = styled.div`
   margin-right: 10px;
   border-radius: 50%;
   overflow: hidden;
+  border: 2px solid ${({ theme }) => theme.textColor.white};
 
   ${({ theme }) => theme.breakpoint.md} {
     width: 60px;
@@ -67,7 +62,10 @@ const Name = styled.p`
   font-size: 16px;
   line-height: 1.3;
   color: ${({ theme }) => theme.textColor.black};
-  margin-bottom: 2px;
+
+  & + * {
+    margin-top: 4px;
+  }
 
   ${({ theme }) => theme.breakpoint.md} {
     font-size: 18px;
@@ -76,12 +74,11 @@ const Name = styled.p`
 
 const Title = styled.p`
   font-weight: 500;
-  font-size: 14px;
-  line-height: 1.5;
+  font-size: 12px;
   color: ${({ theme }) => theme.backgroundColor.black50};
 
   ${({ theme }) => theme.breakpoint.md} {
-    font-size: 16px;
+    font-size: 14px;
   }
 `
 

--- a/packages/politics-tracker/components/politics-detail/toggle-lists/position-change/index.tsx
+++ b/packages/politics-tracker/components/politics-detail/toggle-lists/position-change/index.tsx
@@ -1,8 +1,5 @@
 import styled from 'styled-components'
 
-import DefaultText from '~/components/politics-detail/default-text'
-import ChangedIcon from '~/public/icons/position-changed.svg'
-import ConsistentIcon from '~/public/icons/position-consistent.svg'
 import type { PositionChange } from '~/types/politics-detail'
 import { getFormattedDate } from '~/utils/utils'
 
@@ -69,23 +66,6 @@ const ContentBlock = styled.div`
   }
 `
 
-const IconBlock = styled.div`
-  font-weight: 500;
-  font-size: 14px;
-  display: flex;
-  align-items: center;
-
-  .changed {
-    color: rgba(178, 128, 13, 1);
-    margin-left: 5px;
-  }
-
-  .consistent {
-    color: rgba(131, 131, 131, 1);
-    margin-left: 5px;
-  }
-`
-
 type PositionChangeProps = {
   positions: PositionChange[]
 }
@@ -103,7 +83,7 @@ export default function PositionChange({
             <a
               className="content-text"
               href={link ? link : '/'}
-              target="_blank"
+              target={link ? '_blank' : '_self'}
               rel="noopener noreferrer"
             >
               {content}
@@ -122,33 +102,7 @@ export default function PositionChange({
 
   return (
     <Wrapper>
-      {!!positions.length ? (
-        <ul>{positionLists}</ul>
-      ) : (
-        <DefaultText title="立場變化" />
-      )}
+      <ul>{positionLists}</ul>
     </Wrapper>
-  )
-}
-
-export function PositionChangeIcon({
-  positions = [],
-}: PositionChangeProps): JSX.Element {
-  const hasChangedPosition = positions.some((item) => item.isChanged !== false)
-
-  return (
-    <IconBlock>
-      {hasChangedPosition ? (
-        <>
-          <ChangedIcon />
-          <span className="changed"> 立場轉變</span>
-        </>
-      ) : (
-        <>
-          <ConsistentIcon />
-          <span className="consistent"> 立場一致</span>
-        </>
-      )}
-    </IconBlock>
   )
 }

--- a/packages/politics-tracker/components/politics-detail/toggle-lists/position-change/position-icon.tsx
+++ b/packages/politics-tracker/components/politics-detail/toggle-lists/position-change/position-icon.tsx
@@ -1,0 +1,47 @@
+import styled from 'styled-components'
+
+import ChangedIcon from '~/public/icons/position-changed.svg'
+import ConsistentIcon from '~/public/icons/position-consistent.svg'
+import type { PositionChange } from '~/types/politics-detail'
+
+const IconBlock = styled.div`
+  font-weight: 500;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+
+  .changed {
+    color: rgba(178, 128, 13, 1);
+    margin-left: 5px;
+  }
+
+  .consistent {
+    color: rgba(131, 131, 131, 1);
+    margin-left: 5px;
+  }
+`
+
+type PositionIconProps = {
+  positions: PositionChange[]
+}
+export default function PositionChangeIcon({
+  positions = [],
+}: PositionIconProps): JSX.Element {
+  const hasChangedPosition = positions.some((item) => item.isChanged !== false)
+
+  return (
+    <IconBlock>
+      {hasChangedPosition ? (
+        <>
+          <ChangedIcon />
+          <span className="changed"> 立場轉變</span>
+        </>
+      ) : (
+        <>
+          <ConsistentIcon />
+          <span className="consistent"> 立場一致</span>
+        </>
+      )}
+    </IconBlock>
+  )
+}

--- a/packages/politics-tracker/components/politics-detail/toggle-lists/repeat/repeat-item.tsx
+++ b/packages/politics-tracker/components/politics-detail/toggle-lists/repeat/repeat-item.tsx
@@ -3,8 +3,6 @@ import styled from 'styled-components'
 
 import RelatedLinks from '~/components/politics-detail/related-links'
 import { SOURCE_DELIMITER } from '~/constants/politics'
-import CorrectIcon from '~/public/icons/factcheck-correct.svg'
-import IncorrectIcon from '~/public/icons/factcheck-incorrect.svg'
 import type { Repeat } from '~/types/politics-detail'
 
 const ListWrapper = styled.li`
@@ -82,25 +80,6 @@ const PartnerInfo = styled.div`
   align-items: center;
 `
 
-const Status = styled.div<{ status: boolean }>`
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  font-weight: 500;
-  font-size: 12px;
-  margin-bottom: 12px;
-  color: ${({ theme, status }) =>
-    status ? theme.textColor.green : theme.textColor.red};
-
-  svg {
-    margin-right: 4px;
-  }
-
-  ${({ theme }) => theme.breakpoint.md} {
-    font-size: 14px;
-  }
-`
-
 const SubTitle = styled.span`
   font-size: 12px;
   color: ${({ theme }) => theme.textColor.black50};
@@ -134,8 +113,7 @@ type RepeatItemProps = {
 export default function RepeatItem({
   repeatItem,
 }: RepeatItemProps): JSX.Element {
-  const { checkResultType, link, content, factcheckPartner, contributer } =
-    repeatItem
+  const { link, content, factcheckPartner, contributer } = repeatItem
 
   const factText = content.split(SOURCE_DELIMITER).map((item, index) => {
     return (
@@ -158,7 +136,6 @@ export default function RepeatItem({
                 priority={false}
               />
             </PartnerImage>
-
             {factcheckPartner?.name && <Name>{factcheckPartner?.name}</Name>}
           </PartnerInfo>
 
@@ -168,14 +145,7 @@ export default function RepeatItem({
         {contributer && <Provider>由{contributer}協助提供資料</Provider>}
       </Header>
 
-      <Content>
-        <Status status={checkResultType}>
-          {checkResultType ? <CorrectIcon /> : <IncorrectIcon />}
-          <span>事實釐清：{checkResultType ? '正確' : '錯誤'}</span>
-        </Status>
-
-        {factText}
-      </Content>
+      <Content>{factText}</Content>
       <RelatedLinks links={link} />
     </ListWrapper>
   )

--- a/packages/politics-tracker/components/politics-detail/toggle-lists/response/index.tsx
+++ b/packages/politics-tracker/components/politics-detail/toggle-lists/response/index.tsx
@@ -1,0 +1,25 @@
+import styled from 'styled-components'
+
+import ResponseItem from '~/components/politics-detail/toggle-lists/response/response-item'
+import type { Response } from '~/types/politics-detail'
+
+const Wrapper = styled.div`
+  padding: 12px 0px 40px;
+`
+
+type ResponseProps = {
+  responses: Response[]
+}
+export default function Response({
+  responses = [],
+}: ResponseProps): JSX.Element {
+  return (
+    <Wrapper>
+      <ul>
+        {responses.map((value: Response, index: number) => (
+          <ResponseItem responseItem={value} key={index} />
+        ))}
+      </ul>
+    </Wrapper>
+  )
+}

--- a/packages/politics-tracker/components/politics-detail/toggle-lists/response/response-item.tsx
+++ b/packages/politics-tracker/components/politics-detail/toggle-lists/response/response-item.tsx
@@ -1,0 +1,168 @@
+import Image from '@readr-media/react-image'
+import styled from 'styled-components'
+
+import RelatedLinks from '~/components/politics-detail/related-links'
+import { SOURCE_DELIMITER } from '~/constants/politics'
+import type { Response } from '~/types/politics-detail'
+// import { generateSourceMeta } from '~/utils/utils'
+
+const ListWrapper = styled.li`
+  padding: 20px;
+  background: ${({ theme }) => theme.backgroundColor.black5};
+  border-radius: 20px;
+
+  & + * {
+    margin-top: 12px;
+  }
+`
+
+const Header = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 12px;
+`
+
+const Content = styled.div`
+  margin-bottom: 15px;
+
+  > p {
+    font-weight: 500;
+    font-size: 16px;
+    line-height: 1.8;
+    text-align: justify;
+    color: rgba(15, 45, 53, 0.66);
+
+    & + * {
+      margin-top: 12px;
+    }
+  }
+`
+
+const ResponseImage = styled.div`
+  width: 48px;
+  height: 48px;
+  min-width: 48px;
+  min-height: 48px;
+  margin-right: 10px;
+  border-radius: 50%;
+  overflow: hidden;
+  border: 2px solid ${({ theme }) => theme.textColor.white};
+
+  ${({ theme }) => theme.breakpoint.md} {
+    width: 60px;
+    height: 60px;
+    min-width: 60px;
+    min-height: 60px;
+  }
+`
+
+const Name = styled.p`
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 1.3;
+  color: ${({ theme }) => theme.textColor.black};
+
+  & + * {
+    margin-top: 4px;
+  }
+
+  ${({ theme }) => theme.breakpoint.md} {
+    font-size: 18px;
+  }
+`
+
+const Title = styled.p`
+  font-weight: 500;
+  font-size: 12px;
+  line-height: 1.5;
+  color: ${({ theme }) => theme.backgroundColor.black50};
+
+  ${({ theme }) => theme.breakpoint.md} {
+    font-size: 14px;
+  }
+`
+
+// const Contributer = styled.span`
+//   font-weight: 500;
+//   font-size: 12px;
+//   display: inline-block;
+//   margin-bottom: 10px;
+//   color: ${({ theme }) => theme.backgroundColor.black50};
+
+//   a {
+//     color: ${({ theme }) => theme.textColor.brown};
+//     word-break: break-all;
+//     cursor: pointer;
+//     line-height: 1.5;
+
+//     &:hover {
+//       text-decoration-line: underline;
+//       text-underline-offset: 3.5px;
+//       text-decoration-thickness: 1.5px;
+//     }
+
+//     & + a::before,
+//     & + span::before {
+//       content: '、';
+//       color: ${({ theme }) => theme.backgroundColor.black50};
+//     }
+//   }
+
+//   ${({ theme }) => theme.breakpoint.md} {
+//     font-size: 14px;
+//   }
+// `
+
+type ResponseItemProps = {
+  responseItem: Response
+}
+export default function ResponseItem({
+  responseItem,
+}: ResponseItemProps): JSX.Element {
+  const { responseName, responsePic, responseTitle, content, link } =
+    responseItem
+
+  // const contributers = contributer
+  //   .split(SOURCE_DELIMITER)
+  //   .map((content: string, index: number) => {
+  //     const { isLink, link, text } = generateSourceMeta(content, '', index + 1)
+
+  //     return isLink ? (
+  //       <a key={index} href={link} target="_blank" rel="noopener noreferrer">
+  //         {text}
+  //       </a>
+  //     ) : (
+  //       <span key={index}>{text}</span>
+  //     )
+  //   })
+
+  const responseText = content.split(SOURCE_DELIMITER).map((item, index) => {
+    return <p key={index}>{item}</p>
+  })
+
+  return (
+    <ListWrapper>
+      <Header>
+        <ResponseImage>
+          <Image
+            images={{ original: responsePic }}
+            defaultImage="/images/default-head-photo.png"
+            alt={responseName}
+            priority={false}
+          />
+        </ResponseImage>
+
+        <div>
+          {responseName && <Name>{responseName}</Name>}
+          <Title>{responseTitle}</Title>
+        </div>
+      </Header>
+
+      <Content>
+        {/* {contributer && <Contributer>資料由 {contributers} 提供</Contributer>} */}
+        {responseText}
+      </Content>
+      <RelatedLinks links={link} />
+    </ListWrapper>
+  )
+}

--- a/packages/politics-tracker/graphql/query/politics/get-politic-detail.graphql
+++ b/packages/politics-tracker/graphql/query/politics/get-politic-detail.graphql
@@ -43,17 +43,7 @@ query GetPoliticsDetail($politicId: ID!) {
       content
       link
     }
-    expertPoint(orderBy: { reviewDate: asc }) {
-      id
-      expert
-      avatar
-      contributer
-      title
-      reviewDate
-      content
-      link
-    }
-    positionChange(orderBy: { checkDate: desc }) {
+    positionChange(orderBy: { checkDate: asc }) {
       id
       checkDate
       content
@@ -64,7 +54,17 @@ query GetPoliticsDetail($politicId: ID!) {
         name
       }
     }
-    factCheck(orderBy: { checkDate: desc }) {
+    expertPoint(orderBy: { updatedAt: desc }) {
+      id
+      expert
+      avatar
+      contributer
+      title
+      reviewDate
+      content
+      link
+    }
+    factCheck(orderBy: { updatedAt: desc }) {
       id
       checkResultType
       content
@@ -75,9 +75,8 @@ query GetPoliticsDetail($politicId: ID!) {
         name
       }
     }
-    repeat(orderBy: { checkDate: desc }) {
+    repeat(orderBy: { updatedAt: desc }) {
       id
-      checkResultType
       content
       link
       contributer
@@ -86,6 +85,14 @@ query GetPoliticsDetail($politicId: ID!) {
         sLogo
         name
       }
+    }
+    response(orderBy: { updatedAt: desc }) {
+      id
+      content
+      responseName
+      responsePic
+      responseTitle
+      link
     }
   }
 }

--- a/packages/politics-tracker/types/politics-detail.ts
+++ b/packages/politics-tracker/types/politics-detail.ts
@@ -25,7 +25,6 @@ export type PositionChange = {
 //相似政見
 export type Repeat = {
   id: string
-  checkResultType: boolean
   content: string
   link: string
   contributer: string
@@ -51,6 +50,16 @@ export type ExpertPoint = {
   link: string
   reviewData: string
   title: string
+}
+
+//候選人回應
+export type Response = {
+  id: string
+  content: string
+  responseName: string
+  responsePic: string
+  responseTitle: string
+  link: string
 }
 
 //相關進度


### PR DESCRIPTION
## Notable Changes 
- 新增「候選人回應」元件、type、graphql 設定。
- 移除「相似政見」事實釐清狀態 icon。
- 調整「立場變化」、「相關進度」時間排序邏輯。