### PR TITLE
refactor(mesh): login options and name validation

### DIFF
--- a/packages/mesh/app/actions/get-invalid-names.ts
+++ b/packages/mesh/app/actions/get-invalid-names.ts
@@ -1,0 +1,22 @@
+'use server'
+
+import { STATIC_FILE_ENDPOINTS } from '@/constants/config'
+import fetchStatic from '@/utils/fetch-static'
+import { getLogTraceObjectFromHeaders, logServerSideError } from '@/utils/log'
+
+export async function getInvalidNameList() {
+  const globalLogFields = getLogTraceObjectFromHeaders()
+
+  try {
+    return await fetchStatic<string[]>(STATIC_FILE_ENDPOINTS.invalidNameList, {
+      next: { revalidate: 10 },
+    })
+  } catch (error) {
+    logServerSideError(
+      error,
+      'Error on validate most_recommend_sponsors.json',
+      globalLogFields
+    )
+    return null
+  }
+}

--- a/packages/mesh/app/actions/get-invalid-names.ts
+++ b/packages/mesh/app/actions/get-invalid-names.ts
@@ -14,7 +14,7 @@ export async function getInvalidNameList() {
   } catch (error) {
     logServerSideError(
       error,
-      'Error on validate most_recommend_sponsors.json',
+      'Error: Fail to get invalid name lists',
       globalLogFields
     )
     return null

--- a/packages/mesh/app/login/_components/login-entry.tsx
+++ b/packages/mesh/app/login/_components/login-entry.tsx
@@ -22,6 +22,7 @@ export default function LoginEntry() {
         </p>
       </div>
       <div className="flex w-full flex-col items-center justify-center gap-3">
+        {/* 因第三方因素，暫時停用 facebook login 機制 */}
         {loginOptions
           .filter((option) => option.method !== 'facebook')
           .map((option) => (

--- a/packages/mesh/app/login/_components/login-entry.tsx
+++ b/packages/mesh/app/login/_components/login-entry.tsx
@@ -22,20 +22,22 @@ export default function LoginEntry() {
         </p>
       </div>
       <div className="flex w-full flex-col items-center justify-center gap-3">
-        {loginOptions.map((option) => (
-          <div
-            className="w-full max-w-[320px]"
-            key={`login-with-${option.method}`}
-          >
-            <Button
-              size="lg"
-              color="white"
-              text={transformedBtnText(option.method)}
-              icon={{ iconName: option.iconName, size: 'm' }}
-              onClick={() => onLoginMethodClick(option.method)}
-            />
-          </div>
-        ))}
+        {loginOptions
+          .filter((option) => option.method !== 'facebook')
+          .map((option) => (
+            <div
+              className="w-full max-w-[320px]"
+              key={`login-with-${option.method}`}
+            >
+              <Button
+                size="lg"
+                color="white"
+                text={transformedBtnText(option.method)}
+                icon={{ iconName: option.iconName, size: 'm' }}
+                onClick={() => onLoginMethodClick(option.method)}
+              />
+            </div>
+          ))}
       </div>
       <p className="footnote text-center text-primary-400">
         繼續使用代表您同意與接受我們的

--- a/packages/mesh/app/login/_components/login-set-name.tsx
+++ b/packages/mesh/app/login/_components/login-set-name.tsx
@@ -27,7 +27,7 @@ export default function LoginSetName() {
     }
   }
 
-  const validationResults = validateName(invalidNames, name)
+  const validationResults = validateName({ invalidNames, name })
   const isValid = validationResults.every((result) => result.isValid)
 
   const handleSubmit = () => {
@@ -94,24 +94,30 @@ export default function LoginSetName() {
 const validationRules = [
   {
     message: '姓名在 2-32 字間',
-    check: (invalidNames: string[], name: string) =>
+    check: ({ name }: { name: string }) =>
       name.length >= 2 && name.length <= 32,
   },
   {
     message: '不包含特殊符號',
-    check: (invalidNames: string[], name: string) =>
+    check: ({ name }: { name: string }) =>
       /^[a-zA-Z0-9\u4e00-\u9fa5]+$/.test(name),
   },
   {
     message: '沒有跟媒體名稱重複',
-    check: (invalidNames: string[], name: string) =>
+    check: ({ invalidNames, name }: { invalidNames: string[]; name: string }) =>
       !invalidNames.some((invalidName) =>
         name.toLowerCase().includes(invalidName.toLowerCase())
       ),
   },
 ]
 
-const validateName = (invalidNames: string[], name: string) => {
+const validateName = ({
+  invalidNames,
+  name,
+}: {
+  invalidNames: string[]
+  name: string
+}) => {
   if (!name || !invalidNames.length) {
     return validationRules.map((rule) => ({
       message: rule.message,
@@ -120,6 +126,6 @@ const validateName = (invalidNames: string[], name: string) => {
   }
   return validationRules.map((rule) => ({
     message: rule.message,
-    isValid: rule.check(invalidNames, name),
+    isValid: rule.check({ invalidNames, name }),
   }))
 }

--- a/packages/mesh/constants/config.ts
+++ b/packages/mesh/constants/config.ts
@@ -111,6 +111,7 @@ const STATIC_FILE_ENDPOINTS = {
   contract: `${STATIC_FILE_ORIGIN}/contracts/MeshPoint.json`,
   publisherStoriesFn: (publisherCustomId: string) =>
     `${STATIC_FILE_ORIGIN}/data/${publisherCustomId}_stories.json`,
+  invalidNameList: `${STATIC_FILE_ORIGIN}/data/invalid_names.json`,
 }
 
 export {

--- a/packages/mesh/graphql/__generated__/graphql.ts
+++ b/packages/mesh/graphql/__generated__/graphql.ts
@@ -823,6 +823,60 @@ export type IntNullableFilter = {
   notIn?: InputMaybe<Array<Scalars['Int']['input']>>
 }
 
+export type InvalidName = {
+  __typename?: 'InvalidName'
+  createdAt?: Maybe<Scalars['DateTime']['output']>
+  createdBy?: Maybe<User>
+  id: Scalars['ID']['output']
+  name?: Maybe<Scalars['String']['output']>
+  updatedAt?: Maybe<Scalars['DateTime']['output']>
+  updatedBy?: Maybe<User>
+}
+
+export type InvalidNameCreateInput = {
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>
+  createdBy?: InputMaybe<UserRelateToOneForCreateInput>
+  name?: InputMaybe<Scalars['String']['input']>
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>
+  updatedBy?: InputMaybe<UserRelateToOneForCreateInput>
+}
+
+export type InvalidNameOrderByInput = {
+  createdAt?: InputMaybe<OrderDirection>
+  id?: InputMaybe<OrderDirection>
+  name?: InputMaybe<OrderDirection>
+  updatedAt?: InputMaybe<OrderDirection>
+}
+
+export type InvalidNameUpdateArgs = {
+  data: InvalidNameUpdateInput
+  where: InvalidNameWhereUniqueInput
+}
+
+export type InvalidNameUpdateInput = {
+  createdAt?: InputMaybe<Scalars['DateTime']['input']>
+  createdBy?: InputMaybe<UserRelateToOneForUpdateInput>
+  name?: InputMaybe<Scalars['String']['input']>
+  updatedAt?: InputMaybe<Scalars['DateTime']['input']>
+  updatedBy?: InputMaybe<UserRelateToOneForUpdateInput>
+}
+
+export type InvalidNameWhereInput = {
+  AND?: InputMaybe<Array<InvalidNameWhereInput>>
+  NOT?: InputMaybe<Array<InvalidNameWhereInput>>
+  OR?: InputMaybe<Array<InvalidNameWhereInput>>
+  createdAt?: InputMaybe<DateTimeNullableFilter>
+  createdBy?: InputMaybe<UserWhereInput>
+  id?: InputMaybe<IdFilter>
+  name?: InputMaybe<StringFilter>
+  updatedAt?: InputMaybe<DateTimeNullableFilter>
+  updatedBy?: InputMaybe<UserWhereInput>
+}
+
+export type InvalidNameWhereUniqueInput = {
+  id?: InputMaybe<Scalars['ID']['input']>
+}
+
 export type InvitationCode = {
   __typename?: 'InvitationCode'
   code?: Maybe<Scalars['String']['output']>
@@ -1423,6 +1477,8 @@ export type Mutation = {
   createComment?: Maybe<Comment>
   createComments?: Maybe<Array<Maybe<Comment>>>
   createInitialUser: UserAuthenticationWithPasswordSuccess
+  createInvalidName?: Maybe<InvalidName>
+  createInvalidNames?: Maybe<Array<Maybe<InvalidName>>>
   createInvitationCode?: Maybe<InvitationCode>
   createInvitationCodes?: Maybe<Array<Maybe<InvitationCode>>>
   createMember?: Maybe<Member>
@@ -1459,6 +1515,8 @@ export type Mutation = {
   deleteCollections?: Maybe<Array<Maybe<Collection>>>
   deleteComment?: Maybe<Comment>
   deleteComments?: Maybe<Array<Maybe<Comment>>>
+  deleteInvalidName?: Maybe<InvalidName>
+  deleteInvalidNames?: Maybe<Array<Maybe<InvalidName>>>
   deleteInvitationCode?: Maybe<InvitationCode>
   deleteInvitationCodes?: Maybe<Array<Maybe<InvitationCode>>>
   deleteMember?: Maybe<Member>
@@ -1496,6 +1554,8 @@ export type Mutation = {
   updateCollections?: Maybe<Array<Maybe<Collection>>>
   updateComment?: Maybe<Comment>
   updateComments?: Maybe<Array<Maybe<Comment>>>
+  updateInvalidName?: Maybe<InvalidName>
+  updateInvalidNames?: Maybe<Array<Maybe<InvalidName>>>
   updateInvitationCode?: Maybe<InvitationCode>
   updateInvitationCodes?: Maybe<Array<Maybe<InvitationCode>>>
   updateMember?: Maybe<Member>
@@ -1577,6 +1637,14 @@ export type MutationCreateCommentsArgs = {
 
 export type MutationCreateInitialUserArgs = {
   data: CreateInitialUserInput
+}
+
+export type MutationCreateInvalidNameArgs = {
+  data: InvalidNameCreateInput
+}
+
+export type MutationCreateInvalidNamesArgs = {
+  data: Array<InvalidNameCreateInput>
 }
 
 export type MutationCreateInvitationCodeArgs = {
@@ -1721,6 +1789,14 @@ export type MutationDeleteCommentArgs = {
 
 export type MutationDeleteCommentsArgs = {
   where: Array<CommentWhereUniqueInput>
+}
+
+export type MutationDeleteInvalidNameArgs = {
+  where: InvalidNameWhereUniqueInput
+}
+
+export type MutationDeleteInvalidNamesArgs = {
+  where: Array<InvalidNameWhereUniqueInput>
 }
 
 export type MutationDeleteInvitationCodeArgs = {
@@ -1871,6 +1947,15 @@ export type MutationUpdateCommentArgs = {
 
 export type MutationUpdateCommentsArgs = {
   data: Array<CommentUpdateArgs>
+}
+
+export type MutationUpdateInvalidNameArgs = {
+  data: InvalidNameUpdateInput
+  where: InvalidNameWhereUniqueInput
+}
+
+export type MutationUpdateInvalidNamesArgs = {
+  data: Array<InvalidNameUpdateArgs>
 }
 
 export type MutationUpdateInvitationCodeArgs = {
@@ -2422,6 +2507,7 @@ export type Publisher = {
   full_content?: Maybe<Scalars['Boolean']['output']>
   full_screen_ad?: Maybe<Scalars['String']['output']>
   id: Scalars['ID']['output']
+  is_active?: Maybe<Scalars['Boolean']['output']>
   lang?: Maybe<Scalars['String']['output']>
   logo?: Maybe<Scalars['String']['output']>
   official_site?: Maybe<Scalars['String']['output']>
@@ -2480,6 +2566,7 @@ export type PublisherCreateInput = {
   follower?: InputMaybe<MemberRelateToManyForCreateInput>
   full_content?: InputMaybe<Scalars['Boolean']['input']>
   full_screen_ad?: InputMaybe<Scalars['String']['input']>
+  is_active?: InputMaybe<Scalars['Boolean']['input']>
   lang?: InputMaybe<Scalars['String']['input']>
   logo?: InputMaybe<Scalars['String']['input']>
   official_site?: InputMaybe<Scalars['String']['input']>
@@ -2508,6 +2595,7 @@ export type PublisherOrderByInput = {
   full_content?: InputMaybe<OrderDirection>
   full_screen_ad?: InputMaybe<OrderDirection>
   id?: InputMaybe<OrderDirection>
+  is_active?: InputMaybe<OrderDirection>
   lang?: InputMaybe<OrderDirection>
   logo?: InputMaybe<OrderDirection>
   official_site?: InputMaybe<OrderDirection>
@@ -2556,6 +2644,7 @@ export type PublisherUpdateInput = {
   follower?: InputMaybe<MemberRelateToManyForUpdateInput>
   full_content?: InputMaybe<Scalars['Boolean']['input']>
   full_screen_ad?: InputMaybe<Scalars['String']['input']>
+  is_active?: InputMaybe<Scalars['Boolean']['input']>
   lang?: InputMaybe<Scalars['String']['input']>
   logo?: InputMaybe<Scalars['String']['input']>
   official_site?: InputMaybe<Scalars['String']['input']>
@@ -2583,6 +2672,7 @@ export type PublisherWhereInput = {
   full_content?: InputMaybe<BooleanFilter>
   full_screen_ad?: InputMaybe<StringNullableFilter>
   id?: InputMaybe<IdFilter>
+  is_active?: InputMaybe<BooleanFilter>
   lang?: InputMaybe<StringNullableFilter>
   logo?: InputMaybe<StringFilter>
   official_site?: InputMaybe<StringFilter>
@@ -2623,6 +2713,9 @@ export type Query = {
   comment?: Maybe<Comment>
   comments?: Maybe<Array<Comment>>
   commentsCount?: Maybe<Scalars['Int']['output']>
+  invalidName?: Maybe<InvalidName>
+  invalidNames?: Maybe<Array<InvalidName>>
+  invalidNamesCount?: Maybe<Scalars['Int']['output']>
   invitationCode?: Maybe<InvitationCode>
   invitationCodes?: Maybe<Array<InvitationCode>>
   invitationCodesCount?: Maybe<Scalars['Int']['output']>
@@ -2750,6 +2843,21 @@ export type QueryCommentsArgs = {
 
 export type QueryCommentsCountArgs = {
   where?: CommentWhereInput
+}
+
+export type QueryInvalidNameArgs = {
+  where: InvalidNameWhereUniqueInput
+}
+
+export type QueryInvalidNamesArgs = {
+  orderBy?: Array<InvalidNameOrderByInput>
+  skip?: Scalars['Int']['input']
+  take?: InputMaybe<Scalars['Int']['input']>
+  where?: InvalidNameWhereInput
+}
+
+export type QueryInvalidNamesCountArgs = {
+  where?: InvalidNameWhereInput
 }
 
 export type QueryInvitationCodeArgs = {


### PR DESCRIPTION
## Notable Changes

- Temporarily hide 'Facebook' login option due to third-party provider issues
- Integrate invalid name list JSON for validating user input name.

<img width="374" alt="Screenshot 2024-10-30 at 11 44 30 AM" src="https://github.com/user-attachments/assets/34ace774-7bd5-4b19-a309-2c9c9f2d58fd">


https://github.com/user-attachments/assets/d57afbcc-b46a-40f7-acfd-4e0ae80c682d





---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208636212403722
  - https://app.asana.com/0/0/1208645950390134