### PR TITLE
feat(party-detail): add party politic-detail components

### DIFF
--- a/packages/politics-tracker/components/landing/election-2024/fact-check-group/index.tsx
+++ b/packages/politics-tracker/components/landing/election-2024/fact-check-group/index.tsx
@@ -4,11 +4,10 @@ import styled from 'styled-components'
 import ComparisonBlock from '~/components/landing/election-2024/fact-check-group/president-comparison'
 import FactCheckBlock from '~/components/landing/election-2024/fact-check-group/president-factcheck'
 import type {
-  ExpertPoint,
-  FactCheck,
-  PoliticCategory,
-  Repeat,
-} from '~/types/politics-detail'
+  CategoryOfJson,
+  PresidentComparisonJson,
+  PresidentFactCheckJson,
+} from '~/types/landing'
 
 const Wrapper = styled.div`
   width: 100%;
@@ -44,24 +43,10 @@ const Aside = styled.div`
   }
 `
 
-export type Politic = {
-  id: string
-  desc: string
-  politicCategory: PoliticCategory
-  positionChange: []
-  positionChangeCount: number
-  expertPoint: ExpertPoint[]
-  expertPointCount: number
-  factCheck: FactCheck[]
-  factCheckCount: number
-  repeat: Repeat[]
-  repeatCount: number
-}
-
 type FactCheckProps = {
-  categories: any
-  factCheckJSON: any
-  comparisonJSON: any
+  categories: CategoryOfJson[]
+  factCheckJSON: PresidentFactCheckJson[]
+  comparisonJSON: PresidentComparisonJson[]
 }
 export default function PresidentFactCheck({
   categories = [],

--- a/packages/politics-tracker/components/landing/election-2024/related-posts.tsx
+++ b/packages/politics-tracker/components/landing/election-2024/related-posts.tsx
@@ -207,7 +207,7 @@ export default function RelatedPosts({
           <PostInfo>
             {partnerStr && <span className="partners">{partnerStr}</span>}
             <p className="title">{name}</p>
-            <span className="date">{getFormattedDate(createdAt)}</span>
+            <span className="date">{getFormattedDate(createdAt, '/')}</span>
           </PostInfo>
         </a>
       </PostList>

--- a/packages/politics-tracker/components/landing/election-2024/related-posts.tsx
+++ b/packages/politics-tracker/components/landing/election-2024/related-posts.tsx
@@ -3,8 +3,8 @@ import React, { useState } from 'react'
 import styled from 'styled-components'
 
 import ArrowDown from '~/public/icons/arrow-down-yellow.svg'
+import type { GenericFactCheckPartner } from '~/types/common'
 import type { RelatedPost } from '~/types/landing'
-import type { FactCheckPartner } from '~/types/politics-detail'
 import { getFormattedDate } from '~/utils/utils'
 
 const Wrapper = styled.div`
