### PR TITLE
style(mesh): group font styles in classname

### DIFF
--- a/packages/mesh/styles/global.css
+++ b/packages/mesh/styles/global.css
@@ -41,11 +41,11 @@
   }
 
   .footnote {
-    @apply text-[13px] font-normal leading-[148%];
+    @apply text-[13px] font-normal leading-[150%];
   }
 
   .caption-1 {
-    @apply text-xs font-normal leading-[148%];
+    @apply text-xs font-normal leading-[150%];
   }
 
   .caption-2 {

--- a/packages/mesh/styles/global.css
+++ b/packages/mesh/styles/global.css
@@ -13,7 +13,7 @@
   }
 
   .title-2 {
-    @apply text-lg font-medium leading-[150%];
+    @apply text-lg font-medium leading-normal;
   }
 
   .list-title {
@@ -37,19 +37,19 @@
   }
 
   .body-3 {
-    @apply text-sm font-normal leading-[150%];
+    @apply text-sm font-normal leading-normal;
   }
 
   .footnote {
-    @apply text-[13px] font-normal leading-[150%];
+    @apply text-[13px] font-normal leading-normal;
   }
 
   .caption-1 {
-    @apply text-xs font-normal leading-[150%];
+    @apply text-xs font-normal leading-normal;
   }
 
   .caption-2 {
-    @apply text-[11px] font-normal leading-[100%];
+    @apply text-[11px] font-normal leading-none;
   }
 
   .button {
@@ -69,10 +69,10 @@
   }
 
   .profile-subtitle {
-    @apply text-sm font-normal leading-[100%];
+    @apply text-sm font-normal leading-none;
   }
 
   .quote {
-    @apply text-xl font-bold leading-[150%];
+    @apply text-xl font-bold leading-normal;
   }
 }

--- a/packages/mesh/styles/global.css
+++ b/packages/mesh/styles/global.css
@@ -2,75 +2,77 @@
 @tailwind components;
 @tailwind utilities;
 
-/* the typography types according to the figma */
-.hero-title {
-  @apply text-2xl font-medium leading-[130%];
-}
+@layer components {
+  /* the typography types according to the figma */
+  .hero-title {
+    @apply text-2xl font-medium leading-[130%];
+  }
 
-.title-1 {
-  @apply text-xl font-medium leading-[140%];
-}
+  .title-1 {
+    @apply text-xl font-medium leading-[140%];
+  }
 
-.title-2 {
-  @apply text-lg font-medium leading-[150%];
-}
+  .title-2 {
+    @apply text-lg font-medium leading-[150%];
+  }
 
-.list-title {
-  @apply text-lg font-medium leading-8;
-}
+  .list-title {
+    @apply text-lg font-medium leading-8;
+  }
 
-.subtitle-1 {
-  @apply text-base font-normal;
-}
+  .subtitle-1 {
+    @apply text-base font-normal;
+  }
 
-.subtitle-2 {
-  @apply text-sm font-medium leading-[130%];
-}
+  .subtitle-2 {
+    @apply text-sm font-medium leading-[130%];
+  }
 
-.body-1 {
-  @apply text-lg font-normal leading-[200%];
-}
+  .body-1 {
+    @apply text-lg font-normal leading-[200%];
+  }
 
-.body-2 {
-  @apply text-base font-normal;
-}
+  .body-2 {
+    @apply text-base font-normal;
+  }
 
-.body-3 {
-  @apply text-sm font-normal leading-[150%];
-}
+  .body-3 {
+    @apply text-sm font-normal leading-[150%];
+  }
 
-.footnote {
-  @apply text-[13px] font-normal leading-[148%];
-}
+  .footnote {
+    @apply text-[13px] font-normal leading-[148%];
+  }
 
-.caption-1 {
-  @apply text-xs font-normal leading-[148%];
-}
+  .caption-1 {
+    @apply text-xs font-normal leading-[148%];
+  }
 
-.caption-2 {
-  @apply text-[11px] font-normal leading-[100%];
-}
+  .caption-2 {
+    @apply text-[11px] font-normal leading-[100%];
+  }
 
-.button {
-  @apply text-sm font-normal leading-6;
-}
+  .button {
+    @apply text-sm font-normal leading-6;
+  }
 
-.button-large {
-  @apply text-base font-normal leading-[140%];
-}
+  .button-large {
+    @apply text-base font-normal leading-[140%];
+  }
 
-.profile-title {
-  @apply text-lg font-bold leading-6;
-}
+  .profile-title {
+    @apply text-lg font-bold leading-6;
+  }
 
-.profile-title-2 {
-  @apply text-base font-bold leading-5;
-}
+  .profile-title-2 {
+    @apply text-base font-bold leading-5;
+  }
 
-.profile-subtitle {
-  @apply text-sm font-normal leading-[100%];
-}
+  .profile-subtitle {
+    @apply text-sm font-normal leading-[100%];
+  }
 
-.quote {
-  @apply text-xl font-bold leading-[150%];
+  .quote {
+    @apply text-xl font-bold leading-[150%];
+  }
 }

--- a/packages/mesh/styles/global.css
+++ b/packages/mesh/styles/global.css
@@ -1,3 +1,76 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* the typography types according to the figma */
+.hero-title {
+  @apply text-2xl font-medium leading-[130%];
+}
+
+.title-1 {
+  @apply text-xl font-medium leading-[140%];
+}
+
+.title-2 {
+  @apply text-lg font-medium leading-[150%];
+}
+
+.list-title {
+  @apply text-lg font-medium leading-8;
+}
+
+.subtitle-1 {
+  @apply text-base font-normal;
+}
+
+.subtitle-2 {
+  @apply text-sm font-medium leading-[130%];
+}
+
+.body-1 {
+  @apply text-lg font-normal leading-[200%];
+}
+
+.body-2 {
+  @apply text-base font-normal;
+}
+
+.body-3 {
+  @apply text-sm font-normal leading-[150%];
+}
+
+.footnote {
+  @apply text-[13px] font-normal leading-[148%];
+}
+
+.caption-1 {
+  @apply text-xs font-normal leading-[148%];
+}
+
+.caption-2 {
+  @apply text-[11px] font-normal leading-[100%];
+}
+
+.button {
+  @apply text-sm font-normal leading-6;
+}
+
+.button-large {
+  @apply text-base font-normal leading-[140%];
+}
+
+.profile-title {
+  @apply text-lg font-bold leading-6;
+}
+
+.profile-title-2 {
+  @apply text-base font-bold leading-5;
+}
+
+.profile-subtitle {
+  @apply text-sm font-normal leading-[100%];
+}
+
+.quote {
+  @apply text-xl font-bold leading-[150%];
+}


### PR DESCRIPTION
# Notable Change

使用 tailwind @apply + 各種 font styles css 來建立各種字型 classname，讓開發上可以直接依照設計稿中 Typography 名稱來當作 classname (lower kebab case)，套用對應的 styles。


# Usage

`<div className="hero-title">一段文字</div>`