### PR TITLE
chore(mesh): authorization

### DIFF
--- a/packages/mesh/app/actions/auth.ts
+++ b/packages/mesh/app/actions/auth.ts
@@ -61,7 +61,7 @@ export async function getAccessToken(idToken: string) {
     {
       cache: 'no-cache',
       headers: {
-        Authorization: idToken,
+        Authorization: `Bearer ${idToken}`,
       },
     },
     'fail message'


### PR DESCRIPTION
- sync with access token api [changes](https://github.com/readr-media/mesh-proxy-server/compare/e62f57560533...dd74a9e217b4)