### PR TITLE
fix(readr): sort category by `sortOrder` & timestamp

### DIFF
--- a/packages/readr/constants/constant.ts
+++ b/packages/readr/constants/constant.ts
@@ -46,6 +46,9 @@ const DEFAULT_HEADER_CATEGORY_LIST = [
     posts: [],
     ogDescription: '',
     ogImage: null,
+    sortOrder: null,
+    updatedAt: null,
+    createdAt: null,
   },
   {
     id: '2',
@@ -54,6 +57,9 @@ const DEFAULT_HEADER_CATEGORY_LIST = [
     posts: [],
     ogDescription: '',
     ogImage: null,
+    sortOrder: null,
+    updatedAt: null,
+    createdAt: null,
   },
   {
     id: '3',
@@ -62,6 +68,9 @@ const DEFAULT_HEADER_CATEGORY_LIST = [
     posts: [],
     ogDescription: '',
     ogImage: null,
+    sortOrder: null,
+    updatedAt: null,
+    createdAt: null,
   },
   {
     id: '4',
@@ -70,6 +79,9 @@ const DEFAULT_HEADER_CATEGORY_LIST = [
     posts: [],
     ogDescription: '',
     ogImage: null,
+    sortOrder: null,
+    updatedAt: null,
+    createdAt: null,
   },
   {
     id: '5',
@@ -78,6 +90,9 @@ const DEFAULT_HEADER_CATEGORY_LIST = [
     posts: [],
     ogDescription: '',
     ogImage: null,
+    sortOrder: null,
+    updatedAt: null,
+    createdAt: null,
   },
   {
     id: '6',
@@ -86,6 +101,9 @@ const DEFAULT_HEADER_CATEGORY_LIST = [
     posts: [],
     ogDescription: '',
     ogImage: null,
+    sortOrder: null,
+    updatedAt: null,
+    createdAt: null,
   },
 ]
 

--- a/packages/readr/graphql/query/category.ts
+++ b/packages/readr/graphql/query/category.ts
@@ -62,7 +62,10 @@ const categories = gql`
     ) {
       id
       slug
-      title
+      title    
+      updatedAt
+      createdAt
+      sortOrder
       posts: relatedPost(
         take: $relatedPostFirst
         skip: $postSkip

--- a/packages/readr/graphql/query/category.ts
+++ b/packages/readr/graphql/query/category.ts
@@ -14,7 +14,16 @@ import { convertToStringList } from '~/utils/common'
 export type Category = Override<
   Pick<
     GenericCategory,
-    'id' | 'slug' | 'title' | 'posts' | 'reports' | 'ogImage' | 'ogDescription'
+    | 'id'
+    | 'slug'
+    | 'title'
+    | 'posts'
+    | 'reports'
+    | 'ogImage'
+    | 'ogDescription'
+    | 'updatedAt'
+    | 'createdAt'
+    | 'sortOrder'
   >,
   {
     posts?: Post[]
@@ -49,7 +58,7 @@ const categories = gql`
         state: { equals: "true" } 
         slug: { equals: $slug }
       }
-      orderBy: { createdAt: asc }
+      orderBy: { sortOrder: asc }
     ) {
       id
       slug

--- a/packages/readr/pages/_app.tsx
+++ b/packages/readr/pages/_app.tsx
@@ -24,6 +24,7 @@ import { categories } from '~/graphql/query/category'
 import theme from '~/styles/theme'
 import type { NavigationCategory } from '~/types/component'
 import * as gtag from '~/utils/gtag'
+import { sortByTimeStamp } from '~/utils/index'
 
 export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
   getLayout?: (
@@ -130,7 +131,10 @@ MyApp.getInitialProps = async (context: AppContext) => {
         },
       })
 
-      categoryList.push(...data.categories)
+      const sortCategories =
+        sortByTimeStamp(data.categories) || data.categories || []
+
+      categoryList.push(...sortCategories)
     }
   } catch (error) {
     const err = error as Error

--- a/packages/readr/pages/index.tsx
+++ b/packages/readr/pages/index.tsx
@@ -45,6 +45,7 @@ import type { CollaborationItem } from '~/types/component'
 import { setCacheControl } from '~/utils/common'
 import { convertDataSet } from '~/utils/data-set'
 import * as gtag from '~/utils/gtag'
+import { sortByTimeStamp } from '~/utils/index'
 import { convertPostToArticleCard } from '~/utils/post'
 import { postConvertFunc } from '~/utils/post'
 
@@ -219,14 +220,16 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
     {
       {
         // fetch categories and related latest reports
-
         let data: { categories: Category[] }
         const response = await axios.get<{ categories: Category[] }>(
           LATEST_POSTS_IN_CATEGORIES_URL
         )
         data = response.data
 
-        categories = data.categories.map((category) => {
+        const sortedCategories =
+          sortByTimeStamp(data.categories) || data.categories || []
+
+        categories = sortedCategories.map((category) => {
           const reports = category.reports?.map(postConvertFunc)
 
           const posts =

--- a/packages/readr/types/common.ts
+++ b/packages/readr/types/common.ts
@@ -129,6 +129,9 @@ export type GenericCategory = {
   reports: GenericPost[]
   ogImage: GenericPhoto | null
   ogDescription: string | null
+  updatedAt: string | null
+  createdAt: string | null
+  sortOrder: number | null
 }
 
 export type GenericTag = {

--- a/packages/readr/utils/index.ts
+++ b/packages/readr/utils/index.ts
@@ -1,0 +1,18 @@
+import type { Category } from '~/graphql/query/category'
+
+export function sortByTimeStamp(categories: Category[]) {
+  return categories.sort((a, b) => {
+    // sort by `sortOrder`
+    if (a.sortOrder !== b.sortOrder) {
+      const orderA = a.sortOrder || Number.MAX_SAFE_INTEGER
+      const orderB = b.sortOrder || Number.MAX_SAFE_INTEGER
+      return orderA - orderB
+    }
+
+    // if `sortOrder` is the same, then sort by `updatedAt` & `createdAt`.
+    const dateA = new Date(a.updatedAt || a.createdAt || 0)
+    const dateB = new Date(b.updatedAt || b.createdAt || 0)
+
+    return Number(dateB) - Number(dateA)
+  })
+}


### PR DESCRIPTION
### Notable Changes
- 修正「首頁-最新報導」、「 category 列表頁」分類清單排序。
- 排序方式：
   - 依照 `sortOder` 由小至大排序，如果 `sortOder` 為 null 則一律排最末。
   - 如果 `sortOder` 相同，則進而比較 `updatedAt` 與 `createdAt`，日期由新排至舊，皆為 null 則排最末。

<img width="1216" alt="截圖 2024-01-26 上午9 39 27" src="https://github.com/readr-media/Sachiel/assets/104489150/15e7e7f4-fa97-4194-b194-7502c6717f6a">
<img width="1247" alt="截圖 2024-01-26 上午9 40 02" src="https://github.com/readr-media/Sachiel/assets/104489150/ba40374a-10b2-46cf-9bc2-dac6fe7a78de">
