### PR TITLE
fix(pt): add `props.dependency` to reset crop/expand status

### DIFF
--- a/packages/politics-tracker/components/landing/election-2024/fact-check-group/president-factcheck/factcheck-item.tsx
+++ b/packages/politics-tracker/components/landing/election-2024/fact-check-group/president-factcheck/factcheck-item.tsx
@@ -217,7 +217,9 @@ export default function FactCheckItem({
 
             {hasPolitics && desc ? (
               <PoliticDesc>
-                <PoliticContent>{desc}</PoliticContent>
+                <PoliticContent dependency={politicNumber}>
+                  {desc}
+                </PoliticContent>
               </PoliticDesc>
             ) : (
               <DefaultDec>這個人還沒有被新增政見</DefaultDec>

--- a/packages/politics-tracker/components/politics/politic-content.tsx
+++ b/packages/politics-tracker/components/politics/politic-content.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useResizeDetector } from 'react-resize-detector'
 
 import { logGAEvent } from '~/utils/analytics'
@@ -8,6 +8,7 @@ import s from './politic-content.module.css'
 
 type PoliticContentProps = {
   children: string
+  dependency?: number
 }
 
 export default function PoliticContent(
@@ -16,6 +17,7 @@ export default function PoliticContent(
   const ref = useRef<HTMLDivElement>(null)
   const [isCropped, setIsCropped] = useState<boolean>(false)
   const [isExpanded, setIsExpanded] = useState<boolean>(false)
+
   const onResize = useCallback(() => {
     const current = ref.current
     if (current) {
@@ -26,6 +28,7 @@ export default function PoliticContent(
       }
     }
   }, [])
+
   useResizeDetector({
     targetRef: ref,
     onResize,
@@ -40,6 +43,12 @@ export default function PoliticContent(
     { cropped: isCropped },
     { [s['expanded']]: isExpanded }
   )
+
+  //reset the states of `isCropped` and `isExpanded` when the props.dependency change.
+  useEffect(() => {
+    setIsExpanded(false)
+    onResize()
+  }, [onResize, props.dependency])
 
   function shouldShowControl(isCropped: boolean, isExpanded: boolean): boolean {
     return (isCropped && !isExpanded) || (!isCropped && isExpanded)


### PR DESCRIPTION
### Notable Changes 
- `/politics/politic-content.tsx` 新增 props：dependency，當傳入的指定參數有變動時，重新確認政見內容的「展開全部/顯示較少」狀態。
- 上述調整用以修正 2024 首頁 切換政見時，展開狀態無法正確顯示問題。