### PR TITLE
fix(politics-detail): send edit data to `Editing Politics`

### DIFF
--- a/packages/politics-tracker/graphql/mutation/politics/add-editing-politic-to-thread.graphql
+++ b/packages/politics-tracker/graphql/mutation/politics/add-editing-politic-to-thread.graphql
@@ -1,0 +1,29 @@
+mutation AddEditingPoliticToThread($data: EditingPoliticCreateInput!) {
+  createEditingPolitic(data: $data) {
+    id
+    desc
+    source
+    content
+    person {
+      id
+      person_id {
+        name
+      }
+      election {
+        name
+      }
+      party {
+        name
+      }
+    }
+    thread_parent {
+      id
+      desc
+      source
+    }
+    changeLog
+    checked
+    reviewed
+    contributer
+  }
+}


### PR DESCRIPTION
### Notable Changes

- 新增 `AddEditingPoliticToThread` gql，用來處理「協作後待審」的政見（只送有修改的欄位資料）。
- 如使用者有編輯 `Politic Controversies`：
   - 新增/修改：創立新的一筆 Controversy ，並將「政見（待審核）欄位」關聯到 `Editing Politic` id。
   - 無修改：將既有的 Controversy 的 「政見（待審核）欄位」新加關聯到 `Editing Politic` id。