### PR TITLE
fix(mesh): reander Readr sideIndex error

### DIFF
--- a/packages/mesh/app/story/[id]/_components/api-data-renderer/utils/side-index.ts
+++ b/packages/mesh/app/story/[id]/_components/api-data-renderer/utils/side-index.ts
@@ -1,7 +1,11 @@
 const sideIndexHeaderIdPrefix = 'side-index-header-'
 
-function removeAllWhiteSpces(str: string) {
-  return str.replace(/\s+/g, '')
+function createIdFromText(text: string) {
+  return text
+    .trim() // Remove leading/trailing whitespace
+    .toLowerCase() // Convert to lowercase
+    .replace(/[^\w\s\p{Script=Han}-]/gu, '') // Remove all non-word characters except spaces, hyphens, and Chinese characters
+    .replace(/\s+/g, '') // Replace spaces
 }
 
 export function genReadrSideIndexHeaderId(
@@ -10,7 +14,7 @@ export function genReadrSideIndexHeaderId(
 ) {
   const sideIndexTitle = sideIndexText || h2Text || ''
 
-  const key = removeAllWhiteSpces(sideIndexTitle)
+  const key = createIdFromText(sideIndexTitle)
   return sideIndexHeaderIdPrefix + key
 }
 


### PR DESCRIPTION
# Fix story 1312163 page 500

- log: `SyntaxError: Failed to execute 'querySelector' on 'Document': '#side-index-header-不到10%中間選民將左右選舉結果' is not a valid selector.`

- Reson: 

1. sideIndex button 需要處理不合法字元
2. Readr draft.js 轉成 apiData 的時候格式有跑掉，導致 apiData 上該出現的 h2 沒有出來
Readr CMS draft.js
```
          "24": {
            "data": {
              "h2Text": "負面情緒號召投票 政黨理念非選民首要考量",
              "sideIndexUrl": "",
              "sideIndexText": ""
            },
            "type": "SIDEINDEX",
            "mutability": "IMMUTABLE"
          },
```
Mesh CMS apiData
```
        {
          "id": "6eeg1",
          "type": "sideindex",
          "styles": {},
          "content": [
            {
              "h2Text": "",
              "sideIndexUrl": "",
              "sideIndexText": "負面情緒號召投票 政黨理念非首要考量"
            }
          ],
          "alignment": "center"
        },
```

本次PR解決1.的問題，2.需要去 lilith/draft-editor/draft-converter debug 解決，目前 SideIndex block 沒辦法正常生成 H2