### PR TITLE
fix(politics-detail): modify `GetPoliticDetail` to get correct politic

### DIFF
--- a/packages/politics-tracker/graphql/query/politics/get-politic-detail.graphql
+++ b/packages/politics-tracker/graphql/query/politics/get-politic-detail.graphql
@@ -1,5 +1,22 @@
-query GetPoliticsDetail($politicId: ID!) {
-  politics(where: { id: { equals: $politicId } }) {
+query GetPoliticDetail($politicId: ID!) {
+  politics(
+    where: {
+      OR: [
+        { AND: [{ id: { equals: $politicId } }, { thread_parent: null }] }
+        {
+          thread_parent: {
+            AND: [
+              { id: { equals: $politicId } }
+              { status: { equals: "verified" } }
+              { reviewed: { equals: true } }
+            ]
+          }
+        }
+      ]
+    }
+    orderBy: { id: desc }
+    take: 1
+  ) {
     id
     desc
     content


### PR DESCRIPTION
### Notable Changes 
- 修改 `GetPoliticDetail` graphql。
- 修改單一政見頁抓 Politic 邏輯：
   - 篩選 「已確認＋已檢閱＋thread 為 null」的政見
   - 篩選 「有 thread ＋已確認＋已檢閱 」的政見們。
   - 在上述資料中只取用 id 最大的那筆資料，以呈現最新被驗證過的政見內容。
   - PS：如果政見完全沒被修改過，就只會篩到「已確認＋已檢閱＋thread 為 null」的那一筆原始政見。
   