### PR TITLE
fix(politics-tracker): add config toggle to feedback form in politics summary page

### DIFF
--- a/packages/politics-tracker/components/politics/politic-block.tsx
+++ b/packages/politics-tracker/components/politics/politic-block.tsx
@@ -7,7 +7,7 @@ import PoliticBody from './politic-body'
 
 type PoliticBlockProps = Pick<
   PersonElection,
-  'politics' | 'source' | 'lastUpdate'
+  'politics' | 'source' | 'lastUpdate' | 'shouldShowFeedbackForm'
 > & { hidePoliticDetail: string | null }
 
 type GroupData = {
@@ -55,6 +55,7 @@ export default function PoliticBlock(props: PoliticBlockProps): JSX.Element {
             no={i + 1}
             {...p}
             hidePoliticDetail={props.hidePoliticDetail}
+            shouldShowFeedbackForm={props.shouldShowFeedbackForm ?? false}
           />
         ))}
       </div>

--- a/packages/politics-tracker/components/politics/politic-body.tsx
+++ b/packages/politics-tracker/components/politics/politic-body.tsx
@@ -30,6 +30,7 @@ const PoliticForm = dynamic(() => import('./politic-form'), {
 type PoliticBodyProps = Politic & {
   no: number
   hidePoliticDetail: string | null
+  shouldShowFeedbackForm: boolean
 }
 
 export default function PoliticBody(props: PoliticBodyProps): JSX.Element {
@@ -140,6 +141,7 @@ export default function PoliticBody(props: PoliticBodyProps): JSX.Element {
   const currentDate = new Date()
   const shouldShow =
     hidingDate !== null && hidingDate.getTime() > currentDate.getTime()
+  const shouldShowFeedbackForm = shouldShow && props.shouldShowFeedbackForm
 
   return (
     <div className={style}>
@@ -166,16 +168,16 @@ export default function PoliticBody(props: PoliticBodyProps): JSX.Element {
                 <PoliticContent>{props.desc}</PoliticContent>
               </div>
               {shouldShow && (
-                <>
-                  <FactCheckAbstract
-                    positionChange={props.positionChange}
-                    factCheck={props.factCheck}
-                    expertPoint={props.expertPoint}
-                    repeat={props.repeat}
-                    landing={false}
-                  />
-                  <UserFeedbackToolkit politicId={props.id ?? ''} />
-                </>
+                <FactCheckAbstract
+                  positionChange={props.positionChange}
+                  factCheck={props.factCheck}
+                  expertPoint={props.expertPoint}
+                  repeat={props.repeat}
+                  landing={false}
+                />
+              )}
+              {shouldShowFeedbackForm && (
+                <UserFeedbackToolkit politicId={props.id ?? ''} />
               )}
               <div className={s['control-group']}>
                 <div className={s['button']} onClick={() => setEditing(true)}>

--- a/packages/politics-tracker/components/politics/section-body.tsx
+++ b/packages/politics-tracker/components/politics/section-body.tsx
@@ -14,10 +14,14 @@ import WaitingPoliticBlock from './waiting-politic-block'
 
 type SectionBodyProps = Pick<
   PersonElection,
-  'source' | 'lastUpdate' | 'politics' | 'waitingPolitics'
-> & { show: boolean } & { hidePoliticDetail: string | null } & {
-  mainCandidate: MainCandidate | null
-}
+  | 'source'
+  | 'lastUpdate'
+  | 'politics'
+  | 'waitingPolitics'
+  | 'mainCandidate'
+  | 'hidePoliticDetail'
+  | 'shouldShowFeedbackForm'
+> & { show: boolean }
 
 const Button = styled.button`
   margin: auto;

--- a/packages/politics-tracker/pages/politics/[personId].tsx
+++ b/packages/politics-tracker/pages/politics/[personId].tsx
@@ -224,6 +224,7 @@ export const getServerSideProps: GetServerSideProps<
               hidePoliticDetail: election.hidePoliticDetail ?? null,
               electionTerm: electionTerm,
               organizationId: organizationId,
+              shouldShowFeedbackForm: election.addComments ?? false,
             }
           }
 

--- a/packages/politics-tracker/types/politics.ts
+++ b/packages/politics-tracker/types/politics.ts
@@ -110,4 +110,5 @@ export type PersonElection = {
   electionTerm: PersonElectionTerm
   mainCandidate: MainCandidate | null
   organizationId: OrganizationId | null
+  shouldShowFeedbackForm?: boolean
 }


### PR DESCRIPTION
# Notable Changes
* 補上使用者回饋區塊，在政見總覽頁（人物）上顯示，與 election 設定連動處理。