### PR TITLE
refactor(readr): use webP format of images

### DIFF
--- a/packages/readr/components/index/collaboration-card.tsx
+++ b/packages/readr/components/index/collaboration-card.tsx
@@ -185,6 +185,7 @@ export default function CollaborationCard({
   achvLink,
   collabLink,
   images,
+  imagesWebP,
   title,
   description,
   progress,
@@ -216,6 +217,7 @@ export default function CollaborationCard({
       <ImageBlock>
         <SharedImage
           images={images}
+          imagesWebP={imagesWebP}
           defaultImage={'/icons/default/collaboration.svg'}
           alt={title}
           breakpoint={{

--- a/packages/readr/components/index/editor-choice-card.tsx
+++ b/packages/readr/components/index/editor-choice-card.tsx
@@ -185,6 +185,7 @@ export default function EditorChoiceCard({
   href = '/',
   title = '',
   images = {},
+  imagesWebP = {},
   date = '',
   readTimeText = '',
   isFeatured = false,
@@ -217,6 +218,7 @@ export default function EditorChoiceCard({
       <picture>
         <SharedImage
           images={images}
+          imagesWebP={imagesWebP}
           defaultImage={DEFAULT_POST_IMAGE_PATH}
           alt={title}
           priority={true}

--- a/packages/readr/components/index/feature-card.tsx
+++ b/packages/readr/components/index/feature-card.tsx
@@ -218,6 +218,7 @@ export default function FeatureCard({
   title = '',
   subtitle = '',
   images = {},
+  imagesWebP = {},
   description = '',
   isFirst = false,
 }: FeaturedArticleWithIsFirst): JSX.Element {
@@ -243,6 +244,7 @@ export default function FeatureCard({
       <picture>
         <SharedImage
           images={images}
+          imagesWebP={imagesWebP}
           defaultImage={DEFAULT_POST_IMAGE_PATH}
           alt={title}
           priority={true}

--- a/packages/readr/components/post/article-type/news.tsx
+++ b/packages/readr/components/post/article-type/news.tsx
@@ -109,6 +109,7 @@ export default function News({
             <HeroImage>
               <SharedImage
                 images={postData?.heroImage?.resized}
+                imagesWebP={postData?.heroImage?.resizedWebp}
                 defaultImage={DEFAULT_POST_IMAGE_PATH}
                 alt={postData?.title}
                 priority={false}

--- a/packages/readr/components/shared/article-list-card.tsx
+++ b/packages/readr/components/shared/article-list-card.tsx
@@ -197,6 +197,7 @@ export default function ArticleListCard({
   href = '/',
   title = '',
   images = {},
+  imagesWebP = {},
   date = '',
   readTimeText = '',
   isReport = false,
@@ -232,6 +233,7 @@ export default function ArticleListCard({
         <picture>
           <SharedImage
             images={images}
+            imagesWebP={imagesWebP}
             defaultImage={DEFAULT_POST_IMAGE_PATH}
             alt={title}
             priority={shouldNotLazyload}

--- a/packages/readr/graphql/fragments/post.ts
+++ b/packages/readr/graphql/fragments/post.ts
@@ -6,7 +6,10 @@ import type {
   PhotoWithResizedOnly,
 } from '~/types/common'
 
-import { resizeImagesFragment } from './resized-images'
+import {
+  resizeImagesFragment,
+  resizeWebpImagesFragment,
+} from './resized-images'
 
 export type Post = Override<
   Pick<
@@ -36,14 +39,21 @@ export const postFragment = gql`
       resized {
         ...ResizedImagesField
       }
+      resizedWebp {
+        ...ResizedWebPImagesField
+      }
     }
     ogImage {
       resized {
         ...ResizedImagesField
+      }
+      resizedWebp {
+        ...ResizedWebPImagesField
       }
     }
     publishTime
     readingTime
   }
   ${resizeImagesFragment}
+  ${resizeWebpImagesFragment}
 `

--- a/packages/readr/graphql/query/collaboration.ts
+++ b/packages/readr/graphql/query/collaboration.ts
@@ -63,10 +63,14 @@ const collaborations = gql`
         resized {
           ...ResizedImagesField
         }
+        resizedWebp {
+          ...ResizedWebPImagesField
+        }
       }
     }
   }
   ${resizeImagesFragment}
+  ${resizeWebpImagesFragment}
 `
 
 const featuredCollaborations = gql`

--- a/packages/readr/graphql/query/editor-choice.ts
+++ b/packages/readr/graphql/query/editor-choice.ts
@@ -9,7 +9,10 @@ import type {
 } from '~/types/common'
 import type { ArticleCard } from '~/types/component'
 
-import { resizeImagesFragment } from '../fragments/resized-images'
+import {
+  resizeImagesFragment,
+  resizeWebpImagesFragment,
+} from '../fragments/resized-images'
 
 export type EditorChoice = Override<
   Pick<GenericEditorChoice, 'choices' | 'heroImage' | 'link' | 'name' | 'id'>,
@@ -37,6 +40,9 @@ const editorChoices = gql`
         resized {
           ...ResizedImagesField
         }
+        resizedWebp {
+          ...ResizedWebPImagesField
+        }
       }
       choices {
         ...PostFields
@@ -45,6 +51,7 @@ const editorChoices = gql`
   }
   ${postFragment}
   ${resizeImagesFragment}
+  ${resizeWebpImagesFragment}
 `
 
 export { editorChoices }

--- a/packages/readr/package.json
+++ b/packages/readr/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.3",
-    "@mirrormedia/lilith-draft-renderer": "^1.3.0-alpha.1",
+    "@mirrormedia/lilith-draft-renderer": "1.3.1",
     "@readr-media/react-component": "^2.1.5",
     "@readr-media/react-image": "^2.2.1",
     "@readr-media/share-button": "^1.0.3",

--- a/packages/readr/pages/index.tsx
+++ b/packages/readr/pages/index.tsx
@@ -194,8 +194,18 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
             heroImage?.resized ??
             {}
 
+          const imagesWebP =
+            editorChoice.heroImage?.resizedWebp ??
+            ogImage?.resizedWebp ??
+            heroImage?.resizedWebp ??
+            {}
+
           const choices = {
-            ...convertPostToArticleCard(editorChoice?.choices, images),
+            ...convertPostToArticleCard(
+              editorChoice?.choices,
+              images,
+              imagesWebP
+            ),
             shouldHideBottomInfos: false,
           }
 
@@ -297,8 +307,13 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
         const { subtitle = '', heroImage, ogImage } = feature.featurePost ?? {}
 
         const images = ogImage?.resized ?? heroImage?.resized ?? {}
+        const imagesWebP = ogImage?.resized ?? heroImage?.resized ?? {}
 
-        const article = convertPostToArticleCard(feature?.featurePost, images)
+        const article = convertPostToArticleCard(
+          feature?.featurePost,
+          images,
+          imagesWebP
+        )
 
         return {
           ...article,
@@ -376,6 +391,7 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
           requireTime,
           endTime,
           images: heroImage?.resized ?? {},
+          imagesWebP: heroImage?.resizedWebp ?? {},
         }
       })
     }

--- a/packages/readr/types/component.ts
+++ b/packages/readr/types/component.ts
@@ -5,6 +5,7 @@ export type ArticleCard = {
   href: string
   title: string
   images: ResizedImages
+  imagesWebP: ResizedImages
   date: string
   readTimeText: string
   isReport: boolean
@@ -15,6 +16,7 @@ export type FeaturedArticle = {
   href: string
   title: string
   images: ResizedImages
+  imagesWebP: ResizedImages
   subtitle: string
   description: string
 }
@@ -26,6 +28,7 @@ export type CollaborationItem = {
   achvLink: string
   collabLink: string
   images: ResizedImages
+  imagesWebP: ResizedImages
   progress: number
   requireTime: number
   endTime: string

--- a/packages/readr/utils/post.ts
+++ b/packages/readr/utils/post.ts
@@ -119,7 +119,8 @@ export function getImageOfArticle({
 
 export function convertPostToArticleCard(
   post: Post | null,
-  images?: ResizedImages
+  images?: ResizedImages,
+  imagesWebP?: ResizedImages
 ): ArticleCard {
   const {
     id = 'no-id',
@@ -138,13 +139,15 @@ export function convertPostToArticleCard(
     readTimeText: formatReadTime(readingTime),
     isReport: isReport(style),
     images: images ?? {},
+    imagesWebP: imagesWebP ?? {},
   }
 }
 
 export const postConvertFunc = (post: Post): ArticleCard => {
   const { heroImage, ogImage } = post
   const images = ogImage?.resized ?? heroImage?.resized ?? {}
-  return convertPostToArticleCard(post, images)
+  const imagesWebP = ogImage?.resizedWebp ?? heroImage?.resizedWebp ?? {}
+  return convertPostToArticleCard(post, images, imagesWebP)
 }
 
 export const getResizedUrl = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -3133,12 +3133,12 @@
     npmlog "^6.0.2"
     write-file-atomic "^4.0.1"
 
-"@mirrormedia/lilith-draft-renderer@^1.3.0-alpha.1":
-  version "1.3.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-draft-renderer/-/lilith-draft-renderer-1.3.0-alpha.1.tgz#5ee96411efaa1f5565bef7f281e259c8e6d39c96"
-  integrity sha512-tFdfYZgR/gAAmsNmF5moXB6YKGGDYDGcd6F0YV/tP+A973lBuw3wcjHQdyA7ygXxrGoW3c3j0gM8J7af2jdQmQ==
+"@mirrormedia/lilith-draft-renderer@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@mirrormedia/lilith-draft-renderer/-/lilith-draft-renderer-1.3.1.tgz#33fc5d29e734ea0b731f71f01bd6ec70912a0a8e"
+  integrity sha512-YZhyhgE+vkx+ZzrjmGjpaegCEOhHeqPxScQP02uV3c72kC3yfgN5vWlpc72/dEst3SNNHQgL/BJhaba2N54kJQ==
   dependencies:
-    "@readr-media/react-image" "1.6.0"
+    "@readr-media/react-image" "2.1.3"
     body-scroll-lock "3.1.5"
     draft-js "^0.11.7"
     node-html-parser "^6.1.5"
@@ -3699,10 +3699,10 @@
     serialize-javascript "^6.0.0"
     uuid "^8.3.2"
 
-"@readr-media/react-image@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@readr-media/react-image/-/react-image-1.6.0.tgz#1bff81cdaa8b14f255c22b2504df1d09fc783223"
-  integrity sha512-k4FOxVlAdvsFY5zP7nczs11LrJ3mA2T6Y7rwoTjpA9GMhlf3wtLWD84/XwcsGXNvHg0gbxQtmOcNvKE1LsZxwg==
+"@readr-media/react-image@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@readr-media/react-image/-/react-image-2.1.3.tgz#97834255b39f42d15b93449637131d28a3aca168"
+  integrity sha512-XAuKKSqRNSvH/CJAfbBhVE7Ezkaetc0pM3AEKUPydYJP51N6fp8mWfPR0HUSw/7QLElHSGXVKCvyuOpVIXa5eQ==
 
 "@readr-media/react-image@^1.5.1":
   version "1.5.1"


### PR DESCRIPTION
# Notabla Change

Use resizedWebP from readr cms and send it to the react-image to let the package use webP if accessible.

## Steps

1. JSON update gql query to get resizedWebP from readr gql server.
2. Update gql query in next.js to receive resizedWebP.
3. Modify convert post method to deal with resizedWebP into imagesWebP of posts.
4. Append types with imagesWebP for the existing types containing images.
5. Set imagesWebP as props of react-images.

## Pages

- homepage: Index.js
- listing page: tag/author/category
- article page: post

## Follow-up

Post page need to use latest draft-renderer to show draft-js article with image block using imagesWebP.
Make sure to:

1. Update Lilith readr/core/draft-editor/draft-render to **dev** to check if image button now store resizedWebP.
2. Sachiel/readr update the version of draft-renderer to test if webP image is used.

When deploying all of this to prod, make sure to:

1. Tell HC to deploy the code to generate jsons to staging and prod. Now it only affects on dev.
2. deploy Lilith/readr to prod.
3. Ask 17 if old draft-js images button should be updated to store resizedWebP url.