### PR TITLE
fix(readr): add back collaboration banner & adjust gql field name

### DIFF
--- a/packages/readr/components/index/collaboration-highlight.tsx
+++ b/packages/readr/components/index/collaboration-highlight.tsx
@@ -1,35 +1,96 @@
 // 協作專區的置頂項目
 
+import Image from '@readr-media/react-image'
 import NextLink from 'next/link'
-import styled, { useTheme } from 'styled-components'
+import styled from 'styled-components'
 
+import type { FeaturedCollaboration } from '~/graphql/query/collaboration'
+import type { ResizedImages } from '~/types/common'
 import * as gtag from '~/utils/gtag'
 
-const Container = styled(NextLink)``
+const Container = styled(NextLink)`
+  .desktop-banner,
+  .tablet-banner {
+    display: none;
+  }
+
+  ${({ theme }) => theme.breakpoint.md} {
+    .tablet-banner {
+      display: block;
+    }
+
+    .desktop-banner,
+    .mobile-banner {
+      display: none;
+    }
+  }
+
+  ${({ theme }) => theme.breakpoint.xl} {
+    .desktop-banner {
+      display: block;
+    }
+
+    .tablet-banner,
+    .mobile-banner {
+      display: none;
+    }
+  }
+
+  img {
+    width: 100%;
+  }
+`
 
 type Item = {
   altText: string
   href: string
-  desktopImageSrc: string
-  tabletImageSrc: string
-  defaultImageSrc: string
+  desktopImageSrc: ResizedImages
+  desktopWebpSrc: ResizedImages
+  tabletImageSrc: ResizedImages
+  tabletWebpSrc: ResizedImages
+  mobileImageSrc: ResizedImages
+  mobileWebpSrc: ResizedImages
 }
 
