### PR TITLE
refactor(mesh): remove dummy request & update gql endpoint

### DIFF
--- a/packages/mesh/app/page.tsx
+++ b/packages/mesh/app/page.tsx
@@ -1,30 +1,5 @@
-import { gql } from '@apollo/client'
-
-import { getClient } from '@/apollo'
-
 export const revalidate = 60
 
-const fetchTest = gql`
-  query fetchCategoryBySlug {
-    allCategories(where: { slug: "nini_test_0410" }) {
-      name
-      slug
-      ogDescription
-    }
-  }
-`
-
 export default async function Home() {
-  const client = getClient()
-  const data = await client.query({
-    query: fetchTest,
-    context: {
-      fetchOptions: {
-        next: { revalidate: 0 },
-      },
-    },
-  })
-
-  const title = data.data.allCategories[0].name
-  return <main>Main content: {title}</main>
+  return <main>Main content</main>
 }

--- a/packages/mesh/constants/config.ts
+++ b/packages/mesh/constants/config.ts
@@ -5,8 +5,7 @@ let API_ENDPOINT = ''
 switch (ENV) {
   case 'local':
   case 'dev':
-    // use tv-cms api url for testing only
-    API_ENDPOINT = 'https://api-dev.mnews.tw/admin/api'
+    API_ENDPOINT = 'https://mesh-proxy-server-dev-4g6paft7cq-de.a.run.app/gql'
     break
 
   default:


### PR DESCRIPTION
因為 [PR 764](https://github.com/readr-media/Sachiel/pull/764) 看起來沒那麼快會 merge，先把 endpoint 以及拿掉 dummy request 的邏輯推上來，以避免 endpoint 更改後首頁會壞掉的問題。