### PR TITLE
fix(readr): large posts data cause timeout

### DIFF
--- a/packages/readr/components/about/members.tsx
+++ b/packages/readr/components/about/members.tsx
@@ -552,7 +552,7 @@ export default function Members({
                   })}
                 </Number>
               </InfoWrapper>
-              {member.posts?.length === 0 ? (
+              {member.postsCount === 0 ? (
                 <Work
                   style={{
                     backgroundColor: '#E5E5E5',

--- a/packages/readr/graphql/query/member.ts
+++ b/packages/readr/graphql/query/member.ts
@@ -13,7 +13,7 @@ export type Member = Override<
     | 'special_number'
     | 'number_desc'
     | 'number_desc_en'
-    | 'posts'
+    | 'postsCount'
   >,
   {
     id: string
@@ -31,10 +31,7 @@ const members = gql`
       special_number
       number_desc
       number_desc_en
-      posts {
-        id
-        name
-      }
+      postsCount
     }
   }
 `

--- a/packages/readr/pages/about.tsx
+++ b/packages/readr/pages/about.tsx
@@ -1,6 +1,6 @@
 import type { ApolloQueryResult } from '@apollo/client/core'
 import errors from '@twreporter/errors'
-import type { GetServerSideProps } from 'next'
+import type { GetStaticProps } from 'next'
 import { ReactElement, useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
 
@@ -22,7 +22,6 @@ import { pageVariablesByPage } from '~/graphql/query/page-variable'
 import type { QaList } from '~/graphql/query/qa'
 import { qALists as qAListsGql } from '~/graphql/query/qa'
 import type { Language, RenderedAward } from '~/types/about'
-import { setCacheControl } from '~/utils/common'
 
 import type { NextPageWithLayout } from './_app'
 
@@ -193,11 +192,9 @@ const About: NextPageWithLayout<PageProps> = ({
   )
 }
 
-export const getServerSideProps: GetServerSideProps<PageProps> = async ({
-  res,
-}) => {
-  setCacheControl(res)
-
+// cache a week
+const pageRevalidate = 7 * 24 * 60 * 60
+export const getStaticProps: GetStaticProps<PageProps> = async () => {
   const client = getGqlClient()
   let awardsData: Award[] = []
   let moreReportData: PageVariable[] = []
@@ -288,6 +285,7 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
       membersData,
       qAListsData,
     },
+    revalidate: pageRevalidate,
   }
 }
 

--- a/packages/readr/types/common.ts
+++ b/packages/readr/types/common.ts
@@ -74,6 +74,7 @@ export type GenericAuthor = {
   special_number: string
   number_desc: string
   number_desc_en: string
+  postsCount: number
   posts: GenericPost[]
 }
 


### PR DESCRIPTION
# Notable Change

- Replace `posts` data with `postsCount` to show member info.
- Turn `/about` page into staticProps page since the page data will not be changed in high frequency.