### PR TITLE
refactor(politics-tracker): lots of changes due to feedbacks

### DIFF
--- a/packages/politics-tracker/components/landing/election-2022/related-posts.tsx
+++ b/packages/politics-tracker/components/landing/election-2022/related-posts.tsx
@@ -2,7 +2,7 @@ import CustomImage from '@readr-media/react-image'
 import styled from 'styled-components'
 
 import ArrowTilt from '~/components/icons/arrow-tilt'
-import type { allPostsWithPoliticsTrackerTag } from '~/types/landing'
+import type { AllPostsWithPoliticsTrackerTagAndUrl } from '~/types/landing'
 
 const Wrapper = styled.div`
   width: 100%;
@@ -182,7 +182,7 @@ const Button = styled.button`
 `
 
 type RelatedPostsProps = {
-  posts: allPostsWithPoliticsTrackerTag[]
+  posts: AllPostsWithPoliticsTrackerTagAndUrl[]
 }
 
 export default function RelatedPosts({
@@ -196,11 +196,7 @@ export default function RelatedPosts({
         {posts?.map((item) => {
           return (
             <PostList key={item.id}>
-              <a
-                href={`https://www.readr.tw/post/${item.id}`}
-                target="_blank"
-                rel="noreferrer"
-              >
+              <a href={item.url} target="_blank" rel="noreferrer">
                 <PostImage>
                   <CustomImage
                     images={{ original: item?.heroImage?.resized?.w800 }}