@@ -184,7 +184,9 @@ export default function RelatedPosts({
     return null
   }
 
-  function jointPartnerName(partners: Pick<FactCheckPartner, 'id' | 'name'>[]) {
+  function jointPartnerName(
+    partners: Pick<GenericFactCheckPartner, 'id' | 'name'>[]
+  ) {
     const names = partners.map((partner) => partner.name)
     return names.join('、')
   }

--- a/packages/politics-tracker/components/landing/shared/factcheck-partners.tsx
+++ b/packages/politics-tracker/components/landing/shared/factcheck-partners.tsx
@@ -87,19 +87,19 @@ export default function FactCheckPartners({
 
         if (existingItem) {
           existingItem.partners.push({
-            id: item.id,
-            name: item.name,
-            webUrl: item.webUrl,
+            id: item.id || '',
+            name: item.name || '',
+            webUrl: item.webUrl || '',
             logo: item.logo || [],
           })
         } else {
           result.push({
-            type: item.type,
+            type: item.type || '',
             partners: [
               {
-                id: item.id,
-                name: item.name,
-                webUrl: item.webUrl,
+                id: item.id || '',
+                name: item.name || '',
+                webUrl: item.webUrl || '',
                 logo: item.logo || [],
               },
             ],

--- a/packages/politics-tracker/components/politics-detail/edit/edit-controversy.tsx
+++ b/packages/politics-tracker/components/politics-detail/edit/edit-controversy.tsx
@@ -13,7 +13,7 @@ import CreateControversies from '~/graphql/mutation/politics-detail/create-contr
 import AddEditingPolitic from '~/graphql/mutation/politics/add-editing-politic-to-thread.graphql'
 import EditLink from '~/public/icons/edit-link.svg'
 import EditText from '~/public/icons/edit-text.svg'
-import { Controversy, PoliticDetail } from '~/types/politics-detail'
+import { PoliticControversy, PoliticDetail } from '~/types/politics-detail'
 import {
   getControversyToAdd,
   getControversyToConnect,
@@ -46,21 +46,21 @@ const InputGroup = styled.div`
 `
 
 type EditControversiesProps = {
-  politicData: PoliticDetail
+  politic: PoliticDetail
   setEditMode: React.Dispatch<React.SetStateAction<boolean>>
 }
 export default function EditControversies({
-  politicData,
+  politic,
   setEditMode,
 }: EditControversiesProps): JSX.Element {
-  const { id = '', controversies = [] } = politicData
+  const { id = '', controversies = [] } = politic
 
   const toast = useToast()
   const [list, setList] = useState(controversies)
 
   //「新增」填寫欄位
   function addList() {
-    const extended: Controversy[] = [
+    const extended: PoliticControversy[] = [
       ...list,
       { id: `add-${uuidv4()}`, content: '', link: '' },
     ]
@@ -133,13 +133,13 @@ export default function EditControversies({
   }
 
   async function addControversies(
-    controversyList: Controversy[] | [],
+    controversyList: PoliticControversy[] | [],
     cmsApiUrl: string,
     politicId: number
   ) {
     try {
       const variables = {
-        data: controversyList.map((item: Controversy) => ({
+        data: controversyList.map((item: PoliticControversy) => ({
           link: item.link,
           content: item.content,
           editingPolitic: {

--- a/packages/politics-tracker/components/politics-detail/progressbar.tsx
+++ b/packages/politics-tracker/components/politics-detail/progressbar.tsx
@@ -126,12 +126,12 @@ const ProgressBar = styled.div`
 `
 
 type ProgressBar = {
-  politicData: PoliticDetail
+  politic: PoliticDetail
 }
-export default function Progressbar({ politicData }: ProgressBar): JSX.Element {
-  const electResult = politicData?.person?.elected || false
+export default function Progressbar({ politic }: ProgressBar): JSX.Element {
+  const electResult = politic?.person?.elected || false
   //@ts-ignore
-  const progressType = politicData.current_progress
+  const progressType = politic.current_progress
 
   return (
     <ProgressBar>

--- a/packages/politics-tracker/components/politics-detail/section-content.tsx
+++ b/packages/politics-tracker/components/politics-detail/section-content.tsx
@@ -1,4 +1,3 @@
-import dayjs from 'dayjs'
 import { useState } from 'react'
 import styled from 'styled-components'
 
@@ -12,7 +11,10 @@ import Repeat from '~/components/politics-detail/toggle-lists/repeat'
 import Response from '~/components/politics-detail/toggle-lists/response'
 import TimeLine from '~/components/politics-detail/toggle-lists/timeline'
 import EditButton from '~/components/shared/edit-button'
+import Legislators from '~/components/shared/legislator-at-large'
+import type { LegislatorAtLarge } from '~/types/politics'
 import type { PoliticDetail } from '~/types/politics-detail'
+import { getFormattedDate } from '~/utils/utils'
 
 const Wrapper = styled.div`
   width: 100%;
@@ -42,10 +44,14 @@ type ToggleItems = {
   isActive: boolean
 }
 type SectionContentProps = {
-  politicData: PoliticDetail
+  politic: PoliticDetail
+  legislators?: LegislatorAtLarge[]
+  isElectionFinished?: boolean
 }
 export default function SectionContent({
-  politicData,
+  politic,
+  legislators = [],
+  isElectionFinished = false,
 }: SectionContentProps): JSX.Element {
   const [isControEdit, setIsControEdit] = useState(false)
 
@@ -61,7 +67,7 @@ export default function SectionContent({
     updatedAt = '',
     repeat = [],
     response = [],
-  } = politicData
+  } = politic
 
   const toggleItems: ToggleItems[] = [
     {
@@ -117,7 +123,7 @@ export default function SectionContent({
       ),
       children: (
         <Controversy
-          politicData={politicData}
+          politic={politic}
           controversies={controversies}
           editMode={isControEdit}
           setEditMode={setIsControEdit}
@@ -128,10 +134,15 @@ export default function SectionContent({
     },
   ]
 
-  const formattedDate = dayjs(updatedAt).format('YYYY/MM/DD')
+  //如果選舉類型不是不分區則不要顯示
 
   return (
     <Wrapper>
+      <Legislators
+        isElectionFinished={isElectionFinished}
+        legislators={legislators}
+      />
+
       {toggleItems.map((item, index) =>
         item.showToggle ? (
           <ToggleItem
@@ -146,7 +157,11 @@ export default function SectionContent({
         ) : null
       )}
 
-      {updatedAt && <UpdatedTime>最後更新於：{formattedDate}</UpdatedTime>}
+      {updatedAt && (
+        <UpdatedTime>
+          最後更新於：{getFormattedDate(updatedAt, '/')}
+        </UpdatedTime>
+      )}
     </Wrapper>
   )
 }

--- a/packages/politics-tracker/components/politics-detail/section-title.tsx
+++ b/packages/politics-tracker/components/politics-detail/section-title.tsx
@@ -45,7 +45,11 @@ const Header = styled.div`
 const Title = styled.div`
   font-size: 22px;
   font-weight: 700;
-  margin-bottom: 8px;
+
+  & + * {
+    margin-top: 8px;
+  }
+
   > span {
     margin-right: 5px;
   }
@@ -107,23 +111,43 @@ const PartyImage = styled.div`
 `
 
 type SectionTitleProps = {
-  politicData: PoliticDetail
+  politic: PoliticDetail
   electionTerm: PersonElectionTerm
+  isPartyPage: boolean
 }
 export default function SectionTitle({
-  politicData,
+  politic,
   electionTerm,
+  isPartyPage = false,
 }: SectionTitleProps): JSX.Element {
-  const { person } = politicData
+  const { person, organization } = politic
 
-  const electionArea = person?.electoral_district?.name.slice(0, 3) || ''
-  const linkHref = `/politics/${person?.person_id?.id}` || '/'
+  let electionArea: string = ''
+  let linkHref: string = ''
+  let rawElectionName: string = ''
+  let electionCenturyYear: string = ''
+  let electionWithoutYear: string = ''
 
   //change election_name's year from RepublicYear to Common Era (+1911)
-  const rawElectionName = person?.election?.name || ''
-  const electionCenturyYear = person?.election?.election_year_year || null
-  const electionWithoutYear =
-    rawElectionName.slice(rawElectionName.indexOf('年') + 1) || ''
+
+  if (isPartyPage) {
+    electionArea = ''
+    linkHref = `/politics/party/${organization?.id}` || '/'
+
+    rawElectionName = organization?.elections?.name || ''
+    electionCenturyYear =
+      organization?.elections?.election_year_year?.toString() || ''
+    electionWithoutYear =
+      rawElectionName.slice(rawElectionName.indexOf('年') + 1) || ''
+  } else {
+    const districtName = person?.electoral_district?.name || ''
+    electionArea = districtName.slice(0, 3) || ''
+    linkHref = `/politics/${person?.person_id?.id}` || '/'
+    rawElectionName = person?.election?.name || ''
+    electionCenturyYear = person?.election?.election_year_year?.toString() || ''
+    electionWithoutYear =
+      rawElectionName.slice(rawElectionName.indexOf('年') + 1) || ''
+  }
 
   return (
     <Link href={linkHref}>
@@ -136,24 +160,26 @@ export default function SectionTitle({
             <ElectionArea>{electionArea}</ElectionArea>
           </Title>
 
-          <SubTitle>
-            <PartyInfo>
-              <PartyImage>
-                <Image
-                  images={{ original: person?.party?.image }}
-                  alt={person?.party?.name}
-                  defaultImage="/images/default-head-photo.png"
-                />
-              </PartyImage>
-              <span>{person?.party?.name || '無黨籍'}</span>
-            </PartyInfo>
+          {!isPartyPage && (
+            <SubTitle>
+              <PartyInfo>
+                <PartyImage>
+                  <Image
+                    images={{ original: person?.party?.image }}
+                    alt={person?.party?.name}
+                    defaultImage="/images/default-head-photo.png"
+                  />
+                </PartyImage>
+                <span>{person?.party?.name || '無黨籍'}</span>
+              </PartyInfo>
 
-            <ElectionTerm
-              isElected={person?.elected}
-              isIncumbent={person?.incumbent}
-              termDate={electionTerm}
-            />
-          </SubTitle>
+              <ElectionTerm
+                isElected={person?.elected}
+                isIncumbent={person?.incumbent}
+                termDate={electionTerm}
+              />
+            </SubTitle>
+          )}
         </div>
       </Header>
     </Link>

--- a/packages/politics-tracker/components/politics-detail/section-title.tsx
+++ b/packages/politics-tracker/components/politics-detail/section-title.tsx
@@ -113,7 +113,7 @@ const PartyImage = styled.div`
 type SectionTitleProps = {
   politic: PoliticDetail
   electionTerm: PersonElectionTerm
-  isPartyPage: boolean
+  isPartyPage?: boolean
 }
 export default function SectionTitle({
   politic,

--- a/packages/politics-tracker/components/politics-detail/section.tsx
+++ b/packages/politics-tracker/components/politics-detail/section.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import ProgressBar from '~/components/politics-detail/progressbar'
 import SectionContent from '~/components/politics-detail/section-content'
 import SectionTitle from '~/components/politics-detail/section-title'
+import type { LegislatorAtLarge } from '~/types/politics'
 import type { PersonElectionTerm, PoliticDetail } from '~/types/politics-detail'
 
 import SectionFeedbackForm from './section-feeedback-form'
@@ -18,22 +19,39 @@ const SectionContainer = styled.div`
 `
 
 type SectionProps = {
-  politicData: PoliticDetail
+  politic: PoliticDetail
   electionTerm: PersonElectionTerm
   shouldShowFeedbackForm: boolean
+  isPartyPage?: boolean
+  legislators?: LegislatorAtLarge[]
 }
 export default function Section({
-  politicData,
+  politic,
   electionTerm,
   shouldShowFeedbackForm = false,
+  isPartyPage = false,
+  legislators = [],
 }: SectionProps): JSX.Element {
+  const { organization, person } = politic
+
   //get election Date (YYYY-MM-DD)
-  let electionDate =
-    politicData?.person?.election?.election_year_year +
-    '-' +
-    politicData?.person?.election?.election_year_month +
-    '-' +
-    politicData?.person?.election?.election_year_day
+  let electionDate: string = ''
+
+  if (isPartyPage) {
+    electionDate =
+      organization?.elections?.election_year_year +
+      '-' +
+      organization?.elections?.election_year_month +
+      '-' +
+      organization?.elections?.election_year_day
+  } else {
+    electionDate =
+      person?.election?.election_year_year +
+      '-' +
+      person?.election?.election_year_month +
+      '-' +
+      person?.election?.election_year_day
+  }
 
   // get current Date (YYYY-MM-DD)
   let currentTime = new Date()
@@ -43,16 +61,24 @@ export default function Section({
   let currentDate = `${year}-${month}-${day}`
 
   // compare "election Date" & "current Date"
-  const electionFinishedOrNot = +new Date(electionDate) < +new Date(currentDate)
+  const isElectionFinished = +new Date(electionDate) < +new Date(currentDate)
 
   return (
     <SectionContainer>
       <div>
-        <SectionTitle politicData={politicData} electionTerm={electionTerm} />
-        {electionFinishedOrNot && <ProgressBar politicData={politicData} />}
-        <SectionContent politicData={politicData} />
+        <SectionTitle
+          politic={politic}
+          electionTerm={electionTerm}
+          isPartyPage={isPartyPage}
+        />
+        {isElectionFinished && <ProgressBar politic={politic} />}
+        <SectionContent
+          politic={politic}
+          legislators={legislators}
+          isElectionFinished={isElectionFinished}
+        />
         {shouldShowFeedbackForm && (
-          <SectionFeedbackForm politicId={politicData?.id} />
+          <SectionFeedbackForm politicId={politic?.id} />
         )}
       </div>
     </SectionContainer>

--- a/packages/politics-tracker/components/politics-detail/toggle-lists/controversy.tsx
+++ b/packages/politics-tracker/components/politics-detail/toggle-lists/controversy.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 
 import DefaultText from '~/components/politics-detail/default-text'
 import EditControversy from '~/components/politics-detail/edit/edit-controversy'
-import type { Controversy, PoliticDetail } from '~/types/politics-detail'
+import type { PoliticControversy, PoliticDetail } from '~/types/politics-detail'
 
 const Wrapper = styled.div`
   padding: 20px 0px;
@@ -47,13 +47,13 @@ const List = styled.li`
 `
 
 type ControversyProps = {
-  politicData: PoliticDetail
-  controversies: Controversy[]
+  politic: PoliticDetail
+  controversies: PoliticControversy[]
   editMode: boolean
   setEditMode: React.Dispatch<React.SetStateAction<boolean>>
 }
 export default function Controversy({
-  politicData,
+  politic,
   controversies = [],
   editMode = false,
   setEditMode,
@@ -76,9 +76,7 @@ export default function Controversy({
   } else if (!editMode) {
     jsx = <DefaultText title="相關爭議" />
   } else {
-    jsx = (
-      <EditControversy politicData={politicData} setEditMode={setEditMode} />
-    )
+    jsx = <EditControversy politic={politic} setEditMode={setEditMode} />
   }
 
   return <Wrapper>{jsx}</Wrapper>

--- a/packages/politics-tracker/components/politics-detail/toggle-lists/expert-point/expert-item.tsx
+++ b/packages/politics-tracker/components/politics-detail/toggle-lists/expert-point/expert-item.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import RelatedLinks from '~/components/politics-detail/related-links'
 import { SOURCE_DELIMITER } from '~/constants/politics'
 import ExpertIcon from '~/public/icons/expert-opinion.svg'
-import type { ExpertPoint } from '~/types/politics-detail'
+import type { PoliticExpert } from '~/types/politics-detail'
 import { generateSourceMeta } from '~/utils/utils'
 
 const ListWrapper = styled.li`
@@ -139,19 +139,19 @@ const Contributer = styled.span`
 `
 
 type ExpertItemProps = {
-  expertItem: ExpertPoint
+  expertItem: PoliticExpert
 }
 export default function ExpertItem({
   expertItem,
 }: ExpertItemProps): JSX.Element {
   const {
-    avatar,
-    expert,
-    title,
-    content,
-    link,
-    expertPointSummary,
-    contributer,
+    avatar = '',
+    expert = '',
+    title = '',
+    content = '',
+    link = '',
+    expertPointSummary = ' ',
+    contributer = '',
   } = expertItem
 
   const pointText = content.split(SOURCE_DELIMITER).map((item, index) => {

--- a/packages/politics-tracker/components/politics-detail/toggle-lists/expert-point/index.tsx
+++ b/packages/politics-tracker/components/politics-detail/toggle-lists/expert-point/index.tsx
@@ -2,14 +2,14 @@ import styled from 'styled-components'
 
 import DefaultText from '~/components/politics-detail/default-text'
 import ExpertItem from '~/components/politics-detail/toggle-lists/expert-point/expert-item'
-import type { ExpertPoint } from '~/types/politics-detail'
+import type { PoliticExpert } from '~/types/politics-detail'
 
 const Wrapper = styled.div`
   padding: 12px 0px 40px;
 `
 
 type ExpertPointProps = {
-  experts: ExpertPoint[]
+  experts: PoliticExpert[]
 }
 export default function ExpertPoint({
   experts = [],
@@ -18,7 +18,7 @@ export default function ExpertPoint({
     <Wrapper>
       {experts.length > 0 ? (
         <ul>
-          {experts.map((value: ExpertPoint, index: number) => (
+          {experts.map((value: PoliticExpert, index: number) => (
             <ExpertItem expertItem={value} key={index} />
           ))}
         </ul>

--- a/packages/politics-tracker/components/politics-detail/toggle-lists/fact-check/fact-item.tsx
+++ b/packages/politics-tracker/components/politics-detail/toggle-lists/fact-check/fact-item.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import RelatedLinks from '~/components/politics-detail/related-links'
 import { SOURCE_DELIMITER } from '~/constants/politics'
 import FactCheckIcon from '~/public/icons/fact-check-icon.svg'
-import type { FactCheck } from '~/types/politics-detail'
+import type { PoliticFactCheck } from '~/types/politics-detail'
 import { getCheckResultString } from '~/utils/utils'
 
 const ListWrapper = styled.li`
@@ -111,11 +111,16 @@ const SubTitle = styled.span`
 `
 
 type FactItemProps = {
-  factItem: FactCheck
+  factItem: PoliticFactCheck
 }
 export default function FactItem({ factItem }: FactItemProps): JSX.Element {
-  const { checkResultType, link, content, factcheckPartner, factCheckSummary } =
-    factItem
+  const {
+    checkResultType = '',
+    link = '',
+    content = '',
+    factCheckSummary = '',
+    factcheckPartner,
+  } = factItem
 
   const factType = getCheckResultString(checkResultType, factItem)
   const factText = content.split(SOURCE_DELIMITER).map((item, index) => {

--- a/packages/politics-tracker/components/politics-detail/toggle-lists/fact-check/index.tsx
+++ b/packages/politics-tracker/components/politics-detail/toggle-lists/fact-check/index.tsx
@@ -1,20 +1,20 @@
 import styled from 'styled-components'
 
 import FactItem from '~/components/politics-detail/toggle-lists/fact-check/fact-item'
-import type { FactCheck } from '~/types/politics-detail'
+import type { PoliticFactCheck } from '~/types/politics-detail'
 
 const Wrapper = styled.div`
   padding: 12px 0px 40px;
 `
 
 type FactCheckProps = {
-  facts: FactCheck[]
+  facts: PoliticFactCheck[]
 }
 export default function FactCheck({ facts = [] }: FactCheckProps): JSX.Element {
   return (
     <Wrapper>
       <ul>
-        {facts.map((value: FactCheck, index: number) => (
+        {facts.map((value: PoliticFactCheck, index: number) => (
           <FactItem factItem={value} key={index} />
         ))}
       </ul>

--- a/packages/politics-tracker/components/politics-detail/toggle-lists/position-change/index.tsx
+++ b/packages/politics-tracker/components/politics-detail/toggle-lists/position-change/index.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 
-import type { PositionChange } from '~/types/politics-detail'
+import type { PoliticPositionChange } from '~/types/politics-detail'
 import { getFormattedDate, getPositionChangeString } from '~/utils/utils'
 
 const Wrapper = styled.div`
@@ -106,20 +106,20 @@ const ContentBlock = styled.div`
 `
 
 type PositionChangeProps = {
-  positions: PositionChange[]
+  positions: PoliticPositionChange[]
 }
 export default function PositionChange({
   positions = [],
 }: PositionChangeProps): JSX.Element {
-  const positionLists = positions.map((item: PositionChange) => {
+  const positionLists = positions.map((item: PoliticPositionChange) => {
     const {
-      id,
-      checkDate,
-      isChanged,
-      link,
-      content,
+      id = '',
+      checkDate = '',
+      isChanged = '',
+      link = '',
+      content = '',
+      positionChangeSummary = '',
       factcheckPartner,
-      positionChangeSummary,
     } = item
 
     return (

--- a/packages/politics-tracker/components/politics-detail/toggle-lists/repeat/index.tsx
+++ b/packages/politics-tracker/components/politics-detail/toggle-lists/repeat/index.tsx
@@ -1,20 +1,20 @@
 import styled from 'styled-components'
 
 import RepeatItem from '~/components/politics-detail/toggle-lists/repeat/repeat-item'
-import type { Repeat } from '~/types/politics-detail'
+import type { PoliticRepeat } from '~/types/politics-detail'
 
 const Wrapper = styled.div`
   padding: 12px 0px 40px;
 `
 
 type RepeatProps = {
-  repeats: Repeat[]
+  repeats: PoliticRepeat[]
 }
 export default function Repeat({ repeats = [] }: RepeatProps): JSX.Element {
   return (
     <Wrapper>
       <ul>
-        {repeats.map((value: Repeat, index: number) => (
+        {repeats.map((value: PoliticRepeat, index: number) => (
           <RepeatItem repeatItem={value} key={index} />
         ))}
       </ul>

--- a/packages/politics-tracker/components/politics-detail/toggle-lists/repeat/repeat-item.tsx
+++ b/packages/politics-tracker/components/politics-detail/toggle-lists/repeat/repeat-item.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import RelatedLinks from '~/components/politics-detail/related-links'
 import { SOURCE_DELIMITER } from '~/constants/politics'
 import SimilarIcon from '~/public/icons/similar-policies.svg'
-import type { Repeat } from '~/types/politics-detail'
+import type { PoliticRepeat } from '~/types/politics-detail'
 
 const ListWrapper = styled.li`
   padding: 20px;
@@ -132,13 +132,18 @@ const Summary = styled.span`
   }
 `
 type RepeatItemProps = {
-  repeatItem: Repeat
+  repeatItem: PoliticRepeat
 }
 export default function RepeatItem({
   repeatItem,
 }: RepeatItemProps): JSX.Element {
-  const { link, content, factcheckPartner, contributer, repeatSummary } =
-    repeatItem
+  const {
+    link = '',
+    content = '',
+    contributer = '',
+    repeatSummary = '',
+    factcheckPartner,
+  } = repeatItem
 
   const repeatText = content.split(SOURCE_DELIMITER).map((item, index) => {
     return (

--- a/packages/politics-tracker/components/politics-detail/toggle-lists/response/index.tsx
+++ b/packages/politics-tracker/components/politics-detail/toggle-lists/response/index.tsx
@@ -1,14 +1,14 @@
 import styled from 'styled-components'
 
 import ResponseItem from '~/components/politics-detail/toggle-lists/response/response-item'
-import type { Response } from '~/types/politics-detail'
+import type { PoliticResponse } from '~/types/politics-detail'
 
 const Wrapper = styled.div`
   padding: 12px 0px 40px;
 `
 
 type ResponseProps = {
-  responses: Response[]
+  responses: PoliticResponse[]
 }
 export default function Response({
   responses = [],
@@ -16,7 +16,7 @@ export default function Response({
   return (
     <Wrapper>
       <ul>
-        {responses.map((value: Response, index: number) => (
+        {responses.map((value: PoliticResponse, index: number) => (
           <ResponseItem responseItem={value} key={index} />
         ))}
       </ul>

--- a/packages/politics-tracker/components/politics-detail/toggle-lists/response/response-item.tsx
+++ b/packages/politics-tracker/components/politics-detail/toggle-lists/response/response-item.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 
 import RelatedLinks from '~/components/politics-detail/related-links'
 import { SOURCE_DELIMITER } from '~/constants/politics'
-import type { Response } from '~/types/politics-detail'
+import type { PoliticResponse } from '~/types/politics-detail'
 
 const ListWrapper = styled.li`
   padding: 20px;
@@ -82,13 +82,18 @@ const Title = styled.p`
 `
 
 type ResponseItemProps = {
-  responseItem: Response
+  responseItem: PoliticResponse
 }
 export default function ResponseItem({
   responseItem,
 }: ResponseItemProps): JSX.Element {
-  const { responseName, responsePic, responseTitle, content, link } =
-    responseItem
+  const {
+    responseName = '',
+    responsePic = '',
+    responseTitle = '',
+    content = '',
+    link = '',
+  } = responseItem
 
   const responseText = content.split(SOURCE_DELIMITER).map((item, index) => {
     return <p key={index}>{item}</p>

--- a/packages/politics-tracker/components/politics-detail/toggle-lists/timeline.tsx
+++ b/packages/politics-tracker/components/politics-detail/toggle-lists/timeline.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components'
 
 import DefaultText from '~/components/politics-detail/default-text'
-import type { TimeLine } from '~/types/politics-detail'
+import type { PoliticTimeLine } from '~/types/politics-detail'
 import { getFormattedDate } from '~/utils/utils'
 
 const Wrapper = styled.div`
@@ -58,12 +58,12 @@ const ContentBlock = styled.div`
 `
 
 type TimelineProps = {
-  timelines: TimeLine[]
+  timelines: PoliticTimeLine[]
 }
 export default function Timeline({
   timelines = [],
 }: TimelineProps): JSX.Element {
-  const timeLists = timelines.map((item: TimeLine) => {
+  const timeLists = timelines.map((item: PoliticTimeLine) => {
     const { id, eventDate, link, content } = item
 
     return (

--- a/packages/politics-tracker/components/politics/politic-block.tsx
+++ b/packages/politics-tracker/components/politics/politic-block.tsx
@@ -8,7 +8,7 @@ import PoliticBody from './politic-body'
 type PoliticBlockProps = Pick<
   PersonElection,
   'politics' | 'source' | 'lastUpdate' | 'shouldShowFeedbackForm'
-> & { hidePoliticDetail: string | null } & { isPartyPage: boolean }
+> & { hidePoliticDetail: string | null } & { isPartyPage?: boolean }
 
 type GroupData = {
   name: string

--- a/packages/politics-tracker/components/politics/politic-body.tsx
+++ b/packages/politics-tracker/components/politics/politic-body.tsx
@@ -31,7 +31,7 @@ type PoliticBodyProps = Politic & {
   no: number
   hidePoliticDetail: string | null
   shouldShowFeedbackForm: boolean
-  isPartyPage: boolean
+  isPartyPage?: boolean
 }
 
 export default function PoliticBody(props: PoliticBodyProps): JSX.Element {

--- a/packages/politics-tracker/components/politics/section-body.tsx
+++ b/packages/politics-tracker/components/politics/section-body.tsx
@@ -23,7 +23,7 @@ type SectionBodyProps = Pick<
   | 'hidePoliticDetail'
   | 'electionType'
   | 'shouldShowFeedbackForm'
-> & { show: boolean } & { isPartyPage: boolean }
+> & { show: boolean } & { isPartyPage?: boolean }
 
 const Button = styled.button`
   margin: auto;

--- a/packages/politics-tracker/components/politics/section-list.tsx
+++ b/packages/politics-tracker/components/politics/section-list.tsx
@@ -7,10 +7,10 @@ import SectionBody from './section-body'
 import s from './section-list.module.css'
 import SectionToggle from './section-toggle'
 
-type SectionListProps = PersonElection & { order: number } & {
-  isPartyPage: boolean
+type SectionListProps = PersonElection & {
+  order: number
+  isPartyPage?: boolean
 }
-
 export default function SectionList(props: SectionListProps): JSX.Element {
   const [isActive, setIsActive] = useState<boolean>(props.order === 0)
 
@@ -22,7 +22,6 @@ export default function SectionList(props: SectionListProps): JSX.Element {
           content={props.name}
           isActive={isActive}
           setActive={() => setIsActive(!isActive)}
-          isPartyPage={props.isPartyPage}
         />
         <SectionBody
           show={isActive}
@@ -35,7 +34,6 @@ export default function SectionList(props: SectionListProps): JSX.Element {
           electionType={props.electionType}
           organizationId={props.organizationId}
           shouldShowFeedbackForm={props.shouldShowFeedbackForm}
-          isPartyPage={props.isPartyPage}
         />
       </div>
     </PersonElectionContext.Provider>

--- a/packages/politics-tracker/components/politics/section-toggle.tsx
+++ b/packages/politics-tracker/components/politics/section-toggle.tsx
@@ -31,7 +31,7 @@ type SectionToggleProps = {
   electionTerm: PersonElectionTerm
   elected: boolean
   incumbent: boolean
-  isPartyPage: boolean
+  isPartyPage?: boolean
 }
 export default function SectionToggle(props: SectionToggleProps): JSX.Element {
   const toggleClass = props.isActive ? s['toggle-active'] : s['toggle']

--- a/packages/politics-tracker/components/politics/title.tsx
+++ b/packages/politics-tracker/components/politics/title.tsx
@@ -117,11 +117,7 @@ type TextConfig = {
   customClass: string
 }
 
-export default function Title(
-  props: PersonOverview & {
-    isPartyPage: boolean
-  }
-): JSX.Element {
+export default function Title(props: PersonOverview): JSX.Element {
   const personLarge: IconConfig = {
     width: 60,
     height: 60,

--- a/packages/politics-tracker/components/shared/election-term.tsx
+++ b/packages/politics-tracker/components/shared/election-term.tsx
@@ -1,5 +1,7 @@
 import styled from 'styled-components'
 
+import { PersonElectionTerm } from '~/types/politics-detail'
+
 const Term = styled.div`
   padding: 4px;
   border: 1px solid ${({ theme }) => theme.borderColor.black};
@@ -14,20 +16,11 @@ const Term = styled.div`
   }
 `
 
-type TermDate = {
-  start_date_day: string | null
-  start_date_month: string | null
-  start_date_year: string | null
-  end_date_day: string | null
-  end_date_month: string | null
-  end_date_year: string | null
-}
 type ElectionTermProps = {
-  termDate: TermDate
+  termDate: PersonElectionTerm
   isElected?: boolean
   isIncumbent?: boolean
 }
-
 export default function ElectionTerm({
   termDate,
   isElected = false,
@@ -36,9 +29,9 @@ export default function ElectionTerm({
   if (!termDate || termDate === null) {
     return null
   }
+  //不顯示任期狀況：（1)候選人未當選 (2) termDate 為空物件 (3)有 termDate 但所有任期時間皆為 null (4)政黨頁面
   const isValuesNull = Object.values(termDate).every((value) => value === null)
 
-  //不顯示任期狀況：（1)未當選 (2) termDate 為空物件 (3)有 termDate 但所有任期時間皆為 null
   if (!isElected || Object.keys(termDate).length === 0 || isValuesNull) {
     return null
   }

--- a/packages/politics-tracker/components/shared/legislator-at-large.tsx
+++ b/packages/politics-tracker/components/shared/legislator-at-large.tsx
@@ -106,7 +106,7 @@ export default function LegislatorAtLarge({
         <Group>
           <span className="subtitle">當選</span>
           {electedList.map((legislator, index) => (
-            <div key={index}>
+            <>
               <List
                 href={`/person/${legislator.person_id.id}`}
                 target="_blank"
@@ -115,7 +115,7 @@ export default function LegislatorAtLarge({
                 <li>{legislator.person_id.name}</li>
               </List>
               {index < electedList.length - 1 && <span>、</span>}
-            </div>
+            </>
           ))}
         </Group>
       )}
@@ -124,7 +124,7 @@ export default function LegislatorAtLarge({
         <Group>
           <span className="subtitle">未當選</span>
           {notElectedList.map((legislator, index) => (
-            <div key={index}>
+            <>
               <List
                 href={`/person/${legislator.person_id.id}`}
                 target="_blank"
@@ -133,7 +133,7 @@ export default function LegislatorAtLarge({
                 <li>{legislator.person_id.name}</li>
               </List>
               {index < notElectedList.length - 1 && <span>、</span>}
-            </div>
+            </>
           ))}
         </Group>
       )}

--- a/packages/politics-tracker/components/shared/legislator-at-large.tsx
+++ b/packages/politics-tracker/components/shared/legislator-at-large.tsx
@@ -1,0 +1,170 @@
+import { useState } from 'react'
+import styled, { css } from 'styled-components'
+
+import ArrowDown from '~/public/icons/arrow-down-yellow.svg'
+import type { LegislatorAtLarge } from '~/types/politics'
+
+const dotStyle = css`
+  width: 6px;
+  height: 6px;
+  background-color: ${({ theme }) => theme.backgroundColor.landingYellow};
+  border-radius: 50%;
+  position: absolute;
+`
+
+const Wrapper = styled.div`
+  margin-bottom: 32px;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.5;
+
+  ${({ theme }) => theme.breakpoint.md} {
+    font-size: 14px;
+  }
+`
+
+const Title = styled.div<{ isOpen: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 4px;
+  cursor: pointer;
+  width: fit-content;
+  color: ${({ theme }) => theme.textColor.black};
+  margin-bottom: 12px;
+
+  > svg {
+    transform: ${({ isOpen }) => (isOpen ? 'rotate(180deg)' : 'rotate(0deg)')};
+
+    path {
+      fill: ${({ theme }) => theme.textColor.black30};
+    }
+  }
+`
+
+const LegislatorContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  box-shadow: 0px -1px 0px 0px rgba(0, 0, 0, 0.1) inset;
+  padding-bottom: 12px;
+`
+
+const Group = styled.div`
+  color: ${({ theme }) => theme.textColor.black50};
+
+  .subtitle {
+    color: ${({ theme }) => theme.textColor.yellow};
+    padding: 0px 8px 0px 14px;
+    border-right: 1px solid rgba(0, 0, 0, 0.1);
+    margin-right: 8px;
+    position: relative;
+
+    &::before {
+      ${dotStyle}
+      content: '';
+      position: absolute;
+      left: 0px;
+      top: 8px;
+    }
+  }
+`
+
+const List = styled.a`
+  color: ${({ theme }) => theme.textColor.black50};
+  list-style: none;
+  display: inline-block;
+  width: fit-content;
+  transition: all 0.1s ease-out;
+
+  &:hover {
+    color: ${({ theme }) => theme.textColor.black};
+  }
+`
+
+type LegislatorAtLargeProps = {
+  legislators: LegislatorAtLarge[]
+  isElectionFinished: boolean
+}
+export default function LegislatorAtLarge({
+  legislators = [],
+  isElectionFinished = false,
+}: LegislatorAtLargeProps): JSX.Element | null {
+  const [isOpen, setIsOpen] = useState(false)
+
+  if (!legislators.length) return null
+
+  const filterLegislators = (isElected: boolean) =>
+    legislators.filter((legislator) => legislator.elected === isElected)
+
+  const electedList = filterLegislators(true) || [] //當選名單
+  const notElectedList = filterLegislators(false) || [] //未當選名單
+
+  const legislatorLists = isElectionFinished ? (
+    <>
+      {electedList.length > 0 && (
+        <Group>
+          <span className="subtitle">當選</span>
+          {electedList.map((legislator, index) => (
+            <div key={index}>
+              <List
+                href={`/person/${legislator.person_id.id}`}
+                target="_blank"
+                rel="noreferrer nooppener"
+              >
+                <li>{legislator.person_id.name}</li>
+              </List>
+              {index < electedList.length - 1 && <span>、</span>}
+            </div>
+          ))}
+        </Group>
+      )}
+
+      {notElectedList.length > 0 && (
+        <Group>
+          <span className="subtitle">未當選</span>
+          {notElectedList.map((legislator, index) => (
+            <div key={index}>
+              <List
+                href={`/person/${legislator.person_id.id}`}
+                target="_blank"
+                rel="noreferrer nooppener"
+              >
+                <li>{legislator.person_id.name}</li>
+              </List>
+              {index < notElectedList.length - 1 && <span>、</span>}
+            </div>
+          ))}
+        </Group>
+      )}
+    </>
+  ) : (
+    <Group>
+      <span className="subtitle">提名</span>
+      {legislators.map((legislator, index) => (
+        <>
+          <List
+            href={`/person/${legislator.person_id.id}`}
+            key={index}
+            target="_blank"
+            rel="noreferrer nooppener"
+          >
+            <li>{legislator.person_id.name}</li>
+          </List>
+          {index < legislators.length - 1 && <span>、</span>}
+        </>
+      ))}
+    </Group>
+  )
+
+  return (
+    <Wrapper>
+      <Title onClick={() => setIsOpen(!isOpen)} isOpen={isOpen}>
+        <span>不分區立委名單</span>
+        <ArrowDown />
+      </Title>
+
+      {isOpen && <LegislatorContainer>{legislatorLists}</LegislatorContainer>}
+    </Wrapper>
+  )
+}

--- a/packages/politics-tracker/graphql/query/politics-detail/get-politic-detail.graphql
+++ b/packages/politics-tracker/graphql/query/politics-detail/get-politic-detail.graphql
@@ -14,6 +14,7 @@ query GetPoliticDetail($politicId: ID!) {
     current_progress
     updatedAt
     contributer
+
     person {
       id
       votes_obtained_number
@@ -44,6 +45,26 @@ query GetPoliticDetail($politicId: ID!) {
         image
       }
     }
+
+    organization {
+      id
+      organization_id {
+        id
+        name
+        image
+      }
+      elections {
+        id
+        name
+        type
+        level
+        status
+        election_year_year
+        election_year_month
+        election_year_day
+      }
+    }
+
     timeline(orderBy: { eventDate: asc }) {
       id
       eventDate

--- a/packages/politics-tracker/graphql/query/politics/get-person-elections-related-to-party.graphql
+++ b/packages/politics-tracker/graphql/query/politics/get-person-elections-related-to-party.graphql
@@ -1,0 +1,16 @@
+query GetPersonElectionsRelatedToParty($electionId: ID!, $partyId: ID!) {
+  personElections(
+    where: {
+      election: { id: { equals: $electionId } }
+      party: { id: { equals: $partyId } }
+    }
+    orderBy: { legislatoratlarge_number: asc }
+  ) {
+    id
+    elected
+    person_id {
+      id
+      name
+    }
+  }
+}

--- a/packages/politics-tracker/pages/politics/[personId].tsx
+++ b/packages/politics-tracker/pages/politics/[personId].tsx
@@ -52,8 +52,6 @@ type PoliticsPageProps = {
   latestElection: PersonElection
 }
 
-const isPartyPage = false
-
 export default function Politics(props: PoliticsPageProps) {
   const { asPath } = useRouter()
 
@@ -93,7 +91,7 @@ export default function Politics(props: PoliticsPageProps) {
   }
 
   const sections = props.elections.map((e, index) => (
-    <SectionList key={e.id} order={index} {...e} isPartyPage={isPartyPage} />
+    <SectionList key={e.id} order={index} {...e} />
   ))
 
   return (
@@ -104,11 +102,7 @@ export default function Politics(props: PoliticsPageProps) {
         url={`${siteUrl}${asPath}`}
       />
       <main className="flex w-screen flex-col items-center bg-politics">
-        <Title
-          {...props.titleProps}
-          {...politicAmounts}
-          isPartyPage={isPartyPage}
-        />
+        <Title {...props.titleProps} {...politicAmounts} />
         <div className="my-10 lg:my-[40px]">
           <PoliticAmountContext.Provider
             value={{ amount: politicAmounts, setAmount: setAmount }}

--- a/packages/politics-tracker/pages/politics/detail/[politicId].tsx
+++ b/packages/politics-tracker/pages/politics/detail/[politicId].tsx
@@ -110,7 +110,6 @@ export default function PoliticsDetail({
       <CustomHead {...headProps} url={`${siteUrl}${asPath}`} />
       <Main>
         <Title
-          isPartyPage={false}
           campaign={latestPersonElection.election?.type ?? ''}
           {...titleProps}
         />

--- a/packages/politics-tracker/pages/politics/party/detail/[politicId].tsx
+++ b/packages/politics-tracker/pages/politics/party/detail/[politicId].tsx
@@ -1,0 +1,227 @@
+// @ts-ignore: no definition
+// eslint-disable-next-line simple-import-sort/imports
+import errors from '@twreporter/errors'
+import { print } from 'graphql'
+import type { GetServerSideProps } from 'next'
+import { useRouter } from 'next/router'
+import styled from 'styled-components'
+
+import CustomHead from '~/components/custom-head'
+import DefaultLayout from '~/components/layout/default'
+import Nav from '~/components/nav'
+import Section from '~/components/politics-detail/section'
+import Title from '~/components/politics/title'
+import { cmsApiUrl } from '~/constants/config'
+import { siteUrl } from '~/constants/environment-variables'
+import GetPoliticDetail from '~/graphql/query/politics-detail/get-politic-detail.graphql'
+import type { PersonElectionTerm, PoliticDetail } from '~/types/politics-detail'
+import { fireGqlRequest } from '~/utils/utils'
+import GetPersonElectionsRelatedToParty from '~/graphql/query/politics/get-person-elections-related-to-party.graphql'
+import type { LegislatorAtLarge } from '~/types/politics'
+
+const Main = styled.main`
+  background-color: #fffcf3;
+  height: 100%;
+  min-height: 100vh;
+  margin-top: 64px;
+  padding-bottom: 40px;
+  ${({ theme }) => theme.breakpoint.md} {
+    margin-top: 80px;
+  }
+`
+
+type PartyPoliticsDetailProps = {
+  politic: PoliticDetail
+  electionTerm: PersonElectionTerm
+  legisLatorAtLarge: LegislatorAtLarge[]
+}
+export default function PartyPoliticsDetail({
+  politic,
+  electionTerm,
+  legisLatorAtLarge,
+}: PartyPoliticsDetailProps): JSX.Element {
+  const { asPath } = useRouter()
+  const { organization } = politic
+
+  const titleProps = {
+    id: organization?.organization_id.id || '',
+    name: organization?.organization_id.name || '',
+    avatar: organization?.organization_id.image || '',
+    party: '',
+    partyIcon: '',
+    completed: 0, //FIXME
+    waiting: 0, //FIXME
+  }
+
+  const navProps = {
+    prev: {
+      backgroundColor: 'bg-button',
+      textColor: 'text-black',
+      content: '回政見總覽',
+      href: {
+        pathname: '/politics/party/[organizationId]',
+        query: {
+          organizationId: organization?.organization_id.id,
+        },
+      },
+    },
+    alwaysShowHome: true,
+  }
+
+  //OG title & desc
+  const headProps = { title: '', description: '' }
+  headProps.title = `${organization?.organization_id?.name} - ${politic.desc}｜READr 政商人物資料庫`
+
+  return (
+    <DefaultLayout>
+      <CustomHead {...headProps} url={`${siteUrl}${asPath}`} />
+      <Main>
+        <Title
+          campaign={organization?.elections?.type || ''}
+          isPartyPage={true}
+          {...titleProps}
+        />
+        <Section
+          politic={politic}
+          electionTerm={electionTerm}
+          shouldShowFeedbackForm={true}
+          isPartyPage={true}
+          legislators={legisLatorAtLarge}
+        />
+      </Main>
+      <Nav {...navProps} />
+    </DefaultLayout>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps<
+  PartyPoliticsDetailProps
+> = async ({ query, res }) => {
+  res.setHeader(
+    'Cache-Control',
+    'public, max-age=600, stale-while-revalidate=60'
+  )
+
+  const id = query.politicId
+
+  let politic: PoliticDetail = {
+    id: '',
+    desc: '',
+    content: '',
+    source: '',
+    status: 'notverified',
+    current_progress: 'no-progress',
+    updatedAt: '',
+    contributer: '',
+    person: null,
+    timeline: [],
+    positionChange: [],
+    expertPoint: [],
+    factCheck: [],
+    repeat: [],
+    response: [],
+    controversies: [],
+    politicCategory: null,
+    organization: null,
+  }
+
+  let electionTerm: PersonElectionTerm = {
+    start_date_day: null,
+    start_date_month: null,
+    start_date_year: null,
+    end_date_day: null,
+    end_date_month: null,
+    end_date_year: null,
+  }
+
+  let legisLatorAtLarge: LegislatorAtLarge[] = []
+
+  try {
+    {
+      //get politics by politicId
+      const {
+        data: { politics },
+      } = await fireGqlRequest(
+        print(GetPoliticDetail),
+        { politicId: id },
+        cmsApiUrl
+      )
+
+      if (politics.errors) {
+        throw new Error(
+          'GraphQLerrors: Party Detail politics Error' +
+            JSON.stringify(politics.errors)
+        )
+      }
+
+      if (!politics.length) {
+        return {
+          notFound: true,
+        }
+      }
+
+      politic = politics[0] || []
+    }
+
+    {
+      //get person elections by electionId & partyId
+      const { organization } = politic
+
+      const {
+        data: { personElections },
+      } = await fireGqlRequest(
+        print(GetPersonElectionsRelatedToParty),
+        {
+          electionId: organization?.elections?.id,
+          partyId: organization?.organization_id.id,
+        },
+        cmsApiUrl
+      )
+
+      if (personElections.errors) {
+        throw new Error(
+          'GraphQLerrors: Party Detail personElections Error' +
+            JSON.stringify(personElections.errors)
+        )
+      }
+
+      if (!personElections.length) {
+        return {
+          notFound: true,
+        }
+      }
+
+      legisLatorAtLarge = personElections || []
+    }
+
+    return {
+      props: {
+        politic,
+        electionTerm,
+        legisLatorAtLarge,
+      },
+    }
+  } catch (err) {
+    // All exceptions that include a stack trace will be
+    // integrated with Error Reporting.
+    // See https://cloud.google.com/run/docs/error-reporting
+    console.error(
+      JSON.stringify({
+        severity: 'ERROR',
+        message: errors.helpers.printAll(
+          err,
+          {
+            withStack: true,
+            withPayload: true,
+          },
+          0,
+          0
+        ),
+      })
+    )
+
+    return {
+      notFound: true,
+    }
+  }
+}

--- a/packages/politics-tracker/types/common.ts
+++ b/packages/politics-tracker/types/common.ts
@@ -23,8 +23,8 @@ export type RawElectionArea = Partial<{
   status: StatusOptionsA
   createdAt: string
   updatedAt: string
-  createdBy: string
-  updatedBy: string
+  createdBy: GenericUser
+  updatedBy: GenericUser
 }>
 
 export type RawElection = Partial<{
@@ -42,8 +42,8 @@ export type RawElection = Partial<{
   status: StatusOptionsA
   createdAt: string
   updatedAt: string
-  createdBy: string
-  updatedBy: string
+  createdBy: GenericUser
+  updatedBy: GenericUser
   hidePoliticDetail: string
   addComments: boolean
 }>
@@ -82,8 +82,8 @@ export type RawPerson = Partial<{
   thread_parent: RawPerson
   createdAt: string
   updatedAt: string
-  createdBy: string
-  updatedBy: string
+  createdBy: GenericUser
+  updatedBy: GenericUser
 }>
 
 export type RawOrganization = Partial<{
@@ -109,12 +109,13 @@ export type RawOrganization = Partial<{
   status: StatusOptionsB
   createdAt: string
   updatedAt: string
-  createdBy: string
-  updatedBy: string
+  createdBy: GenericUser
+  updatedBy: GenericUser
 }>
 
 export type RawPersonElection = Partial<{
   id: string
+  name: string
   person_id: RawPerson
   election: RawElection
   party: RawOrganization
@@ -129,8 +130,8 @@ export type RawPersonElection = Partial<{
   politicSource: string
   createdAt: string
   updatedAt: string
-  createdBy: string
-  updatedBy: string
+  createdBy: GenericUser
+  updatedBy: GenericUser
   mainCandidate: MainCandidate
 }>
 
@@ -170,8 +171,8 @@ export type RawTag = Partial<{
   isFeatured: boolean
   createdAt: string
   updatedAt: string
-  createdBy: string
-  updatedBy: string
+  createdBy: GenericUser
+  updatedBy: GenericUser
 }>
 
 export enum PROGRESS {
@@ -196,8 +197,8 @@ export type RawPolitic = Partial<{
   politicCategory: RawTag
   createdAt: string
   updatedAt: string
-  createdBy: string
-  updatedBy: string
+  createdBy: GenericUser
+  updatedBy: GenericUser
 }>
 
 export type Source = {
@@ -213,3 +214,268 @@ export type FeedbackFormConfig = Record<'emoji' | 'text', FormConfig>
 // This utility is for overwriting type without extending it
 // prettier-ignore
 export type Override<T, U extends Partial<Record<keyof T, unknown>>> = Omit<T, keyof U> & U
+
+export type GenericProgressType =
+  | 'no-progress' // 還沒開始
+  | 'in-progress' // 進行中
+  | 'in-trouble' // 卡關中
+  | 'complete' // 已完成
+
+export type GenericStatus =
+  | 'verified' //已確認
+  | 'notverified' //未確認
+
+export type GenericPositionChange = Partial<{
+  id: string
+  positionChangeSummary: string
+  isChanged: string
+  factcheckPartner: GenericFactCheckPartner | null
+  content: string
+  checkDate: string
+  link: string
+  politic: RawPolitic
+  politicCount: number
+  editingPolitic: RawPolitic
+  editingPoliticCount: number
+  createdAt: string
+  updatedAt: string
+  createdBy: GenericUser
+  updatedBy: GenericUser
+}>
+
+export type GenericFactCheck = Partial<{
+  id: string
+  factCheckSummary: string
+  checkResultType: string
+  checkResultOther: string
+  factcheckPartner: GenericFactCheckPartner | null
+  content: string
+  link: string
+  politic: RawPolitic
+  politicCount: number
+  editingPolitic: RawPolitic
+  editingPoliticCount: number
+  createdAt: string
+  updatedAt: string
+  createdBy: GenericUser
+  updatedBy: GenericUser
+}>
+
+export type GenericRepeat = Partial<{
+  id: string
+  repeatSummary: string
+  factcheckPartner: GenericFactCheckPartner | null
+  content: string
+  link: string
+  contributer: string
+  politic: RawPolitic
+  politicCount: number
+  editingPolitic: RawPolitic
+  editingPoliticCount: number
+  createdAt: string
+  updatedAt: string
+  createdBy: GenericUser
+  updatedBy: GenericUser
+}>
+
+export type GenericExpert = Partial<{
+  id: string
+  expertPointSummary: string
+  expert: string
+  avatar: string
+  content: string
+  link: string
+  title: string
+  contributer: string
+  politic: RawPolitic
+  politicCount: number
+  editingPolitic: RawPolitic
+  editingPoliticCount: number
+  createdAt: string
+  updatedAt: string
+  createdBy: GenericUser
+  updatedBy: GenericUser
+}>
+
+export type GenericFactCheckPartner = Partial<{
+  id: string
+  name: string
+  type: string
+  webUrl: string
+  logo: GenericPhoto // for Landing Page
+  slogo: GenericPhoto // for Politic Detail Page
+  year: string
+  postsCount: number
+  positionChange: GenericPositionChange
+  positionChangeCount: number
+  factCheck: GenericFactCheck
+  factCheckCount: number
+  repeat: GenericRepeat
+  repeatCount: number
+  createdAt: string
+  updatedAt: string
+  createdBy: GenericUser
+  updatedBy: GenericUser
+}>
+
+export type GenericResizedImages = Partial<{
+  original: string
+  w480: string
+  w800: string
+  w1200: string
+  w1600: string
+  w2400: string
+}>
+
+export type GenericPersonOrganization = Partial<{
+  id: string
+  person_id: RawPerson
+  organization_id: GenericOrganization
+  election: RawPersonElection
+  role: string
+  start_date_year: string | null
+  start_date_month: string | null
+  start_date_day: string | null
+  end_date_year: string | null
+  end_date_month: string | null
+  end_date_day: string | null
+  source: string
+  createdAt: string
+  updatedAt: string
+  createdBy: GenericUser
+  updatedBy: GenericUser
+}>
+
+export type GenericPoliticCategory = Partial<{
+  id: string
+  name: string
+  brief: string
+  displayColor: string
+  ogTitle: string
+  ogDescription: string
+  isFeatured: boolean
+  politics: RawPolitic
+  politicsCount: number
+  createdAt: string
+  updatedAt: string
+  createdBy: GenericUser
+  updatedBy: GenericUser
+}>
+
+export type GenericUser = Partial<{
+  id: string
+  name: string
+  email: string
+  password: { isSet: boolean }
+  role: string
+  isProtected: boolean
+}>
+
+export type GenericOrganization = Partial<{
+  id: string
+  name: string
+  alternative: string | null
+  other_names: string | null
+  identifiers: string | null
+  classification: string
+  abstract: string | null
+  description: string | null
+  founding_date_year: string
+  founding_date_month: string
+  founding_date_day: string
+  dissolution_date_year: string
+  dissolution_date_month: string
+  dissolution_date_day: string
+  image: string | null
+  contact_details: string | null
+  links: string | null
+  address: string | null
+  source: string | null
+  status: GenericStatus
+  tags: GenericPoliticCategory
+  tagsCount: number
+  reviewed: boolean
+  createdAt: string
+  updatedAt: string
+  createdBy: GenericUser
+  updatedBy: GenericUser
+}>
+
+export type GenericPhoto = Partial<{
+  id: string
+  name: string
+  resized: GenericResizedImages
+  urlOriginal: string
+  createdAt: string
+  updatedAt: string
+  createdBy: GenericUser
+  updatedBy: GenericUser
+}>
+
+export type GenericResponse = Partial<{
+  id: string
+  politic: RawPolitic
+  politicCount: number
+  responseName: string
+  responsePic: string
+  responseTitle: string
+  content: string
+  link: string
+  editingPolitic: RawPolitic
+  editingPoliticCount: number
+  createdAt: string
+  updatedAt: string
+  createdBy: GenericUser
+  updatedBy: GenericUser
+}>
+
+export type GenericTimeline = Partial<{
+  id: string
+  politic: RawPolitic
+  politicCount: number
+  eventDate: string
+  sortOrder: number
+  content: string
+  link: string
+  contributer: string
+  editingPolitic: RawPolitic
+  editingPoliticCount: number
+  createdAt: string
+  updatedAt: string
+  createdBy: GenericUser
+  updatedBy: GenericUser
+}>
+
+export type GenericControversy = Partial<{
+  id: string
+  politic: RawPolitic
+  politicCount: number
+  content: string
+  factcheckPartner: GenericFactCheckPartner | null
+  link: string
+  editingPolitic: RawPolitic
+  editingPoliticCount: number
+  createdAt: string
+  updatedAt: string
+  createdBy: GenericUser
+  updatedBy: GenericUser
+}>
+
+export type GenericOrganizationElection = {
+  id: string
+  organization_id: RawOrganization
+  election_year_year: number
+  election_year_month: number
+  election_year_day: number
+  number: number
+  votes_obtained_number: number
+  seats: string
+  source: string
+  elections: RawElection
+  politics: RawPolitic
+  politicsCount: number
+  createdAt: string
+  updatedAt: string
+  createdBy: GenericUser
+  updatedBy: GenericUser
+}

--- a/packages/politics-tracker/types/landing.ts
+++ b/packages/politics-tracker/types/landing.ts
@@ -1,5 +1,15 @@
-import type { PersonElection } from '~/types/politics'
-import type { FactCheckPartner, PoliticDetail } from '~/types/politics-detail'
+import type {
+  GenericFactCheckPartner,
+  GenericPoliticCategory,
+} from '~/types/common'
+import type {
+  ExpertPoint,
+  FactCheck,
+  PersonElection,
+  PositionChange,
+  Repeat,
+} from '~/types/politics'
+import type { PoliticDetail } from '~/types/politics-detail'
 
 // 候選人資料
 export type Candidate = {
@@ -82,7 +92,7 @@ export type RelatedPost = {
   url: string
   ogIMage: string
   createdAt: string
-  partner: Pick<FactCheckPartner, 'id' | 'name'>[]
+  partner: Pick<GenericFactCheckPartner, 'id' | 'name'>[]
 }
 
 export type CategoryOfJson = {
@@ -112,18 +122,14 @@ export type PresidentFactCheckJson = {
   politics: PoliticOfJson[]
 }
 
-export type PoliticOfJson = Pick<
-  PoliticDetail,
-  | 'id'
-  | 'desc'
-  | 'politicCategory'
-  | 'positionChange'
-  | 'expertPoint'
-  | 'factCheck'
-  | 'repeat'
-> & {
+export type PoliticOfJson = Pick<PoliticDetail, 'id' | 'desc'> & {
   positionChangeCount: number
   expertPointCount: number
   factCheckCount: number
   repeatCount: number
+  positionChange: PositionChange[]
+  factCheck: FactCheck[]
+  expertPoint: ExpertPoint[]
+  repeat: Repeat[]
+  politicCategory: Pick<GenericPoliticCategory, 'id' | 'name'> | null
 }

--- a/packages/politics-tracker/types/politics-detail.ts
+++ b/packages/politics-tracker/types/politics-detail.ts
@@ -1,181 +1,150 @@
+import type {
+  GenericExpert,
+  GenericFactCheck,
+  GenericFactCheckPartner,
+  GenericOrganizationElection,
+  GenericPoliticCategory,
+  GenericPositionChange,
+  GenericProgressType,
+  GenericRepeat,
+  GenericResponse,
+  GenericStatus,
+  GenericTimeline,
+  RawElection,
+  RawOrganization,
+  RawPersonElection,
+} from '~/types/common'
+
 export type PoliticDetail = {
   id: string
-  content: string
-  current_progress: string
-  desc: string
-  expertPoint: ExpertPoint[]
+  desc: string //政見內容
+  content: string //政策補充說明
+  source: string //資料來源
+  status: GenericStatus //狀態
+  current_progress: GenericProgressType //政見進度
+  updatedAt: string //更新時間
+  contributer: string // 資料提供
+  politicCategory: Pick<GenericPoliticCategory, 'id'> | null //類別
+  expertPoint: PoliticExpert[] //專家看點
+  positionChange: PoliticPositionChange[] //立場變化
+  factCheck: PoliticFactCheck[] //事實查核
+  repeat: PoliticRepeat[] //重複政見
+  response: PoliticResponse[] //政見回應
+  controversies: PoliticControversy[] //爭議內容
+  timeline: PoliticTimeLine[] //時間軸（相關進度）
+  organization: OrganizationElection | null
   person: PersonElection | null
-  timeline: TimeLine[]
-  source: string
-  status: string
-  updatedAt: string
-  positionChange: PositionChange[]
-  factCheck: FactCheck[]
-  repeat: Repeat[]
-  response: Response[]
-  controversies: Controversy[]
-  contributer: string
-  politicCategory: Pick<PoliticCategory, 'id'> | null
-  organization: Pick<OrganizationElection, 'id'> | null
 }
 
-//任期
+export type OrganizationElection = {
+  id: Pick<GenericOrganizationElection, 'id'>
+  organization_id: Pick<RawOrganization, 'id' | 'name' | 'image'>
+  elections: Pick<
+    RawElection,
+    | 'id'
+    | 'name'
+    | 'type'
+    | 'level'
+    | 'status'
+    | 'election_year_year'
+    | 'election_year_month'
+    | 'election_year_day'
+  >
+  electoral_district: string
+}
+
+export type PoliticFactCheck = Pick<
+  GenericFactCheck,
+  | 'id'
+  | 'factCheckSummary'
+  | 'checkResultType'
+  | 'checkResultOther'
+  | 'factcheckPartner'
+  | 'content'
+  | 'link'
+>
+
+export type PoliticPositionChange = Pick<
+  GenericPositionChange,
+  | 'id'
+  | 'positionChangeSummary'
+  | 'isChanged'
+  | 'factcheckPartner'
+  | 'content'
+  | 'checkDate'
+  | 'link'
+>
+
+export type PoliticRepeat = Pick<
+  GenericRepeat,
+  | 'id'
+  | 'repeatSummary'
+  | 'factcheckPartner'
+  | 'content'
+  | 'link'
+  | 'contributer'
+>
+
+export type PoliticExpert = Pick<
+  GenericExpert,
+  | 'id'
+  | 'expertPointSummary'
+  | 'expert'
+  | 'avatar'
+  | 'content'
+  | 'link'
+  | 'title'
+  | 'contributer'
+>
+
+export type PersonElection = Pick<
+  RawPersonElection,
+  | 'id'
+  | 'electoral_district'
+  | 'party'
+  | 'election'
+  | 'person_id'
+  | 'votes_obtained_number'
+  | 'votes_obtained_percentage'
+  | 'elected'
+  | 'incumbent'
+>
+
+export type PoliticCategory = Pick<
+  GenericPoliticCategory,
+  'id' | 'name' | 'politicsCount'
+>
+export type PoliticResponse = Pick<
+  GenericResponse,
+  'id' | 'content' | 'responseName' | 'responsePic' | 'responseTitle' | 'link'
+>
+
+export type PoliticTimeLine = Pick<
+  GenericTimeline,
+  'id' | 'link' | 'content' | 'eventDate'
+>
+
+export type PoliticControversy = {
+  id: string
+  link: string
+  content: string
+}
+
+export type FactCheckPartner = Pick<
+  GenericFactCheckPartner,
+  'id' | 'logo' | 'name' | 'type' | 'webUrl'
+>
+
 export type PersonElectionTerm = {
-  start_date_day: string | null
-  start_date_month: string | null
   start_date_year: string | null
-  end_date_day: string | null
-  end_date_month: string | null
+  start_date_month: string | null
+  start_date_day: string | null
   end_date_year: string | null
-}
-
-//立場改變
-export type PositionChange = {
-  content: string
-  checkDate: string
-  id: string
-  link: string
-  isChanged: string
-  positionChangeSummary: string
-  factcheckPartner: FactCheckPartner | null
-}
-
-//相似政見
-export type Repeat = {
-  id: string
-  content: string
-  link: string
-  contributer: string
-  factcheckPartner: FactCheckPartner | null
-  repeatSummary: string
-}
-
-//事實查核
-export type FactCheck = {
-  id: string
-  checkResultType: string
-  content: string
-  link: string
-  factcheckPartner: FactCheckPartner | null
-  factCheckSummary: string
-  checkResultOther: string
-}
-
-//專家看點
-export type ExpertPoint = {
-  avatar: string
-  content: string
-  expert: string
-  id: string
-  link: string
-  title: string
-  expertPointSummary: string
-  contributer: string
-}
-
-//候選人回應
-export type Response = {
-  id: string
-  content: string
-  responseName: string
-  responsePic: string
-  responseTitle: string
-  link: string
-}
-
-//相關進度
-export type TimeLine = {
-  content: string
-  eventDate: string
-  id: string
-  link: string
-}
-
-//相關爭議
-export type Controversy = {
-  id: string
-  link: string
-  content: string
+  end_date_month: string | null
+  end_date_day: string | null
 }
 
 export type PoliticAmount = {
   waiting: number
   passed: number
-}
-
-export type FactCheckPartner = {
-  id: string
-  name: string
-  type: string
-  webUrl: string
-} & Partial<{
-  logo: Logo // for `landing`
-  slogo: Logo // for `politic-detail`
-}>
-
-export type Resized = {
-  original: string
-} & Partial<{
-  w480: string
-  w800: string
-  w1200: string
-  w1600: string
-  w2400: string
-}>
-
-export type Logo = {
-  id: string
-  resized: Resized
-} & Partial<{
-  resizedWebp: Resized
-}>
-
-export type PersonElection = {
-  id: string
-  resized: Resized
-} & Partial<{
-  electoral_district: ElectoralDistrict
-  party: Party
-  election: Election
-  person_id: PersonId
-  votes_obtained_number: string
-  votes_obtained_percentage: string
-  elected: boolean
-  incumbent: boolean
-}>
-
-export type ElectoralDistrict = {
-  id: string
-  name: string
-}
-
-export type Party = {
-  name: string
-  image: string
-}
-
-export type Election = {
-  name: string
-  type: string
-  level: string
-  status: string
-  election_year_year: string
-  election_year_month: string
-  election_year_day: string
-}
-
-export type PersonId = {
-  id: string
-  name: string
-  image: string
-}
-
-export type PoliticCategory = {
-  id: string
-  name: String
-  politicsCount: string
-}
-
-export type OrganizationElection = {
-  id: string
 }

--- a/packages/politics-tracker/types/politics.ts
+++ b/packages/politics-tracker/types/politics.ts
@@ -1,3 +1,5 @@
+import type { RawPersonElection } from '~/types/common'
+
 import { PROGRESS } from './common'
 
 export type PersonOverview = {
@@ -9,7 +11,7 @@ export type PersonOverview = {
   campaign: string
   completed: number
   waiting: number
-  isPartyPage: boolean
+  isPartyPage?: boolean
 }
 
 export type PoliticAmount = Pick<PersonOverview, 'waiting' | 'completed'>
@@ -47,7 +49,7 @@ export type FactCheckPartner = {
 export type FactCheck = {
   id: string
   factCheckSummary: string
-  checkResultType: string | null
+  checkResultType: string
   checkResultOther: string
   factcheckPartner: FactCheckPartner | null
 }
@@ -112,4 +114,10 @@ export type PersonElection = {
   mainCandidate: MainCandidate | null
   organizationId: OrganizationId | null
   shouldShowFeedbackForm?: boolean
+}
+
+export type LegislatorAtLarge = {
+  elected: boolean
+  id: string
+  person_id: Pick<RawPersonElection, 'id' | 'name'>
 }

--- a/packages/politics-tracker/utils/politics-detail.ts
+++ b/packages/politics-tracker/utils/politics-detail.ts
@@ -1,21 +1,27 @@
-import type { Controversy } from '~/types/politics-detail'
+import type { PoliticControversy } from '~/types/politics-detail'
 
-function isSameContent(obj1: Controversy, obj2: Controversy): boolean {
+function isSameContent(
+  obj1: PoliticControversy,
+  obj2: PoliticControversy
+): boolean {
   return JSON.stringify(obj1) === JSON.stringify(obj2)
 }
 
 function getDifferentControversies(
-  array: Controversy[],
-  controversies: Controversy[]
-): Controversy[] | [] {
+  array: PoliticControversy[],
+  controversies: PoliticControversy[]
+): PoliticControversy[] | [] {
   const differentControversies = []
 
   for (const obj of array) {
-    const matchingControversy = controversies.find(
-      (controversy) => controversy.id === obj.id
+    const matchingPoliticControversy = controversies.find(
+      (PoliticControversy) => PoliticControversy.id === obj.id
     )
 
-    if (matchingControversy && !isSameContent(obj, matchingControversy)) {
+    if (
+      matchingPoliticControversy &&
+      !isSameContent(obj, matchingPoliticControversy)
+    ) {
       differentControversies.push(obj)
     }
   }
@@ -24,25 +30,27 @@ function getDifferentControversies(
 }
 
 function getControversyToConnect(
-  array: Controversy[],
-  controversyToAdd: Controversy[]
-): Controversy[] | [] {
+  array: PoliticControversy[],
+  PoliticControversyToAdd: PoliticControversy[]
+): PoliticControversy[] | [] {
   return (
-    array.filter((item: Controversy) => !controversyToAdd.includes(item)) || []
+    array.filter(
+      (item: PoliticControversy) => !PoliticControversyToAdd.includes(item)
+    ) || []
   )
 }
 
 function getControversyToAdd(
-  array: Controversy[],
-  controversies: Controversy[]
-): Controversy[] | [] {
+  array: PoliticControversy[],
+  controversies: PoliticControversy[]
+): PoliticControversy[] | [] {
   let listToAdd = []
 
-  const objWithPrefixed = array.filter((item: Controversy) =>
+  const objWithPrefixed = array.filter((item: PoliticControversy) =>
     item.id.startsWith('add-')
   )
   const objWithoutPrefixed = array.filter(
-    (item: Controversy) => !item.id.startsWith('add-')
+    (item: PoliticControversy) => !item.id.startsWith('add-')
   )
   const differentObjects = getDifferentControversies(
     objWithoutPrefixed,

--- a/packages/politics-tracker/utils/utils.ts
+++ b/packages/politics-tracker/utils/utils.ts
@@ -11,7 +11,7 @@ import {
   SOURCE_DELIMITER,
 } from '~/constants/politics'
 import tailwindConfig from '~/tailwind.config'
-import type { FactCheck } from '~/types/politics'
+import type { PoliticFactCheck } from '~/types/politics-detail'
 
 // ref: https://stackoverflow.com/questions/55604798/find-rendered-line-breaks-with-javascript
 function getLineBreaks(node: ChildNode) {
@@ -206,7 +206,10 @@ function getFormattedDate(
   return formattedDate
 }
 
-function getCheckResultString(checkResultType: string, factCheck: FactCheck) {
+function getCheckResultString(
+  checkResultType: string,
+  factCheck: PoliticFactCheck
+) {
   const checkResultMappings: { [key: string]: string } = {
     '1': '與所查資料相符',
     '2': '數據符合，但推論錯誤',

--- a/packages/politics-tracker/utils/utils.ts
+++ b/packages/politics-tracker/utils/utils.ts
@@ -192,10 +192,17 @@ function generateSourceMeta(
   }
 }
 
-function getFormattedDate(date: string): string | undefined {
+function getFormattedDate(
+  date: string,
+  formatIcon?: string
+): string | undefined {
   if (typeof date !== 'string' || !date) return
 
-  const formattedDate = dayjs(date).format('YYYY-MM-DD')
+  const formatStyle = formatIcon
+    ? `YYYY${formatIcon}MM${formatIcon}DD`
+    : 'YYYY-MM-DD'
+
+  const formattedDate = dayjs(date).format(formatStyle)
   return formattedDate
 }
 


### PR DESCRIPTION
### Notable Changes 
- 新增單一政見頁- 政黨 相關元件。
- 新增 graphql `GetPersonElectionsRelatedToParty`，取得特定選舉＆政黨的參選人（不分區立委）名單。
- 新增「不分區立委」下拉選單共用元件。
- 將 `isPartyPage` 參數改為選擇性參數，如沒傳入也不會報錯。
- 重構 `types/common`：新增各式 Generic types，以供各頁面使用。
- 調整 `types/politics-detail` 結構，並修改相關頁面 type 命名/設定。