### PR TITLE
feat(politics-tracker): add sitemaps for pages related to parties

### DIFF
--- a/packages/politics-tracker/graphql/query/sitemap/get-parties.graphql
+++ b/packages/politics-tracker/graphql/query/sitemap/get-parties.graphql
@@ -1,0 +1,10 @@
+query GetParties {
+  parties: organizations(where: {
+    status: { equals: "verified" },
+    classification: { equals: "party"}
+  }) {
+    id
+    createdAt
+    updatedAt
+  }
+}

--- a/packages/politics-tracker/graphql/query/sitemap/get-politics-related-to-party.graphql
+++ b/packages/politics-tracker/graphql/query/sitemap/get-politics-related-to-party.graphql
@@ -1,0 +1,11 @@
+query GetPoliticsRelatedToParty {
+  politics(where: {
+    status: { equals: "verified" },
+    reviewed: { equals: true }
+    organization: { id: { gt: 0 } }
+  }) {
+    id
+    createdAt
+    updatedAt
+  }
+}

--- a/packages/politics-tracker/graphql/query/sitemap/get-politics-related-to-person.graphql
+++ b/packages/politics-tracker/graphql/query/sitemap/get-politics-related-to-person.graphql
@@ -1,7 +1,8 @@
-query GetPolitics {
+query GetPoliticsRelatedToPerson {
   politics(where: {
     status: { equals: "verified" },
     reviewed: { equals: true }
+    person: { id: { gt: 0 } }
   }) {
     id
     createdAt

--- a/packages/politics-tracker/next-sitemap.config.mjs
+++ b/packages/politics-tracker/next-sitemap.config.mjs
@@ -49,7 +49,7 @@ const sitemapConfig = {
       `${sitemapBaseUrl}/landing-and-elections.xml`, // landing pages and election pages
       ...getSitemapGroup(sitemapBaseUrl, 'person'), // personal pages
       ...getSitemapGroup(sitemapBaseUrl, 'politics-summary'), // politics summary pages
-      `${sitemapBaseUrl}/politics-detail.xml`, // politic detail pages
+      `${sitemapBaseUrl}/politics-detail-related-to-person.xml`, // politic detail pages (person)
     ],
   },
 }

--- a/packages/politics-tracker/next-sitemap.config.mjs
+++ b/packages/politics-tracker/next-sitemap.config.mjs
@@ -1,6 +1,6 @@
 import * as tsImport from 'ts-import'
 
-const { siteUrl } = await tsImport.load('./constants/config.ts')
+const { siteUrl } = await tsImport.load('./constants/environment-variables.ts')
 const sitemapBaseUrl = `${siteUrl}/server-sitemaps`
 
 /** @type {(string|number)[]} */

--- a/packages/politics-tracker/next-sitemap.config.mjs
+++ b/packages/politics-tracker/next-sitemap.config.mjs
@@ -49,6 +49,7 @@ const sitemapConfig = {
       `${sitemapBaseUrl}/landing-and-elections.xml`, // landing pages and election pages
       ...getSitemapGroup(sitemapBaseUrl, 'person'), // personal pages
       ...getSitemapGroup(sitemapBaseUrl, 'politics-summary-related-to-person'), // politics summary pages (person)
+      `${sitemapBaseUrl}/politics-summary-related-to-party.xml`, // politics summary pages (party)
       `${sitemapBaseUrl}/politics-detail-related-to-person.xml`, // politic detail pages (person)
       `${sitemapBaseUrl}/politics-detail-related-to-party.xml`, // politic detail pages (party)
     ],

--- a/packages/politics-tracker/next-sitemap.config.mjs
+++ b/packages/politics-tracker/next-sitemap.config.mjs
@@ -48,7 +48,7 @@ const sitemapConfig = {
     additionalSitemaps: [
       `${sitemapBaseUrl}/landing-and-elections.xml`, // landing pages and election pages
       ...getSitemapGroup(sitemapBaseUrl, 'person'), // personal pages
-      ...getSitemapGroup(sitemapBaseUrl, 'politics-summary'), // politics summary pages
+      ...getSitemapGroup(sitemapBaseUrl, 'politics-summary-related-to-person'), // politics summary pages (person)
       `${sitemapBaseUrl}/politics-detail-related-to-person.xml`, // politic detail pages (person)
       `${sitemapBaseUrl}/politics-detail-related-to-party.xml`, // politic detail pages (party)
     ],

--- a/packages/politics-tracker/next-sitemap.config.mjs
+++ b/packages/politics-tracker/next-sitemap.config.mjs
@@ -50,6 +50,7 @@ const sitemapConfig = {
       ...getSitemapGroup(sitemapBaseUrl, 'person'), // personal pages
       ...getSitemapGroup(sitemapBaseUrl, 'politics-summary'), // politics summary pages
       `${sitemapBaseUrl}/politics-detail-related-to-person.xml`, // politic detail pages (person)
+      `${sitemapBaseUrl}/politics-detail-related-to-party.xml`, // politic detail pages (party)
     ],
   },
 }

