### PR TITLE
fix(politics-detail): change `election-term` to shred components

### DIFF
--- a/packages/politics-tracker/components/politics-detail/section-title.tsx
+++ b/packages/politics-tracker/components/politics-detail/section-title.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import styled from 'styled-components'
 
 import ArrowLeft from '~/components/icons/arrow-left'
+import ElectionTerm from '~/components/shared/election-term'
 import type { PersonElectionTerm, PoliticDetail } from '~/types/politics-detail'
 
 const Header = styled.div`
@@ -101,18 +102,6 @@ const PartyImage = styled.div`
   }
 `
 
-const ElectionTerm = styled.div`
-  padding: 4px;
-  border: 1px solid #000000;
-  font-size: 12px;
-  font-weight: 500;
-  display: inline-block;
-
-  ${({ theme }) => theme.breakpoint.md} {
-    font-size: 14px;
-  }
-`
-
 type SectionTitleProps = {
   politicData: PoliticDetail
   personOrganization: PersonElectionTerm
@@ -139,22 +128,6 @@ export default function SectionTitle({
     return newYear
   }
 
-  //election term
-  const {
-    start_date_day,
-    start_date_month,
-    start_date_year,
-    end_date_day,
-    end_date_month,
-    end_date_year,
-  } = personOrganization
-
-  const termStart = `${start_date_year}-${start_date_month}-${start_date_day}`
-  const termEnd = `${end_date_year}-${end_date_month}-${end_date_day}`
-
-  const shouldShowTerm =
-    person?.elected && Object.keys(personOrganization).length !== 0
-
   return (
     <Link href={linkHref}>
       <Header>
@@ -178,11 +151,11 @@ export default function SectionTitle({
               <span>{person?.party?.name || '無黨籍'}</span>
             </PartyInfo>
 
-            {shouldShowTerm && (
-              <ElectionTerm>
-                任期 {termStart} ~ {termEnd}
-              </ElectionTerm>
-            )}
+            <ElectionTerm
+              isElected={person?.elected}
+              isIncumbent={person?.incumbent}
+              termDate={personOrganization}
+            />
           </SubTitle>
         </div>
       </Header>

--- a/packages/politics-tracker/components/shared/election-term.tsx
+++ b/packages/politics-tracker/components/shared/election-term.tsx
@@ -80,7 +80,6 @@ export default function ElectionTerm({
         day: end_date_day,
       })
 
-  console.log('isIncumbent', isIncumbent)
   return (
     <Term>
       任期 {startTime} ~ {endTime}

--- a/packages/politics-tracker/components/shared/election-term.tsx
+++ b/packages/politics-tracker/components/shared/election-term.tsx
@@ -1,0 +1,89 @@
+import React from 'react'
+import styled from 'styled-components'
+
+const Term = styled.div`
+  padding: 4px;
+  border: 1px solid ${({ theme }) => theme.borderColor.black};
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 500;
+  display: inline-block;
+
+  ${({ theme }) => theme.breakpoint.md} {
+    font-size: 14px;
+  }
+`
+
+type TermDate = {
+  start_date_day: string | null
+  start_date_month: string | null
+  start_date_year: string | null
+  end_date_day: string | null
+  end_date_month: string | null
+  end_date_year: string | null
+}
+type ElectionTermProps = {
+  termDate: TermDate
+  isElected?: boolean
+  isIncumbent?: boolean
+}
+
+export default function ElectionTerm({
+  termDate,
+  isElected = false,
+  isIncumbent = false,
+}: ElectionTermProps): JSX.Element | null {
+  const isValuesNull = Object.values(termDate).every((value) => value === null)
+
+  //不顯示任期狀況：（1)未當選 (2) termDate 為空物件 (3)有 termDate 但所有任期時間皆為 null
+  if (!isElected || Object.keys(termDate).length === 0 || isValuesNull) {
+    return null
+  }
+
+  const {
+    start_date_day,
+    start_date_month,
+    start_date_year,
+    end_date_day,
+    end_date_month,
+    end_date_year,
+  } = termDate
+
+  type Props = {
+    year: string | null
+    month: string | null
+    day: string | null
+  }
+  const formatDateString = ({ year, month, day }: Props): string => {
+    if (year && month && day) {
+      return `${year}-${month}-${day}`
+    } else if (year && month) {
+      return `${year}-${month}`
+    } else if (year) {
+      return year
+    } else {
+      return ''
+    }
+  }
+
+  const startTime = formatDateString({
+    year: start_date_year,
+    month: start_date_month,
+    day: start_date_day,
+  })
+
+  const endTime = isIncumbent
+    ? ''
+    : formatDateString({
+        year: end_date_year,
+        month: end_date_month,
+        day: end_date_day,
+      })
+
+  console.log('isIncumbent', isIncumbent)
+  return (
+    <Term>
+      任期 {startTime} ~ {endTime}
+    </Term>
+  )
+}

--- a/packages/politics-tracker/graphql/query/politics/get-person-organization.graphql
+++ b/packages/politics-tracker/graphql/query/politics/get-person-organization.graphql
@@ -1,6 +1,5 @@
 query GetPersonOrganization($electionId: ID!) {
   personOrganizations(where: { election: { id: { equals: $electionId } } }) {
-    id
     start_date_day
     start_date_month
     start_date_year


### PR DESCRIPTION
### Notable Changes 
- 單一政見頁「任期」轉為共用元件，改放於 `/components/shared` 底下。
- 傳入參數：`termDate`：日期年月份資料、`isElected`：是否當選、`isIncumbent`：是否現任。
- 以下狀況不顯示「任期」資訊：
   - 該 PersonElection id 「是否當選」 checkbox 未勾。
   - 未傳入 `termDate` 資料。
   - 有傳入 `termDate` 資料但內容皆為 null。
- 當 PersonElection「是否現任」 checkbox 有勾，則一律不顯示結束日期。