-export default function CollaborationHighlight(): JSX.Element {
-  const theme = useTheme()
-  const path = '/images/collaboration'
-  const directory = '/open-relation'
+type CollaborationHighlightProps = {
+  featured: FeaturedCollaboration
+}
+export default function CollaborationHighlight({
+  featured,
+}: CollaborationHighlightProps): JSX.Element | null {
+  if (Object.keys(featured).length === 0) return null
 
-  function createUrlPath(file: string) {
-    return [path, directory, file].join('/')
+  const {
+    name,
+    collabLink,
+    bannerDesktop = null,
+    bannerTablet = null,
+    bannerMobile = null,
+  } = featured
+
+  // if bannerDesktop/bannerTablet/bannerMobile is `null`, banner is hidden.
+  if (!bannerDesktop && !bannerTablet && !bannerMobile) {
+    return null
+  }
+
+  const defaultImageSrc = {
+    original: '',
+    w480: '',
+    w800: '',
+    w1200: '',
+    w1600: '',
+    w2400: '',
   }
 
   const item: Item = {
-    altText: 'open-relation-banner',
-    href: 'https://whoareyou.readr.tw/',
-    desktopImageSrc: createUrlPath('desktop_1096x241.png'),
-    tabletImageSrc: createUrlPath('tablet_710x215.png'),
-    defaultImageSrc: createUrlPath('mobile_280x172.png'),
+    altText: name || '',
+    href: collabLink || '/',
+    desktopImageSrc: bannerDesktop?.resized || defaultImageSrc,
+    desktopWebpSrc: bannerDesktop?.resizedWebp || defaultImageSrc,
+    tabletImageSrc: bannerTablet?.resized || defaultImageSrc,
+    tabletWebpSrc: bannerTablet?.resizedWebp || defaultImageSrc,
+    mobileImageSrc: bannerMobile?.resized || defaultImageSrc,
+    mobileWebpSrc: bannerMobile?.resizedWebp || defaultImageSrc,
   }
 
   return (
@@ -41,16 +102,31 @@ export default function CollaborationHighlight(): JSX.Element {
         gtag.sendEvent('homepage', 'click', 'collaboration-banner')
       }
     >
-      <picture>
-        <source
-          srcSet={item.desktopImageSrc}
-          media={`(min-width: ${theme.mediaSize.xl}px)`}
+      <picture className="desktop-banner">
+        <Image
+          images={item.desktopImageSrc}
+          imagesWebP={item.desktopWebpSrc}
+          alt={item.altText}
+          defaultImage={'/icons/default/post.svg'}
         />
-        <source
-          srcSet={item.tabletImageSrc}
-          media={`(min-width: ${theme.mediaSize.md}px)`}
+      </picture>
+
+      <picture className="tablet-banner">
+        <Image
+          images={item.tabletImageSrc}
+          imagesWebP={item.tabletWebpSrc}
+          alt={item.altText}
+          defaultImage={'/icons/default/post.svg'}
         />
-        <img src={item.defaultImageSrc} alt={item.altText} />
+      </picture>
+
+      <picture className="mobile-banner">
+        <Image
+          images={item.mobileImageSrc}
+          imagesWebP={item.mobileWebpSrc}
+          alt={item.altText}
+          defaultImage={'/icons/default/post.svg'}
+        />
       </picture>
     </Container>
   )

--- a/packages/readr/components/index/collaboration-section.tsx
+++ b/packages/readr/components/index/collaboration-section.tsx
@@ -112,7 +112,7 @@ export default function CollaborationSection(
         headingLevel={2}
       />
       <HighlightPart>
-        <CollaborationHighlight />
+        <CollaborationHighlight featured={featured} />
         {/* <CollaborationQuoteSlider /> is replaced by <CollaborationHighlight />, but we still keep it for further usage. */}
         {/* <CollaborationQuoteSlider quotes={quotes} /> */}
       </HighlightPart>

--- a/packages/readr/graphql/query/collaboration.ts
+++ b/packages/readr/graphql/query/collaboration.ts
@@ -33,14 +33,14 @@ export type FeaturedCollaboration = Override<
     | 'id'
     | 'name'
     | 'collabLink'
-    | 'ImageDesktop'
-    | 'ImageTablet'
-    | 'ImageMobile'
+    | 'bannerDesktop'
+    | 'bannerTablet'
+    | 'bannerMobile'
   >,
   {
-    ImageDesktop: PhotoWithResizedOnly | null
-    ImageTablet: PhotoWithResizedOnly | null
-    ImageMobile: PhotoWithResizedOnly | null
+    bannerDesktop: PhotoWithResizedOnly | null
+    bannerTablet: PhotoWithResizedOnly | null
+    bannerMobile: PhotoWithResizedOnly | null
   }
 >
 
@@ -73,12 +73,12 @@ const featuredCollaborations = gql`
   query {
     collaborations(
       orderBy: [{ sortOrder: asc }, { publishTime: desc }]
-      where: { state: { equals: "published" }, isFeatured: { equals: true } }
+      where: { state: { equals: "published" }, isBanner: { equals: true } }
     ) {
       id
       name
       collabLink
-      ImageDesktop {
+      bannerDesktop {
         resized {
           ...ResizedImagesField
         }
@@ -86,7 +86,7 @@ const featuredCollaborations = gql`
           ...ResizedWebPImagesField
         }
       }
-      ImageTablet {
+      bannerTablet {
         resized {
           ...ResizedImagesField
         }
@@ -94,7 +94,7 @@ const featuredCollaborations = gql`
           ...ResizedWebPImagesField
         }
       }
-      ImageMobile {
+      bannerMobile {
         resized {
           ...ResizedImagesField
         }

--- a/packages/readr/pages/index.tsx
+++ b/packages/readr/pages/index.tsx
@@ -156,9 +156,9 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
     id: '',
     name: '',
     collabLink: '',
-    ImageDesktop: null,
-    ImageTablet: null,
-    ImageMobile: null,
+    bannerDesktop: null,
+    bannerTablet: null,
+    bannerMobile: null,
   }
   let dataSetItems: DataSetItem[] = []
   let dataSetCount: number = 0
@@ -375,6 +375,28 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
           images: heroImage?.resized ?? {},
         }
       })
+    }
+
+    {
+      // fetch featured collaboration (collaboration banner)
+      const { data, errors: gqlErrors } = await client.query<{
+        collaborations: FeaturedCollaboration[]
+      }>({
+        query: featuredCollaborationsQuery,
+      })
+
+      if (gqlErrors) {
+        const annotatingError = errors.helpers.wrap(
+          new Error('Errors returned in `collaborations` query'),
+          'GraphQLError',
+          'failed to complete `collaborations`',
+          { errors: gqlErrors }
+        )
+
+        throw annotatingError
+      }
+
+      featuredCollaboration = data.collaborations[0] ?? {}
     }
 
     {

--- a/packages/readr/types/common.ts
+++ b/packages/readr/types/common.ts
@@ -169,9 +169,9 @@ export type GenericCollaboration = {
   requireTime: number
   endTime: string
   heroImage: GenericPhoto | null
-  ImageDesktop: GenericPhoto | null
-  ImageTablet: GenericPhoto | null
-  ImageMobile: GenericPhoto | null
+  bannerDesktop: GenericPhoto | null
+  bannerTablet: GenericPhoto | null
+  bannerMobile: GenericPhoto | null
 }
 
 export type GenericGallery = {


### PR DESCRIPTION
- 調整 collaboration banner 顯示邏輯：當 bannerDesktop/bannerTablet/bannerMobile 都無資料時，不顯示 banner 區塊。
- 配合 Lilith 欄位名稱修正，調整 graphQL 參數名稱。