--- a/packages/politics-tracker/next-sitemap.config.mjs
+++ b/packages/politics-tracker/next-sitemap.config.mjs
@@ -46,7 +46,7 @@ const sitemapConfig = {
   exclude: ['/server-sitemaps/*'],
   robotsTxtOptions: {
     additionalSitemaps: [
-      `${sitemapBaseUrl}/landing-and-elections.xml`, // landing page and election pages
+      `${sitemapBaseUrl}/landing-and-elections.xml`, // landing pages and election pages
       ...getSitemapGroup(sitemapBaseUrl, 'person'), // personal pages
       ...getSitemapGroup(sitemapBaseUrl, 'politics-summary'), // politics summary pages
       `${sitemapBaseUrl}/politics-detail.xml`, // politic detail pages

--- a/packages/politics-tracker/next.config.js
+++ b/packages/politics-tracker/next.config.js
@@ -75,8 +75,9 @@ const nextConfig = {
       },
       // for personal page sitemaps
       {
-        source: '/server-sitemaps/politics-summary/:year',
-        destination: '/server-sitemaps/politics-summary.xml?=:year',
+        source: '/server-sitemaps/politics-summary-related-to-person/:year',
+        destination:
+          '/server-sitemaps/politics-summary-related-to-person.xml?=:year',
       },
     ]
   },

--- a/packages/politics-tracker/pages/server-sitemaps/politics-detail-related-to-party.xml/index.tsx
+++ b/packages/politics-tracker/pages/server-sitemaps/politics-detail-related-to-party.xml/index.tsx
@@ -1,0 +1,73 @@
+// dynamic URLs for politic detail pages (party)
+// @ts-ignore: no definition
+import errors from '@twreporter/errors'
+import { print } from 'graphql'
+import { GetServerSideProps } from 'next'
+import { getServerSideSitemap } from 'next-sitemap'
+
+import { cmsApiUrl } from '~/constants/config'
+import { siteUrl } from '~/constants/environment-variables'
+import GetPoliticsRelatedToParty from '~/graphql/query/sitemap/get-politics-related-to-party.graphql'
+import { GenericGQLData, RawPolitic } from '~/types/common'
+import { fireGqlRequest } from '~/utils/utils'
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  const fields = []
+
+  try {
+    const tasks = []
+    tasks.push(
+      fireGqlRequest(print(GetPoliticsRelatedToParty), undefined, cmsApiUrl)
+    )
+    const results = await Promise.allSettled(tasks)
+
+    // politic detail page (party)
+    const resultOfPolitics = results[0] as PromiseSettledResult<
+      GenericGQLData<RawPolitic[], 'politics'>
+    >
+    if (resultOfPolitics.status === 'fulfilled') {
+      const politicList = resultOfPolitics.value?.data?.politics ?? []
+
+      for (const politic of politicList) {
+        const politicId = String(politic.id)
+        const lastModified =
+          politic.updatedAt ?? politic.createdAt ?? new Date().toISOString()
+
+        fields.push({
+          loc: encodeURI(`${siteUrl}/politics/party/detail/${politicId}`),
+          lastmod: lastModified,
+        })
+      }
+    }
+  } catch (err) {
+    // All exceptions that include a stack trace will be
+    // integrated with Error Reporting.
+    // See https://cloud.google.com/run/docs/error-reporting
+    console.error(
+      JSON.stringify({
+        severity: 'ERROR',
+        message: errors.helpers.printAll(
+          err,
+          {
+            withStack: true,
+            withPayload: true,
+          },
+          0,
+          0
+        ),
+      })
+    )
+  }
+
+  console.log(
+    JSON.stringify({
+      severity: 'DEBUG',
+      message: `There are ${fields.length} URLs about politic detail pages (party).`,
+    })
+  )
+
+  return getServerSideSitemap(ctx, fields)
+}
+
+// Default export to prevent next.js errors
+export default function Sitemap() {}

--- a/packages/politics-tracker/pages/server-sitemaps/politics-detail-related-to-person.xml/index.tsx
+++ b/packages/politics-tracker/pages/server-sitemaps/politics-detail-related-to-person.xml/index.tsx
@@ -1,4 +1,4 @@
-// dynamic URLs for politic detail pages
+// dynamic URLs for politic detail pages (person)
 // @ts-ignore: no definition
 import errors from '@twreporter/errors'
 import { print } from 'graphql'
@@ -7,7 +7,7 @@ import { getServerSideSitemap } from 'next-sitemap'
 
 import { cmsApiUrl } from '~/constants/config'
 import { siteUrl } from '~/constants/environment-variables'
-import GetPolitics from '~/graphql/query/sitemap/get-politics.graphql'
+import GetPoliticsRelatedToPerson from '~/graphql/query/sitemap/get-politics-related-to-person.graphql'
 import { GenericGQLData, RawPolitic } from '~/types/common'
 import { fireGqlRequest } from '~/utils/utils'
 
