### PR TITLE
feat(pt): add useContext to check party page

### DIFF
--- a/packages/politics-tracker/components/politics-detail/progressbar.tsx
+++ b/packages/politics-tracker/components/politics-detail/progressbar.tsx
@@ -1,12 +1,14 @@
 import React from 'react'
 import styled from 'styled-components'
 
+import { useIsPartyPage } from '~/components/react-context/use-check-party-page'
 import type { PoliticDetail } from '~/types/politics-detail'
 
 const ProgressBar = styled.div`
   overflow: hidden;
   height: 44px;
   box-shadow: inset 0px -4px 0px #000000;
+
   .clearfix:after {
     content: '';
     display: block;
@@ -125,18 +127,28 @@ const ProgressBar = styled.div`
   }
 `
 
-type ProgressBar = {
+type ProgressBarProps = {
   politic: PoliticDetail
 }
-export default function Progressbar({ politic }: ProgressBar): JSX.Element {
-  const electResult = politic?.person?.elected || false
-  //@ts-ignore
+export default function Progressbar({
+  politic,
+}: ProgressBarProps): JSX.Element {
+  const { isPartyPage } = useIsPartyPage()
+
+  let isElected: boolean = false
+
+  if (isPartyPage) {
+    isElected = Number(politic.organization?.seats) > 0
+  } else {
+    isElected = politic?.person?.elected || false
+  }
+
   const progressType = politic.current_progress
 
   return (
     <ProgressBar>
       <div className="arrow-steps clearfix">
-        {electResult ? (
+        {isElected ? (
           <>
             <div className="step step1">
               <span>提出政見</span>
@@ -173,7 +185,7 @@ export default function Progressbar({ politic }: ProgressBar): JSX.Element {
               <span>提出政見</span>
             </div>
             <div className="step step3">
-              <span>未當選</span>
+              <span>{isPartyPage ? '未取得席次' : '未當選'}</span>
             </div>
           </>
         )}

--- a/packages/politics-tracker/components/politics-detail/section-title.tsx
+++ b/packages/politics-tracker/components/politics-detail/section-title.tsx
@@ -2,6 +2,7 @@ import Image from '@readr-media/react-image'
 import Link from 'next/link'
 import styled from 'styled-components'
 
+import { useIsPartyPage } from '~/components/react-context/use-check-party-page'
 import ElectionTerm from '~/components/shared/election-term'
 import ArrowLeft from '~/public/icons/arrow-left.svg'
 import type { PersonElectionTerm, PoliticDetail } from '~/types/politics-detail'
@@ -113,13 +114,12 @@ const PartyImage = styled.div`
 type SectionTitleProps = {
   politic: PoliticDetail
   electionTerm: PersonElectionTerm
-  isPartyPage?: boolean
 }
 export default function SectionTitle({
   politic,
   electionTerm,
-  isPartyPage = false,
 }: SectionTitleProps): JSX.Element {
+  const { isPartyPage } = useIsPartyPage()
   const { person, organization } = politic
 
   let electionArea: string = ''

--- a/packages/politics-tracker/components/politics-detail/section.tsx
+++ b/packages/politics-tracker/components/politics-detail/section.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import ProgressBar from '~/components/politics-detail/progressbar'
 import SectionContent from '~/components/politics-detail/section-content'
 import SectionTitle from '~/components/politics-detail/section-title'
+import { useIsPartyPage } from '~/components/react-context/use-check-party-page'
 import type { LegislatorAtLarge } from '~/types/politics'
 import type { PersonElectionTerm, PoliticDetail } from '~/types/politics-detail'
 
@@ -22,16 +23,15 @@ type SectionProps = {
   politic: PoliticDetail
   electionTerm: PersonElectionTerm
   shouldShowFeedbackForm: boolean
-  isPartyPage?: boolean
   legislators?: LegislatorAtLarge[]
 }
 export default function Section({
   politic,
   electionTerm,
   shouldShowFeedbackForm = false,
-  isPartyPage = false,
   legislators = [],
 }: SectionProps): JSX.Element {
+  const { isPartyPage } = useIsPartyPage()
   const { organization, person } = politic
 
   //get election Date (YYYY-MM-DD)
@@ -66,11 +66,7 @@ export default function Section({
   return (
     <SectionContainer>
       <div>
-        <SectionTitle
-          politic={politic}
-          electionTerm={electionTerm}
-          isPartyPage={isPartyPage}
-        />
+        <SectionTitle politic={politic} electionTerm={electionTerm} />
         {isElectionFinished && <ProgressBar politic={politic} />}
         <SectionContent
           politic={politic}

--- a/packages/politics-tracker/components/react-context/use-check-party-page.ts
+++ b/packages/politics-tracker/components/react-context/use-check-party-page.ts
@@ -1,0 +1,14 @@
+import { createContext } from 'react'
+import { useContext } from 'react'
+
+//Provider
+const CheckPartyPage = createContext<{
+  isPartyPage: boolean
+}>({
+  isPartyPage: false,
+})
+
+export { CheckPartyPage }
+
+//useContext
+export const useIsPartyPage = () => useContext(CheckPartyPage)

--- a/packages/politics-tracker/graphql/query/politics-detail/get-politic-detail.graphql
+++ b/packages/politics-tracker/graphql/query/politics-detail/get-politic-detail.graphql
@@ -48,6 +48,7 @@ query GetPoliticDetail($politicId: ID!) {
 
     organization {
       id
+      seats
       organization_id {
         id
         name

--- a/packages/politics-tracker/pages/politics/party/detail/[politicId].tsx
+++ b/packages/politics-tracker/pages/politics/party/detail/[politicId].tsx
@@ -26,6 +26,7 @@ import GetOrganizationOverView from '~/graphql/query/politics/get-organization-o
 import GetEditingPoliticsRelatedToOrganizationElections from '~/graphql/query/politics/get-editing-politics-related-to-organization-elections.graphql'
 import GetPoliticsRelatedToOrganizationsElections from '~/graphql/query/politics/get-politics-related-to-organization-elections.graphql'
 import { RawPolitic } from '~/types/common'
+import { CheckPartyPage } from '~/components/react-context/use-check-party-page'
 
 const Main = styled.main`
   background-color: #fffcf3;
@@ -91,20 +92,27 @@ export default function PartyPoliticsDetail({
   return (
     <DefaultLayout>
       <CustomHead {...headProps} url={`${siteUrl}${asPath}`} />
-      <Main>
-        <Title
-          campaign={organization?.elections?.type || ''}
-          isPartyPage={true}
-          {...titleProps}
-        />
-        <Section
-          politic={politic}
-          electionTerm={electionTerm}
-          shouldShowFeedbackForm={true}
-          isPartyPage={true}
-          legislators={legisLatorAtLarge}
-        />
-      </Main>
+
+      <CheckPartyPage.Provider
+        value={{
+          isPartyPage: true,
+        }}
+      >
+        <Main>
+          <Title
+            campaign={organization?.elections?.type || ''}
+            isPartyPage={true}
+            {...titleProps}
+          />
+          <Section
+            politic={politic}
+            electionTerm={electionTerm}
+            shouldShowFeedbackForm={true}
+            legislators={legisLatorAtLarge}
+          />
+        </Main>
+      </CheckPartyPage.Provider>
+
       <Nav {...navProps} />
     </DefaultLayout>
   )

--- a/packages/politics-tracker/types/politics-detail.ts
+++ b/packages/politics-tracker/types/politics-detail.ts
@@ -38,6 +38,8 @@ export type PoliticDetail = {
 
 export type OrganizationElection = {
   id: Pick<RawOrganizationElection, 'id'>
+  seats: Pick<RawOrganizationElection, 'seats'>
+  electoral_district: string
   organization_id: Pick<RawOrganization, 'id' | 'name' | 'image'>
   elections: Pick<
     RawElection,
@@ -50,7 +52,6 @@ export type OrganizationElection = {
     | 'election_year_month'
     | 'election_year_day'
   >
-  electoral_district: string
 }
 
 export type PoliticFactCheck = Pick<


### PR DESCRIPTION
### Notable Changes 
- add useContext：`use-check-party-page` to get `isPartyPage` in each components
- remove props `isPartyPage` in party-detail related components
- graphql `GetPoliticDetail`： add `seats` fragment
- adjust wording in progressbar of party page