### PR TITLE
refactor(mesh): update rwd layout

### DIFF
--- a/packages/mesh/app/layout.tsx
+++ b/packages/mesh/app/layout.tsx
@@ -30,9 +30,7 @@ export default function RootLayout({
         {/* block for non-fixed content, set padding for fixed blocks */}
         <div className="flex min-h-screen flex-col bg-gray-50 pb-[theme(height.nav.default)] pt-[theme(height.header.default)]  sm:pb-0 sm:pt-[theme(height.header.sm)] sm:pl-[theme(width.nav.sm)] md:pl-[theme(width.nav.md)] xl:pl-[calc((100vw-theme(width.maxContent))/2+theme(width.nav.xl))]">
           {/* block for main and aside content to maintain the max width for screen width larger than 1440 */}
-          <div className="mr-auto w-full max-w-[theme(width.maxMain)] grow">
-            {children}
-          </div>
+          <div className="grow xl:max-w-[theme(width.maxMain)]">{children}</div>
           {/* footer after main content */}
           <footer className="h-[theme(height.footer.default)] border-t bg-white sm:h-[theme(height.footer.sm)]">
             {/* nested footer to maintain the max width for screen width larger than 1440 */}

--- a/packages/mesh/app/layout.tsx
+++ b/packages/mesh/app/layout.tsx
@@ -19,33 +19,37 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="zh-Hant" className={notoSans.className}>
-      <body className="min-h-screen pt-15 pb-16 sm:pl-[theme(width.nav.sm)] sm:pt-16 sm:pb-0 md:pl-[theme(width.nav.md)] xl:pl-[calc((100vw-theme(width.maxContent))/2+theme(width.nav.xl))]">
-        <header className="fixed top-0 left-0 h-[theme(height.header.default)] w-full border sm:h-[theme(height.header.sm)]">
+      <body className="min-h-screen">
+        {/* fixed header */}
+        <header className="fixed top-0 left-0 h-[theme(height.header.default)] w-full border bg-white sm:h-[theme(height.header.sm)]">
           {/* nested header to maintain the max width for screen width larger than 1440 */}
           <div className="mx-auto h-full max-w-[theme(width.maxContent)]">
             這是 header
           </div>
         </header>
-        <main className="min-h-[calc(100dvh-theme(height.footer.default)-theme(height.header.default)-theme(height.nav.default))] w-full border sm:min-h-[calc(100dvh-theme(height.footer.sm)-theme(height.header.sm))]">
-          {/* nested main to maintain the max width for screen width larger than 1440 */}
-          <div className="mr-auto max-w-[theme(width.maxMain)]">{children}</div>
-        </main>
-        {/*  */}
-        <footer className="h-[theme(height.footer.default)] border sm:h-[theme(height.footer.sm)]">
-          {/* nested footer to maintain the max width for screen width larger than 1440 */}
-          <div className="mr-auto h-full max-w-[theme(width.maxMain)]">
-            這是 footer
+        {/* block for non-fixed content, set padding for fixed blocks */}
+        <div className="border bg-gray-50 pb-[theme(height.nav.default)] pt-[theme(height.header.default)]  sm:pb-0 sm:pt-[theme(height.header.sm)] sm:pl-[theme(width.nav.sm)] md:pl-[theme(width.nav.md)] xl:pl-[calc((100vw-theme(width.maxContent))/2+theme(width.nav.xl))]">
+          {/* block for main and aside content to maintain the max width for screen width larger than 1440 */}
+          <div className="mr-auto min-h-[calc(100dvh-theme(height.header.default)-theme(height.footer.default)-theme(height.nav.default))] max-w-[theme(width.maxMain)] sm:min-h-[calc(100dvh-theme(height.header.sm)-theme(height.footer.sm))]">
+            {children}
           </div>
-        </footer>
+          {/* footer after main content */}
+          <footer className="h-[theme(height.footer.default)] border bg-white sm:h-[theme(height.footer.sm)]">
+            {/* nested footer to maintain the max width for screen width larger than 1440 */}
+            <div className="mr-auto h-full max-w-[theme(width.maxMain)]">
+              這是 footer
+            </div>
+          </footer>
+        </div>
         {/* fixed left nav shown on tablet, desktop size */}
-        <nav className="fixed left-0 top-16 hidden h-[calc(100%-theme(height.header.sm))] w-[theme(width.nav.sm)] border sm:block md:w-[theme(width.nav.md)] xl:w-[calc((100vw-theme(width.maxContent))/2+theme(width.nav.xl))] ">
+        <nav className="fixed left-0 top-16 hidden h-[calc(100%-theme(height.header.sm))] w-[theme(width.nav.sm)] border bg-white sm:block md:w-[theme(width.nav.md)] xl:w-[calc((100vw-theme(width.maxContent))/2+theme(width.nav.xl))] ">
           {/* nested nav bar to maintain the max width for screen width larger than 1440 */}
           <div className="absolute top-0 right-0 h-full w-full xl:max-w-[theme(width.nav.xl)]">
             左側 navbar, 只在平板以上尺寸顯示
           </div>
         </nav>
         {/* fixed bottom nav bar shown on mobile only */}
-        <nav className="fixed bottom-0 left-0 h-[theme(height.nav.default)] w-full border sm:hidden">
+        <nav className="fixed bottom-0 left-0 h-[theme(height.nav.default)] w-full border bg-white sm:hidden">
           <div>置底 nav bar, 只在手機尺寸顯示</div>
         </nav>
       </body>

--- a/packages/mesh/app/layout.tsx
+++ b/packages/mesh/app/layout.tsx
@@ -1,10 +1,16 @@
 import '@/styles/global.css'
 
 import type { Metadata } from 'next'
+import { Noto_Sans_TC } from 'next/font/google'
 
 export const metadata: Metadata = {
   title: 'Mesh',
 }
+
+const notoSans = Noto_Sans_TC({
+  subsets: ['latin'],
+  display: 'swap',
+})
 
 export default function RootLayout({
   children,
@@ -12,7 +18,7 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="zh-Hant">
+    <html lang="zh-Hant" className={notoSans.className}>
       <body>{children}</body>
     </html>
   )

--- a/packages/mesh/app/layout.tsx
+++ b/packages/mesh/app/layout.tsx
@@ -19,29 +19,33 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="zh-Hant" className={notoSans.className}>
-      <body className="min-h-screen pt-15 pb-16 sm:pl-32 sm:pt-16 sm:pb-0 md:pl-[220px] xl:pl-[calc((100vw-1440px)/2+320px)]">
-        <header className="fixed top-0 left-0 h-15 w-full border sm:h-16">
+      <body className="min-h-screen pt-15 pb-16 sm:pl-[theme(width.nav.sm)] sm:pt-16 sm:pb-0 md:pl-[theme(width.nav.md)] xl:pl-[calc((100vw-theme(width.maxContent))/2+theme(width.nav.xl))]">
+        <header className="fixed top-0 left-0 h-[theme(height.header.default)] w-full border sm:h-[theme(height.header.sm)]">
           {/* nested header to maintain the max width for screen width larger than 1440 */}
-          <div className="mx-auto h-full max-w-[1440px]">這是 header</div>
+          <div className="mx-auto h-full max-w-[theme(width.maxContent)]">
+            這是 header
+          </div>
         </header>
-        <main className="min-h-[calc(100%-641px)] w-full border sm:min-h-[calc(100dvh-317px-62px)]">
+        <main className="min-h-[calc(100dvh-theme(height.footer.default)-theme(height.header.default)-theme(height.nav.default))] w-full border sm:min-h-[calc(100dvh-theme(height.footer.sm)-theme(height.header.sm))]">
           {/* nested main to maintain the max width for screen width larger than 1440 */}
-          <div className="mr-auto max-w-[1220px]">{children}</div>
+          <div className="mr-auto max-w-[theme(width.maxMain)]">{children}</div>
         </main>
         {/*  */}
-        <footer className="h-[641px] border sm:h-[317px]">
+        <footer className="h-[theme(height.footer.default)] border sm:h-[theme(height.footer.sm)]">
           {/* nested footer to maintain the max width for screen width larger than 1440 */}
-          <div className="mr-auto h-full max-w-[1220px]">這是 footer</div>
+          <div className="mr-auto h-full max-w-[theme(width.maxMain)]">
+            這是 footer
+          </div>
         </footer>
         {/* fixed left nav shown on tablet, desktop size */}
-        <nav className="fixed left-0 top-16 hidden h-[calc(100%-64px)] w-32 border sm:block md:w-[220px] xl:w-[calc((100vw-1440px)/2+320px)] ">
+        <nav className="fixed left-0 top-16 hidden h-[calc(100%-theme(height.header.sm))] w-[theme(width.nav.sm)] border sm:block md:w-[theme(width.nav.md)] xl:w-[calc((100vw-theme(width.maxContent))/2+theme(width.nav.xl))] ">
           {/* nested nav bar to maintain the max width for screen width larger than 1440 */}
-          <div className="absolute top-0 right-0 h-full w-full xl:max-w-[320px]">
+          <div className="absolute top-0 right-0 h-full w-full xl:max-w-[theme(width.nav.xl)]">
             左側 navbar, 只在平板以上尺寸顯示
           </div>
         </nav>
         {/* fixed bottom nav bar shown on mobile only */}
-        <nav className="fixed bottom-0 left-0 h-16 w-full border sm:hidden">
+        <nav className="fixed bottom-0 left-0 h-[theme(height.nav.default)] w-full border sm:hidden">
           <div>置底 nav bar, 只在手機尺寸顯示</div>
         </nav>
       </body>

--- a/packages/mesh/app/layout.tsx
+++ b/packages/mesh/app/layout.tsx
@@ -2,7 +2,6 @@ import '@/styles/global.css'
 
 import type { Metadata } from 'next'
 import { Noto_Sans_TC } from 'next/font/google'
-import { twMerge } from 'tailwind-merge'
 
 export const metadata: Metadata = {
   title: 'Mesh',
@@ -19,13 +18,13 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="zh-Hant" className={twMerge('h-full', notoSans.className)}>
-      <body className="h-full pt-15 pb-16 sm:pl-32 sm:pt-16 sm:pb-0 md:pl-[220px] xl:pl-[calc((100vw-1440px)/2+320px)]">
+    <html lang="zh-Hant" className={notoSans.className}>
+      <body className="min-h-screen pt-15 pb-16 sm:pl-32 sm:pt-16 sm:pb-0 md:pl-[220px] xl:pl-[calc((100vw-1440px)/2+320px)]">
         <header className="fixed top-0 left-0 h-15 w-full border sm:h-16">
           {/* nested header to maintain the max width for screen width larger than 1440 */}
           <div className="mx-auto h-full max-w-[1440px]">這是 header</div>
         </header>
-        <main className="min-h-[calc(100%-641px)] w-full border sm:min-h-[calc(100%-317px)]">
+        <main className="min-h-[calc(100%-641px)] w-full border sm:min-h-[calc(100dvh-317px-62px)]">
           {/* nested main to maintain the max width for screen width larger than 1440 */}
           <div className="mr-auto max-w-[1220px]">{children}</div>
         </main>

--- a/packages/mesh/app/layout.tsx
+++ b/packages/mesh/app/layout.tsx
@@ -22,21 +22,28 @@ export default function RootLayout({
     <html lang="zh-Hant" className={twMerge('h-full', notoSans.className)}>
       <body className="h-full pt-15 pb-16 sm:pl-32 sm:pt-16 sm:pb-0 md:pl-[220px] xl:pl-[calc((100vw-1440px)/2+320px)]">
         <header className="fixed top-0 left-0 h-15 w-full border sm:h-16">
+          {/* nested header to maintain the max width for screen width larger than 1440 */}
           <div className="mx-auto h-full max-w-[1440px]">這是 header</div>
         </header>
-        <aside className="fixed left-0 top-16 hidden h-[calc(100%-64px)] w-32 border sm:block md:w-[220px] xl:w-[calc((100vw-1440px)/2+320px)] ">
-          <div className="absolute top-0 right-0 h-full w-full xl:max-w-[320px]">
-            這是aside
-          </div>
-        </aside>
         <main className="min-h-[calc(100%-641px)] w-full border sm:min-h-[calc(100%-317px)]">
+          {/* nested main to maintain the max width for screen width larger than 1440 */}
           <div className="mr-auto max-w-[1220px]">{children}</div>
         </main>
+        {/*  */}
         <footer className="h-[641px] border sm:h-[317px]">
+          {/* nested footer to maintain the max width for screen width larger than 1440 */}
           <div className="mr-auto h-full max-w-[1220px]">這是 footer</div>
         </footer>
+        {/* fixed left nav shown on tablet, desktop size */}
+        <nav className="fixed left-0 top-16 hidden h-[calc(100%-64px)] w-32 border sm:block md:w-[220px] xl:w-[calc((100vw-1440px)/2+320px)] ">
+          {/* nested nav bar to maintain the max width for screen width larger than 1440 */}
+          <div className="absolute top-0 right-0 h-full w-full xl:max-w-[320px]">
+            左側 navbar, 只在平板以上尺寸顯示
+          </div>
+        </nav>
+        {/* fixed bottom nav bar shown on mobile only */}
         <nav className="fixed bottom-0 left-0 h-16 w-full border sm:hidden">
-          <div>這是 nav bar</div>
+          <div>置底 nav bar, 只在手機尺寸顯示</div>
         </nav>
       </body>
     </html>

--- a/packages/mesh/app/layout.tsx
+++ b/packages/mesh/app/layout.tsx
@@ -2,6 +2,7 @@ import '@/styles/global.css'
 
 import type { Metadata } from 'next'
 import { Noto_Sans_TC } from 'next/font/google'
+import { twMerge } from 'tailwind-merge'
 
 export const metadata: Metadata = {
   title: 'Mesh',
@@ -18,8 +19,26 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="zh-Hant" className={notoSans.className}>
-      <body>{children}</body>
+    <html lang="zh-Hant" className={twMerge('h-full', notoSans.className)}>
+      <body className="h-full pt-15 pb-16 sm:pl-32 sm:pt-16 sm:pb-0 md:pl-[220px] xl:pl-[calc((100vw-1440px)/2+320px)]">
+        <header className="fixed top-0 left-0 h-15 w-full border sm:h-16">
+          <div className="mx-auto h-full max-w-[1440px]">這是 header</div>
+        </header>
+        <aside className="fixed left-0 top-16 hidden h-[calc(100%-64px)] w-32 border sm:block md:w-[220px] xl:w-[calc((100vw-1440px)/2+320px)] ">
+          <div className="absolute top-0 right-0 h-full w-full xl:max-w-[320px]">
+            這是aside
+          </div>
+        </aside>
+        <main className="min-h-[calc(100%-641px)] w-full border sm:min-h-[calc(100%-317px)]">
+          <div className="mr-auto max-w-[1220px]">{children}</div>
+        </main>
+        <footer className="h-[641px] border sm:h-[317px]">
+          <div className="mr-auto h-full max-w-[1220px]">這是 footer</div>
+        </footer>
+        <nav className="fixed bottom-0 left-0 h-16 w-full border sm:hidden">
+          <div>這是 nav bar</div>
+        </nav>
+      </body>
     </html>
   )
 }

--- a/packages/mesh/app/layout.tsx
+++ b/packages/mesh/app/layout.tsx
@@ -34,21 +34,21 @@ export default function RootLayout({
           {/* footer after main content */}
           <footer className="h-[theme(height.footer.default)] border-t bg-white sm:h-[theme(height.footer.sm)]">
             {/* nested footer to maintain the max width for screen width larger than 1440 */}
-            <div className="mr-auto h-full max-w-[theme(width.maxMain)]">
+            <div className="h-full max-w-[theme(width.maxMain)]">
               這是 footer
             </div>
           </footer>
         </div>
         {/* fixed left nav shown on tablet, desktop size */}
-        <nav className="fixed left-0 top-16 bottom-0 hidden w-[theme(width.nav.sm)] border-r bg-white sm:flex sm:justify-end md:w-[theme(width.nav.md)] xl:w-[calc((100vw-theme(width.maxContent))/2+theme(width.nav.xl))] ">
+        <nav className="fixed left-0 top-16 bottom-0 hidden w-[theme(width.nav.sm)] bg-white sm:flex sm:justify-end md:w-[theme(width.nav.md)] xl:w-[calc((100vw-theme(width.maxContent))/2+theme(width.nav.xl))] ">
           {/* nested nav bar to maintain the max width for screen width larger than 1440 */}
-          <div className="grow xl:max-w-[theme(width.nav.xl)]">
+          <div className="grow border-r xl:max-w-[theme(width.nav.xl)]">
             左側 navbar, 只在平板以上尺寸顯示
           </div>
         </nav>
         {/* fixed bottom nav bar shown on mobile only */}
         <nav className="fixed bottom-0 left-0 right-0 h-[theme(height.nav.default)] border-t bg-white sm:hidden">
-          <div>置底 nav bar, 只在手機尺寸顯示</div>
+          <div className="h-full">置底 nav bar, 只在手機尺寸顯示</div>
         </nav>
       </body>
     </html>

--- a/packages/mesh/app/layout.tsx
+++ b/packages/mesh/app/layout.tsx
@@ -21,20 +21,20 @@ export default function RootLayout({
     <html lang="zh-Hant" className={notoSans.className}>
       <body className="min-h-screen">
         {/* fixed header */}
-        <header className="fixed top-0 left-0 h-[theme(height.header.default)] w-full border bg-white sm:h-[theme(height.header.sm)]">
+        <header className="fixed top-0 left-0 right-0 h-[theme(height.header.default)] border-b bg-white sm:h-[theme(height.header.sm)]">
           {/* nested header to maintain the max width for screen width larger than 1440 */}
           <div className="mx-auto h-full max-w-[theme(width.maxContent)]">
             這是 header
           </div>
         </header>
         {/* block for non-fixed content, set padding for fixed blocks */}
-        <div className="border bg-gray-50 pb-[theme(height.nav.default)] pt-[theme(height.header.default)]  sm:pb-0 sm:pt-[theme(height.header.sm)] sm:pl-[theme(width.nav.sm)] md:pl-[theme(width.nav.md)] xl:pl-[calc((100vw-theme(width.maxContent))/2+theme(width.nav.xl))]">
+        <div className="flex min-h-screen flex-col bg-gray-50 pb-[theme(height.nav.default)] pt-[theme(height.header.default)]  sm:pb-0 sm:pt-[theme(height.header.sm)] sm:pl-[theme(width.nav.sm)] md:pl-[theme(width.nav.md)] xl:pl-[calc((100vw-theme(width.maxContent))/2+theme(width.nav.xl))]">
           {/* block for main and aside content to maintain the max width for screen width larger than 1440 */}
-          <div className="mr-auto min-h-[calc(100dvh-theme(height.header.default)-theme(height.footer.default)-theme(height.nav.default))] max-w-[theme(width.maxMain)] sm:min-h-[calc(100dvh-theme(height.header.sm)-theme(height.footer.sm))]">
+          <div className="mr-auto w-full max-w-[theme(width.maxMain)] grow">
             {children}
           </div>
           {/* footer after main content */}
-          <footer className="h-[theme(height.footer.default)] border bg-white sm:h-[theme(height.footer.sm)]">
+          <footer className="h-[theme(height.footer.default)] border-t bg-white sm:h-[theme(height.footer.sm)]">
             {/* nested footer to maintain the max width for screen width larger than 1440 */}
             <div className="mr-auto h-full max-w-[theme(width.maxMain)]">
               這是 footer
@@ -42,14 +42,14 @@ export default function RootLayout({
           </footer>
         </div>
         {/* fixed left nav shown on tablet, desktop size */}
-        <nav className="fixed left-0 top-16 hidden h-[calc(100%-theme(height.header.sm))] w-[theme(width.nav.sm)] border bg-white sm:block md:w-[theme(width.nav.md)] xl:w-[calc((100vw-theme(width.maxContent))/2+theme(width.nav.xl))] ">
+        <nav className="fixed left-0 top-16 bottom-0 hidden w-[theme(width.nav.sm)] border-r bg-white sm:flex sm:justify-end md:w-[theme(width.nav.md)] xl:w-[calc((100vw-theme(width.maxContent))/2+theme(width.nav.xl))] ">
           {/* nested nav bar to maintain the max width for screen width larger than 1440 */}
-          <div className="absolute top-0 right-0 h-full w-full xl:max-w-[theme(width.nav.xl)]">
+          <div className="grow xl:max-w-[theme(width.nav.xl)]">
             左側 navbar, 只在平板以上尺寸顯示
           </div>
         </nav>
         {/* fixed bottom nav bar shown on mobile only */}
-        <nav className="fixed bottom-0 left-0 h-[theme(height.nav.default)] w-full border bg-white sm:hidden">
+        <nav className="fixed bottom-0 left-0 right-0 h-[theme(height.nav.default)] border-t bg-white sm:hidden">
           <div>置底 nav bar, 只在手機尺寸顯示</div>
         </nav>
       </body>

--- a/packages/mesh/app/page.tsx
+++ b/packages/mesh/app/page.tsx
@@ -26,5 +26,5 @@ export default async function Home() {
   })
 
   const title = data.data.allCategories[0].name
-  return <div>Main content: {title}</div>
+  return <main>Main content: {title}</main>
 }

--- a/packages/mesh/app/page.tsx
+++ b/packages/mesh/app/page.tsx
@@ -1,4 +1,5 @@
 import { gql } from '@apollo/client'
+import Image from 'next/image'
 
 import { getClient } from '@/apollo'
 
@@ -26,9 +27,5 @@ export default async function Home() {
   })
 
   const title = data.data.allCategories[0].name
-  return (
-    <main className="text-wrap mt-4 text-3xl font-bold">
-      Hello Mesh Title: {title}
-    </main>
-  )
+  return <div>Main content: {title}</div>
 }

--- a/packages/mesh/app/page.tsx
+++ b/packages/mesh/app/page.tsx
@@ -1,5 +1,4 @@
 import { gql } from '@apollo/client'
-import Image from 'next/image'
 
 import { getClient } from '@/apollo'
 

--- a/packages/mesh/package.json
+++ b/packages/mesh/package.json
@@ -16,7 +16,8 @@
     "next": "14.2.2",
     "react": "^18",
     "react-dom": "^18",
-    "server-only": "^0.0.1"
+    "server-only": "^0.0.1",
+    "tailwind-merge": "^2.3.0"
   },
   "devDependencies": {
     "@types/node": "^20",
@@ -28,6 +29,7 @@
     "eslint-config-next": "14.2.2",
     "postcss": "^8.4.38",
     "prettier-plugin-tailwindcss": "^0.1.13",
+    "tailwind-merge": "^2.3.0",
     "tailwindcss": "^3.1.8",
     "typescript": "^5"
   }

--- a/packages/mesh/tailwind.config.js
+++ b/packages/mesh/tailwind.config.js
@@ -5,7 +5,21 @@ module.exports = {
     './components/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      screens: {
+        sm: '768px',
+        md: '960px',
+        lg: '1200px',
+        xl: '1440px',
+        xxl: '1920px',
+      },
+      height: {
+        15: '3.75rem',
+      },
+      padding: {
+        15: '3.75rem',
+      },
+    },
   },
   plugins: [],
 }

--- a/packages/mesh/tailwind.config.js
+++ b/packages/mesh/tailwind.config.js
@@ -5,16 +5,19 @@ module.exports = {
     './components/**/*.{js,ts,jsx,tsx,mdx}',
   ],
   theme: {
+    screens: {
+      sm: '768px',
+      md: '960px',
+      lg: '1200px',
+      xl: '1440px',
+      xxl: '1920px',
+    },
     extend: {
-      screens: {
-        sm: '768px',
-        md: '960px',
-        lg: '1200px',
-        xl: '1440px',
-        xxl: '1920px',
-      },
       height: {
         15: '3.75rem',
+      },
+      minHeight: {
+        screen: ['100vh /* fallback for Opera, IE and etc. */', '100dvh'],
       },
       padding: {
         15: '3.75rem',

--- a/packages/mesh/tailwind.config.js
+++ b/packages/mesh/tailwind.config.js
@@ -13,8 +13,28 @@ module.exports = {
       xxl: '1920px',
     },
     extend: {
+      width: {
+        maxContent: '1440px',
+        maxMain: '1220px',
+        nav: {
+          sm: '128px',
+          md: '220px',
+          xl: '320px',
+        },
+      },
       height: {
         15: '3.75rem',
+        header: {
+          default: '60px',
+          sm: '64px',
+        },
+        footer: {
+          default: '641px',
+          sm: '317px',
+        },
+        nav: {
+          default: '64px',
+        },
       },
       minHeight: {
         screen: ['100vh /* fallback for Opera, IE and etc. */', '100dvh'],

--- a/packages/mesh/tailwind.config.js
+++ b/packages/mesh/tailwind.config.js
@@ -22,8 +22,10 @@ module.exports = {
           xl: '320px',
         },
       },
-      height: {
+      spacing: {
         15: '3.75rem',
+      },
+      height: {
         header: {
           default: '60px',
           sm: '64px',
@@ -38,9 +40,6 @@ module.exports = {
       },
       minHeight: {
         screen: ['100vh /* fallback for Opera, IE and etc. */', '100dvh'],
-      },
-      padding: {
-        15: '3.75rem',
       },
     },
   },

--- a/packages/mesh/tailwind.config.js
+++ b/packages/mesh/tailwind.config.js
@@ -15,7 +15,7 @@ module.exports = {
     extend: {
       width: {
         maxContent: '1440px',
-        maxMain: '1220px',
+        maxMain: '1120px',
         nav: {
           sm: '128px',
           md: '220px',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2009,7 +2009,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.23.2":
+"@babel/runtime@^7.23.2", "@babel/runtime@^7.24.1":
   version "7.24.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.4.tgz#de795accd698007a66ba44add6cc86542aff1edd"
   integrity sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==
@@ -12385,6 +12385,13 @@ tailwind-clip-path@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/tailwind-clip-path/-/tailwind-clip-path-1.0.0.tgz#2a1d41480cac00603b6c4504d597426f6b4d0c88"
   integrity sha512-pac3BiCZCEKtX+3In4508PFcX2eZL7JwliZMtfYE0RoqFMjfbCVLmu+uuEFqn1y/f2vrOB5rY4XNcmaOSG1csw==
+
+tailwind-merge@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-2.3.0.tgz#27d2134fd00a1f77eca22bcaafdd67055917d286"
+  integrity sha512-vkYrLpIP+lgR0tQCG6AP7zZXCTLc1Lnv/CCRT3BqJ9CZ3ui2++GPaGb1x/ILsINIMSYqqvrpqjUFsMNLlW99EA==
+  dependencies:
+    "@babel/runtime" "^7.24.1"
 
 tailwindcss@^3.1.8:
   version "3.1.8"


### PR DESCRIPTION
# Notable Change

1. use `next/font/google` to setup Noto Sans TC font
2. add tailwind-merge to handle classname combination
3. setup breakpoints in tailwind config.js
4. build rwd layout

follow-up:
Layout 中的 header, footer, aside, nav 和 main 等 element 會被封裝到各自的 component 中，這邊只是依照設計稿把各個區塊會產生的變化用直觀的方式呈現。

reference:
[Figma 設計稿](https://www.figma.com/file/wqODc69zqgbu7TZFtQAmnN/2024_READr-Mesh_Web?type=design&node-id=5453-466662&mode=design&t=7mhhl7GvfQCn5NUs-0)