### PR TITLE
feat(pt): add ElectionTerm to politics overview

### DIFF
--- a/packages/politics-tracker/components/politics/politic-body.tsx
+++ b/packages/politics-tracker/components/politics/politic-body.tsx
@@ -55,8 +55,6 @@ export default function PoliticBody(props: PoliticBodyProps): JSX.Element {
         cmsApiUrl
       )
 
-      console.log(props.id)
-
       if (result.errors) {
         console.log(result.errors[0]?.message)
         return null
@@ -158,8 +156,6 @@ export default function PoliticBody(props: PoliticBodyProps): JSX.Element {
             : null,
         },
       }
-
-      console.log(data)
 
       // result is not used currently
       // eslint-disable-next-line

--- a/packages/politics-tracker/components/politics/section-toggle.module.css
+++ b/packages/politics-tracker/components/politics/section-toggle.module.css
@@ -66,7 +66,7 @@
 }
 
 .party-group {
-  @apply mt-2 flex flex-row flex-nowrap items-center;
+  @apply flex flex-row flex-nowrap items-center;
 }
 
 .party {

--- a/packages/politics-tracker/components/politics/section-toggle.tsx
+++ b/packages/politics-tracker/components/politics/section-toggle.tsx
@@ -1,9 +1,24 @@
+import styled from 'styled-components'
+
 import Icon from '~/components/icon'
 import ArrowDown from '~/components/icons/arrow-down'
 import ArrowUp from '~/components/icons/arrow-up'
+import ElectionTerm from '~/components/shared/election-term'
+import type { PersonElectionTerm } from '~/types/politics'
 import { logGAEvent } from '~/utils/analytics'
 
 import s from './section-toggle.module.css'
+
+const PartyTermWrapper = styled.div`
+  margin-top: 8px;
+  display: flex;
+  gap: 8px;
+  flex-direction: column;
+  ${({ theme }) => theme.breakpoint.md} {
+    flex-direction: row;
+    width: fit-content;
+  }
+`
 
 type SectionToggleProps = {
   id: string
@@ -13,6 +28,9 @@ type SectionToggleProps = {
   isActive: boolean
   order: number
   setActive: () => void
+  electionTerm: PersonElectionTerm
+  elected: boolean
+  incumbent: boolean
 }
 export default function SectionToggle(props: SectionToggleProps): JSX.Element {
   const toggleClass = props.isActive ? s['toggle-active'] : s['toggle']
@@ -37,16 +55,23 @@ export default function SectionToggle(props: SectionToggleProps): JSX.Element {
       <div className={toggleClass} onClick={toggle}>
         <div className={s['content']}>
           <div className={s['text']}>{props.content}</div>
-          <div className={s['party-group']}>
-            <Icon
-              src={props.partyIcon}
-              width={20}
-              height={20}
-              borderWidth={1}
-              unoptimized={true}
+          <PartyTermWrapper>
+            <div className={s['party-group']}>
+              <Icon
+                src={props.partyIcon}
+                width={20}
+                height={20}
+                borderWidth={1}
+                unoptimized={true}
+              />
+              <div className={s['party']}>{props.party}</div>
+            </div>
+            <ElectionTerm
+              isElected={props.elected}
+              isIncumbent={props.incumbent}
+              termDate={props.electionTerm}
             />
-            <div className={s['party']}>{props.party}</div>
-          </div>
+          </PartyTermWrapper>
         </div>
         <span className={s['control']}>
           {props.isActive ? <ArrowUp /> : <ArrowDown />}

--- a/packages/politics-tracker/components/shared/election-term.tsx
+++ b/packages/politics-tracker/components/shared/election-term.tsx
@@ -1,9 +1,9 @@
-import React from 'react'
 import styled from 'styled-components'
 
 const Term = styled.div`
   padding: 4px;
   border: 1px solid ${({ theme }) => theme.borderColor.black};
+  width: fit-content;
   font-size: 12px;
   font-style: normal;
   font-weight: 500;

--- a/packages/politics-tracker/graphql/query/politics/get-person-overview.graphql
+++ b/packages/politics-tracker/graphql/query/politics/get-person-overview.graphql
@@ -7,6 +7,7 @@ query GetPersonOverView($personId: ID!) {
     id
     politicSource
     elected
+    incumbent
     person_id {
       id
       name

--- a/packages/politics-tracker/pages/politics/[personId].tsx
+++ b/packages/politics-tracker/pages/politics/[personId].tsx
@@ -50,7 +50,6 @@ type PoliticsPageProps = {
 }
 
 export default function Politics(props: PoliticsPageProps) {
-  console.log(props)
   const [politicAmounts, setPoliticAmounts] = useState<PoliticAmount>({
     waiting: props.titleProps.waiting,
     completed: props.titleProps.completed,
@@ -211,6 +210,7 @@ export const getServerSideProps: GetServerSideProps<
                 )
               ),
               elected: current.elected === true,
+              incumbent: current.incumbent === true,
               source: current.politicSource ?? '',
               lastUpdate: null,
               politics: [],

--- a/packages/politics-tracker/types/politics.ts
+++ b/packages/politics-tracker/types/politics.ts
@@ -84,6 +84,7 @@ export type PersonElection = {
   month: number
   day: number
   elected: boolean
+  incumbent: boolean
   isFinished: boolean
   source: string | null
   lastUpdate: string | null

--- a/packages/politics-tracker/types/politics.ts
+++ b/packages/politics-tracker/types/politics.ts
@@ -64,6 +64,15 @@ export type Repeat = {
   factcheckPartner: FactCheckPartner | null
 }
 
+export type PersonElectionTerm = {
+  start_date_day: string | null
+  start_date_month: string | null
+  start_date_year: string | null
+  end_date_day: string | null
+  end_date_month: string | null
+  end_date_year: string | null
+}
+
 export type PersonElection = {
   electionArea: string
   electionType: string
@@ -81,4 +90,5 @@ export type PersonElection = {
   politics: Politic[]
   waitingPolitics: Politic[]
   hidePoliticDetail: string | null
+  electionTerm: PersonElectionTerm
 }


### PR DESCRIPTION
- iterate through each election in the elections array, query the `electionTerm` for that specific election, and push the electionTerm data to the election object
- use the shared component `ElectionTerm` to render term data on the elections overview  