### PR TITLE
feat(landing/2024): add logo links

### DIFF
--- a/packages/politics-tracker/components/landing/shared/factcheck-partners.tsx
+++ b/packages/politics-tracker/components/landing/shared/factcheck-partners.tsx
@@ -44,13 +44,15 @@ const PartnerGroup = styled.div`
   }
 `
 
-const Item = styled.div`
+const Item = styled.a<{ href: string }>`
+  display: block;
   width: 140px;
   height: 83px;
   background: ${({ theme }) => theme.backgroundColor.white};
   display: flex;
   align-items: center;
   justify-content: center;
+  cursor: ${({ href }) => (href ? 'pointer' : 'auto')};
 
   ${({ theme }) => theme.breakpoint.md} {
     width: 157px;
@@ -68,6 +70,7 @@ type PartnerByType = {
   partners: {
     id: string
     name: string
+    webUrl: string
     logo: Object
   }[]
 }
@@ -86,12 +89,20 @@ export default function FactCheckPartners({
           existingItem.partners.push({
             id: item.id,
             name: item.name,
+            webUrl: item.webUrl,
             logo: item.logo || [],
           })
         } else {
           result.push({
             type: item.type,
-            partners: [{ id: item.id, name: item.name, logo: item.logo || [] }],
+            partners: [
+              {
+                id: item.id,
+                name: item.name,
+                webUrl: item.webUrl,
+                logo: item.logo || [],
+              },
+            ],
           })
         }
         return result
@@ -112,7 +123,12 @@ export default function FactCheckPartners({
             <Title>{item.type}</Title>
             <PartnerGroup>
               {item.partners.map((partner: any) => (
-                <Item key={partner.id}>
+                <Item
+                  key={partner.id}
+                  href={partner.webUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
                   <CustomImage
                     images={partner?.logo?.resized}
                     defaultImage="/images/default-factcheck-partner.svg"

--- a/packages/politics-tracker/graphql/query/landing/get-factcheck-partners.graphql
+++ b/packages/politics-tracker/graphql/query/landing/get-factcheck-partners.graphql
@@ -6,6 +6,7 @@ query GetFactCheckPartners($year: String) {
     id
     name
     type
+    webUrl
     logo {
       resized {
         original

--- a/packages/politics-tracker/types/politics-detail.ts
+++ b/packages/politics-tracker/types/politics-detail.ts
@@ -107,6 +107,7 @@ export type FactCheckPartner = {
   id: string
   name: string
   type: string
+  webUrl: string
 } & Partial<{
   logo: Logo // for `landing`
   slogo: Logo // for `politic-detail`


### PR DESCRIPTION
### Notable Changes 
- 2024 首頁：合作夥伴區塊 Logo 牆新增外連網址功能。
- 如合作夥伴的「網站網址」無資料，則 hover 時游標不會有更動，如使用者照樣點選，會另開分頁至首頁。