--- a/packages/politics-tracker/components/landing/election-2022/related-posts.tsx
+++ b/packages/politics-tracker/components/landing/election-2022/related-posts.tsx
@@ -203,7 +203,7 @@ export default function RelatedPosts({
               >
                 <PostImage>
                   <CustomImage
-                    images={{ original: item?.heroImage?.urlOriginal }}
+                    images={{ original: item?.heroImage?.resized?.w800 }}
                     alt={item?.name}
                     defaultImage="/images/default-post-photo.svg"
                   />

--- a/packages/politics-tracker/constants/common.ts
+++ b/packages/politics-tracker/constants/common.ts
@@ -1,3 +1,12 @@
+/* eslint-disable no-unused-vars */
+
+/** 系統環境 */
+export enum SYSTEM_ENV {
+  LOCALHOST = 'localhost',
+  DEVELOPMENT = 'dev',
+  PRODUCTION = 'prod',
+}
+
 export enum POLITIC_PROGRESS {
   NOT_START = 'no-progress', // 還沒開始
   IN_PROGRESS = 'in-progress', // 進行中

--- a/packages/politics-tracker/constants/environment-variables.ts
+++ b/packages/politics-tracker/constants/environment-variables.ts
@@ -12,6 +12,7 @@ let gtmId: string
 let feedbackFormApi: string =
   process.env.NEXT_PUBLIC_FEEDBACK_FORM_API ??
   'https://storytelling-prod-4g6paft7cq-de.a.run.app'
+let postPathOfREADr: string
 
 switch (env) {
   case SYSTEM_ENV.DEVELOPMENT:
@@ -23,6 +24,7 @@ switch (env) {
       process.env.NEXT_PUBLIC_PREFIX_OF_JSON_FOR_LANDING_2024 ??
       'https://whoru-gcs-dev.readr.tw/json'
     gtmId = 'GTM-NRMC5WWL'
+    postPathOfREADr = 'https://dev.readr.tw/post'
     break
   case SYSTEM_ENV.PRODUCTION: {
     gaTrackingId =
@@ -32,6 +34,7 @@ switch (env) {
       process.env.NEXT_PUBLIC_PREFIX_OF_JSON_FOR_LANDING_2024 ??
       'https://whoru-gcs.readr.tw/json'
     gtmId = 'GTM-5PG5FN7J'
+    postPathOfREADr = 'https://www.readr.tw/post'
     break
   }
   default:
@@ -41,6 +44,7 @@ switch (env) {
       process.env.NEXT_PUBLIC_PREFIX_OF_JSON_FOR_LANDING_2024 ??
       'https://whoru-gcs-dev.readr.tw/json'
     gtmId = 'GTM-NRMC5WWL'
+    postPathOfREADr = 'https://dev.readr.tw/post'
     break
 }
 
@@ -49,6 +53,7 @@ export {
   feedbackFormApi,
   gaTrackingId,
   gtmId,
+  postPathOfREADr,
   prefixOfJSONForLanding2024,
   siteUrl,
 }

--- a/packages/politics-tracker/constants/environment-variables.ts
+++ b/packages/politics-tracker/constants/environment-variables.ts
@@ -1,8 +1,9 @@
 // 這裡管理的是在 Build 階段就會寫死數值的環境變數 (通常為 `NEXT_PUBLIC_` 開頭)
-const envList: string[] = ['dev', 'prod']
-const env: string = envList.includes(String(process.env.NEXT_PUBLIC_ENV))
-  ? String(process.env.NEXT_PUBLIC_ENV)
-  : 'localhost'
+import { SYSTEM_ENV } from './common'
+const env: string =
+  String(process.env.NEXT_PUBLIC_ENV) in SYSTEM_ENV
+    ? String(process.env.NEXT_PUBLIC_ENV)
+    : SYSTEM_ENV.LOCALHOST
 
 let siteUrl: string
 let gaTrackingId: string
@@ -13,7 +14,7 @@ let feedbackFormApi: string =
   'https://storytelling-prod-4g6paft7cq-de.a.run.app'
 
 switch (env) {
-  case 'dev':
+  case SYSTEM_ENV.DEVELOPMENT:
     gaTrackingId =
       process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID ?? 'UA-83609754-1'
     siteUrl =
@@ -23,7 +24,7 @@ switch (env) {
       'https://whoru-gcs-dev.readr.tw/json'
     gtmId = 'GTM-NRMC5WWL'
     break
-  case 'prod': {
+  case SYSTEM_ENV.PRODUCTION: {
     gaTrackingId =
       process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_TRACKING_ID ?? 'UA-83609754-1'
     siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://whoareyou.readr.tw'

--- a/packages/politics-tracker/constants/environment-variables.ts
+++ b/packages/politics-tracker/constants/environment-variables.ts
@@ -13,6 +13,7 @@ let feedbackFormApi: string =
   process.env.NEXT_PUBLIC_FEEDBACK_FORM_API ??
   'https://storytelling-prod-4g6paft7cq-de.a.run.app'
 let postPathOfREADr: string
+let gcsBucketForElectionDataLoader: string
 
 switch (env) {
   case SYSTEM_ENV.DEVELOPMENT:
@@ -25,6 +26,7 @@ switch (env) {
       'https://whoru-gcs-dev.readr.tw/json'
     gtmId = 'GTM-NRMC5WWL'
     postPathOfREADr = 'https://dev.readr.tw/post'
+    gcsBucketForElectionDataLoader = 'elections-dev'
     break
   case SYSTEM_ENV.PRODUCTION: {
     gaTrackingId =
@@ -35,6 +37,7 @@ switch (env) {
       'https://whoru-gcs.readr.tw/json'
     gtmId = 'GTM-5PG5FN7J'
     postPathOfREADr = 'https://www.readr.tw/post'
+    gcsBucketForElectionDataLoader = 'elections'
     break
   }
   default:
@@ -45,6 +48,7 @@ switch (env) {
       'https://whoru-gcs-dev.readr.tw/json'
     gtmId = 'GTM-NRMC5WWL'
     postPathOfREADr = 'https://dev.readr.tw/post'
+    gcsBucketForElectionDataLoader = 'elections-dev'
     break
 }
 
@@ -52,6 +56,7 @@ export {
   env,
   feedbackFormApi,
   gaTrackingId,
+  gcsBucketForElectionDataLoader,
   gtmId,
   postPathOfREADr,
   prefixOfJSONForLanding2024,

--- a/packages/politics-tracker/graphql/query/landing/get-posts-related-to-politics-tracker-tag.graphql
+++ b/packages/politics-tracker/graphql/query/landing/get-posts-related-to-politics-tracker-tag.graphql
@@ -18,7 +18,9 @@ query GetPostsOfPoliticsTrackerTag($tag: String!) {
     heroImage {
       id
       name
-      urlOriginal
+      resized {
+        w800
+      }
     }
   }
 }

--- a/packages/politics-tracker/graphql/query/politics/get-editing-politics-related-to-organization-elections.graphql
+++ b/packages/politics-tracker/graphql/query/politics/get-editing-politics-related-to-organization-elections.graphql
@@ -1,5 +1,5 @@
 query GetEditingPoliticsRelatedToOrganizationElections($ids: [ID!]) {
-  editingPolitics(where: { organization: { id: { in: $ids } } }) {
+  editingPolitics(where: { organization: { id: { in: $ids } }, thread_parent: { id: { gt: 0 } } }) {
     id
     desc
     content

--- a/packages/politics-tracker/graphql/query/politics/get-editing-politics-related-to-person-elections.graphql
+++ b/packages/politics-tracker/graphql/query/politics/get-editing-politics-related-to-person-elections.graphql
@@ -1,5 +1,5 @@
 query GetEditingPoliticsRelatedToPersonElections($ids: [ID!]) {
-  editingPolitics(where: { person: { id: { in: $ids } } }) {
+  editingPolitics(where: { person: { id: { in: $ids } }, thread_parent: { id: { gt: 0 } } }) {
     id
     desc
     content

--- a/packages/politics-tracker/graphql/query/politics/get-politics-related-to-organization-elections.graphql
+++ b/packages/politics-tracker/graphql/query/politics/get-politics-related-to-organization-elections.graphql
@@ -1,5 +1,5 @@
 query GetPoliticsRelatedToOrganizationsElections($ids: [ID!]) {
-  politics(where: { organization: { id: { in: $ids } } }) {
+  politics(where: { organization: { id: { in: $ids } }, thread_parent: null }) {
     id
     desc
     content

--- a/packages/politics-tracker/graphql/query/politics/get-politics-related-to-person-elections.graphql
+++ b/packages/politics-tracker/graphql/query/politics/get-politics-related-to-person-elections.graphql
@@ -1,5 +1,5 @@
 query GetPoliticsRelatedToPersonElections($ids: [ID!]) {
-  politics(where: { person: { id: { in: $ids } } }) {
+  politics(where: { person: { id: { in: $ids } }, thread_parent: null }) {
     id
     desc
     content

--- a/packages/politics-tracker/pages/2022.jsx
+++ b/packages/politics-tracker/pages/2022.jsx
@@ -15,7 +15,7 @@ import {
   readrCmsApiUrl,
   urlOfJsonForlandingPage,
 } from '~/constants/config'
-import { siteUrl } from '~/constants/environment-variables'
+import { postPathOfREADr, siteUrl } from '~/constants/environment-variables'
 import GetPeopleInElection from '~/graphql/query/landing/get-people-in-election.graphql'
 import GetPoliticsRelatedToPersonElections from '~/graphql/query/landing/get-politics-related-to-person-elections.graphql'
 import GetPostsWithPoliticsTracker from '~/graphql/query/landing/get-posts-related-to-politics-tracker-tag.graphql'
@@ -24,7 +24,8 @@ import { fireGqlRequest, typedHasOwnProperty } from '~/utils/utils'
 /**
  * @typedef { import('~/types/landing').PropsData } PropsData
  * @typedef { import('~/types/landing').PersonData } PersonData
- * @typedef { import('~/types/landing').allPostsWithPoliticsTrackerTag } AllPostsWithPoliticsTrackerTag
+ * @typedef { import('~/types/landing').AllPostsWithPoliticsTrackerTag } AllPostsWithPoliticsTrackerTag
+ * @typedef { import('~/types/landing').AllPostsWithPoliticsTrackerTagAndUrl } AllPostsWithPoliticsTrackerTagAndUrl
  * @typedef { import('~/types/landing').CityOfMayorElection } CityOfMayorElection
  * @typedef { import('~/types/landing').DistrinctOfMayorElection } DistrinctOfMayorElection
  * @typedef { import('~/types/landing').AreaOfCouncilorElection } AreaOfCouncilorElection
@@ -202,6 +203,7 @@ export const getServerSideProps = async ({ res }) => {
             publishTime: moment(value.publishTime)
               .tz('Asia/Taipei')
               .format('YYYY/MM/DD'),
+            url: `${postPathOfREADr}/${value.id}`,
           }
         })
     }

--- a/packages/politics-tracker/pages/election.tsx
+++ b/packages/politics-tracker/pages/election.tsx
@@ -11,8 +11,10 @@ import DefaultLayout from '~/components/layout/default'
 import Nav, { type LinkMember, NavProps } from '~/components/nav'
 import { cmsApiUrl } from '~/constants/config'
 import { districtsMapping, electionTypesMapping } from '~/constants/election'
-import { env } from '~/constants/environment-variables'
-import { siteUrl } from '~/constants/environment-variables'
+import {
+  gcsBucketForElectionDataLoader,
+  siteUrl,
+} from '~/constants/environment-variables'
 import GetElection from '~/graphql/query/election/get-election.graphql'
 import GetElectionHistoryOfArea from '~/graphql/query/election/get-election-history-of-area.graphql'
 import type { GenericGQLData } from '~/types/common'
@@ -50,9 +52,7 @@ export const getServerSideProps: GetServerSideProps<
 
   const electionType = electionTypesMapping[String(type)]
   let ldr = new DataLoader({
-    apiUrl: `https://whoareyou-gcs.readr.tw/${
-      env === 'dev' ? 'elections-dev' : 'elections'
-    }`,
+    apiUrl: `https://whoareyou-gcs.readr.tw/${gcsBucketForElectionDataLoader}`,
     version: 'v2',
   })
   let scrollTo = ''

--- a/packages/politics-tracker/pages/politics/[personId].tsx
+++ b/packages/politics-tracker/pages/politics/[personId].tsx
@@ -27,7 +27,7 @@ import type {
   OverviewInfo,
   PersonElectionData,
   PersonElectionTerm,
-  PersonOrgnizationData,
+  PersonOrganizationData,
   Politic,
   PoliticAmount,
   PoliticDataForPerson,
@@ -487,7 +487,7 @@ export const getServerSideProps: GetServerSideProps<
     // Iterate through each election and query its election term
     for (const election of elections) {
       const result: GenericGQLData<
-        PersonOrgnizationData[],
+        PersonOrganizationData[],
         'personOrganizations'
       > = await fireGqlRequest(
         print(GetPersonOrganization),

--- a/packages/politics-tracker/pages/politics/detail/[politicId].tsx
+++ b/packages/politics-tracker/pages/politics/detail/[politicId].tsx
@@ -26,7 +26,7 @@ import type { PersonElectionData as PersonElectionDataFromPerson } from '~/types
 import type {
   PoliticDataForPerson,
   PersonElectionData as PersonElectionDataFromPolitic,
-  PersonOrgnizationData,
+  PersonOrganizationData,
   PersonElectionTerm,
   OverviewInfo,
 } from '~/types/politics'
@@ -316,7 +316,7 @@ export const getServerSideProps: GetServerSideProps<
     {
       //get election term by person id
       const result: GenericGQLData<
-        PersonOrgnizationData[],
+        PersonOrganizationData[],
         'personOrganizations'
       > = await fireGqlRequest(
         print(GetPersonOrganization),

--- a/packages/politics-tracker/pages/politics/party/[organizationId].tsx
+++ b/packages/politics-tracker/pages/politics/party/[organizationId].tsx
@@ -130,7 +130,7 @@ export const getServerSideProps: GetServerSideProps<
       isPartyPage: isPartyPage,
     }
     const elections: ElectionDataForParty[] = []
-    // orgnizationElection id to election id
+    // organizationElection id to election id
     const electionIdMap: Record<string, string> = {}
     const electionMap: Record<string, ElectionDataForParty> = {}
     const organizationElectionIds: string[] = []

--- a/packages/politics-tracker/pages/politics/party/[organizationId].tsx
+++ b/packages/politics-tracker/pages/politics/party/[organizationId].tsx
@@ -33,6 +33,15 @@ import type {
   PositionChange,
   Repeat,
 } from '~/types/politics'
+import {
+  expertPointMapFunc,
+  isCompletedPolitic,
+  isWaitingPolitic,
+  notEmptyPoliticFunc,
+  politicChangeMapFunc,
+  politicFactCheckMapFunc,
+  politicRepeatMapFunc,
+} from '~/utils/politic'
 import { electionName, fireGqlRequest } from '~/utils/utils'
 
 const isPartyPage = true
@@ -275,7 +284,8 @@ export const getServerSideProps: GetServerSideProps<
         throw annotatingError
       }
 
-      const politicList = rawData.data?.politics || []
+      let politicList = rawData.data?.politics || []
+      politicList = politicList.filter(notEmptyPoliticFunc)
 
       // Fetch 'editingPolitics' data
       const editingRawData: GenericGQLData<
@@ -304,75 +314,40 @@ export const getServerSideProps: GetServerSideProps<
         throw annotatingEditingError
       }
 
-      const editingPoliticList = editingRawData.data?.editingPolitics || []
+      let editingPoliticList = editingRawData.data?.editingPolitics || []
+      editingPoliticList = editingPoliticList.filter(notEmptyPoliticFunc)
 
-      // Combine 'politics' and 'editingPolitics' arrays
-      const combinedPolitics = politicList.concat(editingPoliticList)
+      for (const politic of politicList) {
+        const eId = politic.organization?.elections?.id
 
-      const politicGroup: Record<
-        string,
-        {
-          latestId: string
-          politic: PoliticDataForParty
-        }
-      > = {}
-      // keep latest politic of each politic thread
-      for (const politic of combinedPolitics) {
-        const status = politic.status
-        const reviewed = politic.reviewed
+        if (!eId) continue
 
-        if (status === 'verified' && reviewed) {
-          const selfId = politic.id
-          const commonId = politic.thread_parent?.id ?? selfId
-          if (politicGroup.hasOwnProperty(commonId)) {
-            const latestId = politicGroup[commonId].latestId
-            if (Number(selfId) - Number(latestId) > 0) {
-              politicGroup[commonId] = {
-                latestId: selfId,
-                politic,
-              }
-            }
-          } else {
-            politicGroup[commonId] = {
-              latestId: selfId,
-              politic,
-            }
-          }
-        } else if (!reviewed) {
-          const eId = politic.organization?.elections?.id
-
-          if (!eId) continue
-
+        if (isCompletedPolitic(politic)) {
           const positionChangeData: PositionChange[] =
-            politic.positionChange.map((change) => ({
-              id: change.id,
-              isChanged: change.isChanged,
-              positionChangeSummary: change.positionChangeSummary,
-              factcheckPartner: change.factcheckPartner,
-            }))
-
-          const factCheckData: FactCheck[] = politic.factCheck.map((fact) => ({
-            id: fact.id,
-            factCheckSummary: fact.factCheckSummary,
-            checkResultType: fact.checkResultType,
-            checkResultOther: fact.checkResultOther,
-            factcheckPartner: fact.factcheckPartner,
-          }))
-
-          const expertPointData: ExpertPoint[] = politic.expertPoint.map(
-            (point) => ({
-              id: point.id,
-              expertPointSummary: point.expertPointSummary,
-              expert: point.expert,
-            })
+            politic.positionChange.map(politicChangeMapFunc)
+          const factCheckData: FactCheck[] = politic.factCheck.map(
+            politicFactCheckMapFunc
           )
+          const expertPointData: ExpertPoint[] =
+            politic.expertPoint.map(expertPointMapFunc)
+          const repeatData: Repeat[] = politic.repeat.map(politicRepeatMapFunc)
 
-          const repeatData: Repeat[] = politic.repeat.map((re) => ({
-            id: re.id,
-            repeatSummary: re.repeatSummary,
-            factcheckPartner: re.factcheckPartner,
-          }))
-
+          electionMap[eId].politics.push({
+            id: politic.id,
+            desc: politic.desc,
+            source: politic.source,
+            content: politic.content,
+            progress: politic.current_progress ?? POLITIC_PROGRESS.NOT_START,
+            politicCategoryId: politic.politicCategory?.id ?? null,
+            politicCategoryName: politic.politicCategory?.name ?? null,
+            createdAt: politic.createdAt,
+            updatedAt: politic.updatedAt ?? null,
+            positionChange: positionChangeData,
+            factCheck: factCheckData,
+            expertPoint: expertPointData,
+            repeat: repeatData,
+          })
+        } else if (isWaitingPolitic(politic)) {
           electionMap[eId].waitingPolitics.push({
             id: politic.id,
             desc: politic.desc,
@@ -383,69 +358,36 @@ export const getServerSideProps: GetServerSideProps<
             politicCategoryName: null,
             createdAt: politic.createdAt,
             updatedAt: politic.updatedAt ?? null,
-            positionChange: positionChangeData,
-            factCheck: factCheckData,
-            expertPoint: expertPointData,
-            repeat: repeatData,
+            positionChange: [],
+            factCheck: [],
+            expertPoint: [],
+            repeat: [],
           })
         }
       }
 
-      const verifiedLatestPoliticList: PoliticDataForParty[] = Object.keys(
-        politicGroup
-      ).map((key) => politicGroup[key].politic)
-
-      for (const politic of verifiedLatestPoliticList) {
+      for (const politic of editingPoliticList) {
         const eId = politic.organization?.elections?.id
 
         if (!eId) continue
 
-        const positionChangeData: PositionChange[] = politic.positionChange.map(
-          (change) => ({
-            id: change.id,
-            isChanged: change.isChanged,
-            positionChangeSummary: change.positionChangeSummary,
-            factcheckPartner: change.factcheckPartner,
+        if (isWaitingPolitic(politic)) {
+          electionMap[eId].waitingPolitics.push({
+            id: politic.id,
+            desc: politic.desc,
+            source: '',
+            content: '',
+            progress: POLITIC_PROGRESS.NOT_START,
+            politicCategoryId: null,
+            politicCategoryName: null,
+            createdAt: politic.createdAt,
+            updatedAt: politic.updatedAt ?? null,
+            positionChange: [],
+            factCheck: [],
+            expertPoint: [],
+            repeat: [],
           })
-        )
-
-        const factCheckData: FactCheck[] = politic.factCheck.map((fact) => ({
-          id: fact.id,
-          factCheckSummary: fact.factCheckSummary,
-          checkResultType: fact.checkResultType,
-          checkResultOther: fact.checkResultOther,
-          factcheckPartner: fact.factcheckPartner,
-        }))
-
-        const expertPointData: ExpertPoint[] = politic.expertPoint.map(
-          (point) => ({
-            id: point.id,
-            expertPointSummary: point.expertPointSummary,
-            expert: point.expert,
-          })
-        )
-
-        const repeatData: Repeat[] = politic.repeat.map((re) => ({
-          id: re.id,
-          repeatSummary: re.repeatSummary,
-          factcheckPartner: re.factcheckPartner,
-        }))
-
-        electionMap[eId].politics.push({
-          id: politic.thread_parent?.id ?? politic.id,
-          desc: politic.desc,
-          source: politic.source,
-          content: politic.content,
-          progress: politic.current_progress ?? POLITIC_PROGRESS.NOT_START,
-          politicCategoryId: politic.politicCategory?.id ?? null,
-          politicCategoryName: politic.politicCategory?.name ?? null,
-          createdAt: politic.createdAt,
-          updatedAt: politic.updatedAt ?? null,
-          positionChange: positionChangeData,
-          factCheck: factCheckData,
-          expertPoint: expertPointData,
-          repeat: repeatData,
-        })
+        }
       }
 
       // get latestUpdate info of each election

--- a/packages/politics-tracker/pages/politics/party/detail/[politicId].tsx
+++ b/packages/politics-tracker/pages/politics/party/detail/[politicId].tsx
@@ -67,12 +67,12 @@ export default function PartyPoliticsDetail({
     organization?.elections?.addComments ?? false
 
   const titleProps: OverviewInfo = {
-    id: organization?.organization_id?.id || '',
-    name: organization?.organization_id?.name || '',
-    avatar: organization?.organization_id?.image || '',
-    partyId: '',
-    party: '',
-    partyIcon: '',
+    id: '',
+    name: '',
+    avatar: '',
+    partyId: organization?.organization_id?.id || '',
+    party: organization?.organization_id?.name || '',
+    partyIcon: organization?.organization_id?.image || '',
     completed: politicAmount.passed,
     waiting: politicAmount.waiting,
     campaign: organization?.elections?.type || '',

--- a/packages/politics-tracker/pages/politics/party/detail/[politicId].tsx
+++ b/packages/politics-tracker/pages/politics/party/detail/[politicId].tsx
@@ -36,6 +36,7 @@ import type {
 } from '~/types/politics-detail'
 import { fireGqlRequest } from '~/utils/utils'
 import { POLITIC_PROGRESS } from '~/constants/common'
+import { getPoliticAmount, notEmptyPoliticFunc } from '~/utils/politic'
 
 const Main = styled.main`
   background-color: #fffcf3;
@@ -270,7 +271,8 @@ export const getServerSideProps: GetServerSideProps<
           cmsApiUrl
         )
 
-      const politicList = rawData.data?.politics || []
+      let politicList = rawData.data?.politics || []
+      politicList.filter(notEmptyPoliticFunc)
 
       // get `editing politics` amount (passed/waiting)
       const editingRawData: GenericGQLData<
@@ -284,23 +286,14 @@ export const getServerSideProps: GetServerSideProps<
         cmsApiUrl
       )
 
-      const editingPoliticList = editingRawData.data?.editingPolitics || []
+      let editingPoliticList = editingRawData.data?.editingPolitics || []
+      editingPoliticList.filter(notEmptyPoliticFunc)
 
-      const passedAmount = politicList.filter(
-        (value: PoliticDataForParty) =>
-          value.status === 'verified' &&
-          value.reviewed &&
-          value.thread_parent === null
-      ).length
-
-      const waitingAmount = editingPoliticList.filter(
-        (value: PoliticDataForParty) =>
-          value.status !== 'verified' && !value.reviewed
-      ).length
+      const amountData = getPoliticAmount(politicList, editingPoliticList)
 
       politicAmount = {
-        passed: passedAmount || 0,
-        waiting: waitingAmount || 0,
+        waiting: amountData.waiting,
+        passed: amountData.completed,
       }
     }
 

--- a/packages/politics-tracker/types/common.ts
+++ b/packages/politics-tracker/types/common.ts
@@ -470,7 +470,7 @@ export type RawPoliticTimeline = {
 }
 
 /** 人物 - 組織關係 */
-export type RawPersonOrgnization = {
+export type RawPersonOrganization = {
   id: string
   /** 姓名 */
   person_id: RawPerson | null

--- a/packages/politics-tracker/types/landing.ts
+++ b/packages/politics-tracker/types/landing.ts
@@ -87,7 +87,7 @@ export type allPostsWithPoliticsTrackerTag = {
 export type ImageOfPost = {
   id: string
   name: string //文章視覺圖名稱
-  urlOriginal: string //文章視覺圖網址
+  resized: { w800: string } | null // 文章視覺圖
 }
 
 type PP = Pick<RawPerson, 'id' | 'name' | 'birth_date_year'>

--- a/packages/politics-tracker/types/landing.ts
+++ b/packages/politics-tracker/types/landing.ts
@@ -72,17 +72,23 @@ export type PropsData = {
   totalCompletionOfCouncilor: number // 已有通過審核政見的議員候選人數
   mayorAndPolitics: DistrinctOfMayorElection[]
   councilorAndPolitics: CityOfCouncilorElection[]
-  postsWithPoliticsTrackerTag: allPostsWithPoliticsTrackerTag[]
+  postsWithPoliticsTrackerTag: AllPostsWithPoliticsTrackerTagAndUrl[]
 }
 
 // Landing 2022 - READr 內符合指定標籤(tag)的文章(post)資料
-export type allPostsWithPoliticsTrackerTag = {
+export type AllPostsWithPoliticsTrackerTag = {
   id: string
   name: string // 文章標題
   state: string // 文章發佈狀態(Draft/Published/Scheduled/Archived)
   publishTime: string // 文章發佈時間
   heroImage: ImageOfPost | null
 }
+
+export type AllPostsWithPoliticsTrackerTagAndUrl =
+  AllPostsWithPoliticsTrackerTag & {
+    /** 文章網址 */
+    url: string
+  }
 
 export type ImageOfPost = {
   id: string

--- a/packages/politics-tracker/types/politics.ts
+++ b/packages/politics-tracker/types/politics.ts
@@ -10,7 +10,7 @@ import type {
   RawOrganizationElection,
   RawPerson,
   RawPersonElection,
-  RawPersonOrgnization,
+  RawPersonOrganization,
   RawPolitic,
   RawPoliticCategory,
   RawPoliticPositionChange,
@@ -309,8 +309,8 @@ export type PoliticDataForParty = Override<
 export type PoliticData = PoliticDataForPerson | PoliticDataForParty
 
 /** type for GetPersonOrganization query */
-export type PersonOrgnizationData = Pick<
-  RawPersonOrgnization,
+export type PersonOrganizationData = Pick<
+  RawPersonOrganization,
   | 'start_date_year'
   | 'start_date_month'
   | 'start_date_day'

--- a/packages/politics-tracker/utils/politic.ts
+++ b/packages/politics-tracker/utils/politic.ts
@@ -7,7 +7,12 @@ import type {
 import type {
   ElectionData,
   ElectionDataForPerson,
+  ExpertPoint,
+  FactCheck,
   PersonElectionData,
+  PoliticData,
+  PositionChange,
+  Repeat,
 } from '~/types/politics'
 
 import { isTypeOfOneFromCouple } from './utils'
@@ -74,9 +79,82 @@ function getLastestElectionData<T extends PersonElectionData>(
   return previous
 }
 
+function isWaitingPolitic(politic: PoliticData): boolean {
+  return !politic.reviewed
+}
+
+function isCompletedPolitic(politic: PoliticData): boolean {
+  return politic.reviewed && politic.status === 'verified'
+}
+
+function politicChangeMapFunc({
+  id,
+  isChanged,
+  positionChangeSummary,
+  factcheckPartner,
+}: PositionChange): PositionChange {
+  return {
+    id,
+    isChanged,
+    positionChangeSummary,
+    factcheckPartner,
+  }
+}
+
+function politicFactCheckMapFunc({
+  id,
+  factCheckSummary,
+  factcheckPartner,
+  checkResultType,
+  checkResultOther,
+}: FactCheck): FactCheck {
+  return {
+    id,
+    factCheckSummary,
+    factcheckPartner: factcheckPartner ?? null,
+    checkResultType: checkResultType ?? null,
+    checkResultOther,
+  }
+}
+
+function expertPointMapFunc({
+  id,
+  expertPointSummary,
+  expert,
+}: ExpertPoint): ExpertPoint {
+  return {
+    id,
+    expertPointSummary,
+    expert,
+  }
+}
+
+function politicRepeatMapFunc({
+  id,
+  repeatSummary,
+  factcheckPartner,
+}: Repeat): Repeat {
+  return {
+    id,
+    repeatSummary,
+    factcheckPartner,
+  }
+}
+
+function notEmptyPoliticFunc(politic: PoliticData): boolean {
+  return Boolean(politic.desc)
+}
+
 export {
   checkIsPartyPage,
+  expertPointMapFunc,
   getLastestElectionData,
+  isCompletedPolitic,
   isDraftPoliticForModification,
   isElectionDataForPerson,
+  isWaitingPolitic,
+  notEmptyPoliticFunc,
+  politicChangeMapFunc,
+  politicFactCheckMapFunc,
+  politicRepeatMapFunc,
 }

--- a/packages/politics-tracker/utils/politic.ts
+++ b/packages/politics-tracker/utils/politic.ts
@@ -10,6 +10,7 @@ import type {
   ExpertPoint,
   FactCheck,
   PersonElectionData,
+  PoliticAmount,
   PoliticData,
   PositionChange,
   Repeat,
@@ -87,6 +88,31 @@ function isCompletedPolitic(politic: PoliticData): boolean {
   return politic.reviewed && politic.status === 'verified'
 }
 
+function getPoliticAmount(
+  politics: PoliticData[],
+  editingPolitics: PoliticData[]
+): PoliticAmount {
+  const amount: PoliticAmount = {
+    waiting: 0,
+    completed: 0,
+  }
+
+  for (let politic of politics) {
+    if (isCompletedPolitic(politic)) {
+      amount.completed += 1
+    } else if (isWaitingPolitic(politic)) {
+      amount.waiting += 1
+    }
+  }
+
+  for (let politic of editingPolitics) {
+    if (isWaitingPolitic(politic)) {
+      amount.waiting += 1
+    }
+  }
+
+  return amount
+}
 function politicChangeMapFunc({
   id,
   isChanged,
@@ -149,6 +175,7 @@ export {
   checkIsPartyPage,
   expertPointMapFunc,
   getLastestElectionData,
+  getPoliticAmount,
   isCompletedPolitic,
   isDraftPoliticForModification,
   isElectionDataForPerson,


### PR DESCRIPTION
## Notable Changes
* 修正在政見細節頁（政黨）的儀表板中，未顯示政黨名稱和圖像的問題
* 修正在 2022 首頁的相關報導中，文章首圖未顯示的問題
* 修正政見總覽頁（人物）和政見細節頁（人物）的儀表板，在政見數量上顯示不一致的問題
* 修正政見總覽頁（政黨）和政見細節頁（政黨）的儀表板，在政見數量上顯示不一致的問題

## Reminders
* 儀表板上的政見數量邏輯
  * Politic 和 EditingPolitc 進入計算處理前，會先針對空內容做過濾處理
  * 目前政見數 = Politic (reviewed: `true` && status: `verified`)
  * 待審核政見數 = Politic (reviewed: `false`) + EditingPolitic (reviewed: `false`)
  