@@ -16,10 +16,12 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
 
   try {
     const tasks = []
-    tasks.push(fireGqlRequest(print(GetPolitics), undefined, cmsApiUrl))
+    tasks.push(
+      fireGqlRequest(print(GetPoliticsRelatedToPerson), undefined, cmsApiUrl)
+    )
     const results = await Promise.allSettled(tasks)
 
-    // politic detail page
+    // politic detail page (person)
     const resultOfPolitics = results[0] as PromiseSettledResult<
       GenericGQLData<RawPolitic[], 'politics'>
     >
@@ -60,7 +62,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
   console.log(
     JSON.stringify({
       severity: 'DEBUG',
-      message: `There are ${fields.length} URLs about politic detail pages.`,
+      message: `There are ${fields.length} URLs about politic detail pages (person).`,
     })
   )
 

--- a/packages/politics-tracker/pages/server-sitemaps/politics-summary-related-to-party.xml/index.tsx
+++ b/packages/politics-tracker/pages/server-sitemaps/politics-summary-related-to-party.xml/index.tsx
@@ -1,0 +1,71 @@
+// dynamic URLs for politics summary pages (party)
+// @ts-ignore: no definition
+import errors from '@twreporter/errors'
+import { print } from 'graphql'
+import { GetServerSideProps } from 'next'
+import { getServerSideSitemap } from 'next-sitemap'
+
+import { cmsApiUrl } from '~/constants/config'
+import { siteUrl } from '~/constants/environment-variables'
+import GetParties from '~/graphql/query/sitemap/get-parties.graphql'
+import { GenericGQLData, RawOrganization } from '~/types/common'
+import { fireGqlRequest } from '~/utils/utils'
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  const fields = []
+
+  try {
+    const tasks = []
+    tasks.push(fireGqlRequest(print(GetParties), undefined, cmsApiUrl))
+    const results = await Promise.allSettled(tasks)
+
+    // politic summary pages (party)
+    const resultOfParties = results[0] as PromiseSettledResult<
+      GenericGQLData<RawOrganization[], 'parties'>
+    >
+    if (resultOfParties.status === 'fulfilled') {
+      const partyList = resultOfParties.value?.data?.parties ?? []
+
+      for (const party of partyList) {
+        const partyId = String(party.id)
+        const lastModified =
+          party.updatedAt ?? party.createdAt ?? new Date().toISOString()
+
+        fields.push({
+          loc: encodeURI(`${siteUrl}/politics/party/${partyId}`),
+          lastmod: lastModified,
+        })
+      }
+    }
+  } catch (err) {
+    // All exceptions that include a stack trace will be
+    // integrated with Error Reporting.
+    // See https://cloud.google.com/run/docs/error-reporting
+    console.error(
+      JSON.stringify({
+        severity: 'ERROR',
+        message: errors.helpers.printAll(
+          err,
+          {
+            withStack: true,
+            withPayload: true,
+          },
+          0,
+          0
+        ),
+      })
+    )
+  }
+
+  console.log(
+    JSON.stringify({
+      severity: 'DEBUG',
+      message: `There are ${fields.length} URLs about politic summary pages (party).`,
+    })
+  )
+
+  return getServerSideSitemap(ctx, fields)
+}
+
+// Default export to prevent next.js errors
+export default function Sitemap() {}

--- a/packages/politics-tracker/pages/server-sitemaps/politics-summary-related-to-person.xml/index.tsx
+++ b/packages/politics-tracker/pages/server-sitemaps/politics-summary-related-to-person.xml/index.tsx
@@ -1,4 +1,4 @@
-// dynamic URLs for politics summary pages
+// dynamic URLs for politics summary pages (person)
 // @ts-ignore: no definition
 import errors from '@twreporter/errors'
 import { print } from 'graphql'
@@ -69,7 +69,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
     tasks.push(fireGqlRequest(print(GetPeople), { customFilter }, cmsApiUrl))
     const results = await Promise.allSettled(tasks)
 
-    // politic summary page
+    // politic summary page (person)
     const resultOfPeople = results[0] as PromiseSettledResult<
       GenericGQLData<RawPerson[], 'people'>
     >
@@ -110,7 +110,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
   console.log(
     JSON.stringify({
       severity: 'DEBUG',
-      message: `There are ${fields.length} URLs about politic summary pages.`,
+      message: `There are ${fields.length} URLs about politic summary pages (person).`,
       debugPayload: {
         query,
         match: {


### PR DESCRIPTION
## Notable Chanages
* 增加政見總覽頁（政黨）的 sitemap 資訊
* 增加政見細節頁（政黨）的 sitemap 資訊
* 調整政見總覽頁（人物）的 sitemap 路徑
* 調整政見細節頁（人物）的 sitemap 路徑