### PR TITLE
refactor(mesh): add category slug as search params

### DIFF
--- a/packages/mesh/app/media/_components/category-selector.tsx
+++ b/packages/mesh/app/media/_components/category-selector.tsx
@@ -1,9 +1,10 @@
-import type { Dispatch, MouseEventHandler, SetStateAction } from 'react'
+import type { MouseEventHandler } from 'react'
 import { useRef, useState } from 'react'
 
 import { addCategory, removeCategory } from '@/app/actions/edit-category'
 import Button from '@/components/button'
 import InteractiveIcon, { type Icon } from '@/components/interactive-icon'
+import { categorySearchParamName } from '@/constants/search-param-names'
 import TOAST_MESSAGE from '@/constants/toast'
 import { useToast } from '@/context/toast'
 import { useUser } from '@/context/user'
@@ -14,6 +15,7 @@ import {
   undoAddCategories,
   undoDeleteCategroies,
 } from '@/utils/edit-category'
+import { setSearchParams } from '@/utils/search-params'
 
 import type { Category } from '../page'
 import CategoryEditor from './category-editor'
@@ -37,11 +39,9 @@ const NavigateButton = ({
 export default function CategorySelector({
   allCategories,
   currentCategory,
-  setCurrentCategory,
 }: {
   allCategories: Category[]
-  currentCategory: Category
-  setCurrentCategory: Dispatch<SetStateAction<Category>>
+  currentCategory?: Category
 }) {
   const { user, setUser } = useUser()
   const displayCategories = user.followingCategories
@@ -98,10 +98,10 @@ export default function CategorySelector({
     }
 
     const isCurrentCategoryDeleted = !finalCategories.find(
-      (category) => category.slug === currentCategory.slug
+      (category) => category.slug === currentCategory?.slug
     )
     if (isCurrentCategoryDeleted) {
-      setCurrentCategory(finalCategories[0])
+      setSearchParams(categorySearchParamName, finalCategories[0].slug ?? '')
     }
 
     setUser((user) => ({
@@ -130,10 +130,13 @@ export default function CategorySelector({
                   color="nav-chip"
                   text={category.title ?? ''}
                   activeState={{
-                    isActive: category.slug === currentCategory.slug,
+                    isActive: category.slug === currentCategory?.slug,
                   }}
                   onClick={() => {
-                    setCurrentCategory(category)
+                    setSearchParams(
+                      categorySearchParamName,
+                      category.slug ?? ''
+                    )
                   }}
                 />
               </div>

--- a/packages/mesh/app/media/page.tsx
+++ b/packages/mesh/app/media/page.tsx
@@ -18,6 +18,5 @@ export default async function Page() {
 
   const allCategoriesResponse = await getAllCategories()
   const allCategories = allCategoriesResponse?.categories ?? []
-
   return <MediaStories allCategories={allCategories} />
 }

--- a/packages/mesh/constants/search-param-names.ts
+++ b/packages/mesh/constants/search-param-names.ts
@@ -1,0 +1,1 @@
+export const categorySearchParamName = 'c'

--- a/packages/mesh/utils/search-params.ts
+++ b/packages/mesh/utils/search-params.ts
@@ -1,0 +1,25 @@
+/**
+ * Use window.history to add search param to prevent next router reload the page
+ */
+export function replaceSearchParams(paramName: string, paramValue: string) {
+  const searchParams = new URLSearchParams(window.location.search)
+  searchParams.set(paramName, paramValue)
+  window.history.replaceState(
+    null,
+    '',
+    `${window.location.pathname}?${searchParams.toString()}`
+  )
+}
+
+/**
+ * Use window.history to add search param to prevent next router reload the page
+ */
+export function setSearchParams(paramName: string, paramValue: string) {
+  const searchParams = new URLSearchParams(window.location.search)
+  searchParams.set(paramName, paramValue)
+  window.history.pushState(
+    null,
+    '',
+    `${window.location.pathname}?${searchParams.toString()}`
+  )
+}


### PR DESCRIPTION
# Notable Changes

Use category slug as search params and replace `useState` with `useSearchParams`. 

Use window.history to push/replace search params rather than next.js router to prevent page reload when set search params.

Pages: 
- Homepage (category section)
- Media 