### PR TITLE
fix: old eslint parser using on new next.js project

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "homepage": "https://github.com/readr-media/Sachiel#readme",
   "devDependencies": {
     "eslint": "8.24.0",
-    "eslint-config-next": "12.3.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",
     "husky": "^8.0.1",

--- a/packages/politics-tracker/package.json
+++ b/packages/politics-tracker/package.json
@@ -52,6 +52,7 @@
     "@types/uuid": "^8.3.4",
     "autoprefixer": "^10.4.12",
     "cssnano": "^5.1.13",
+    "eslint-config-next": "12.3.1",
     "postcss": "^8.4.17",
     "prettier-plugin-tailwindcss": "^0.1.13",
     "tailwind-clip-path": "^1.0.0",


### PR DESCRIPTION
# Notable Change
- move eslint-config-next from root to politics-tracker

Error on Mesh when running `yarn lint` 
![image](https://github.com/user-attachments/assets/0ecbbdbe-f3d4-42e9-8fb1-a87a085425dd)

Observation:
root package 的 eslint-config-next 版本太低，造成裝了兩套 `@typescript-eslint/parser` > `@typescript-eslint/typescript-estree`，然後因為不明原因導致 lint 都用到了舊版的 `typescript/estree` 就會噴錯