### PR TITLE
feat(profile): add show more toggle for user intro text

### DIFF
--- a/packages/mesh/app/profile/_components/user-profile.tsx
+++ b/packages/mesh/app/profile/_components/user-profile.tsx
@@ -1,5 +1,8 @@
+import { useState } from 'react'
+
 import Avatar from '@/components/story-card/avatar'
 import { type UserType } from '@/types/profile'
+import { debounce } from '@/utils/performance'
 
 type UserProfileProps = {
   name: string
@@ -17,6 +20,9 @@ const UserProfile: React.FC<UserProfileProps> = ({
   userType,
   pickedCount,
 }) => {
+  const [showMore, setShowMore] = useState(false)
+  const toggleShowMore = () => setShowMore((prev) => !prev)
+  const handleOnClickShowMore = debounce(toggleShowMore)
   const userPickOrPickedSubtitle = (userType: string) => {
     if (userType === 'publisher') {
       return (
@@ -44,7 +50,12 @@ const UserProfile: React.FC<UserProfileProps> = ({
           {userPickOrPickedSubtitle(userType)}
         </div>
       </section>
-      <p className="body-3 sm:body-2 mt-3 line-clamp-6 w-full whitespace-pre text-primary-500 sm:mt-4">
+      <p
+        className={`body-3 sm:body-2 mt-3 w-full whitespace-normal text-primary-500 sm:mt-4 ${
+          showMore ? '' : 'line-clamp-6'
+        }`}
+        onClick={handleOnClickShowMore}
+      >
         {intro}
       </p>
     </>


### PR DESCRIPTION
- Add expandable functionality to user profile intro text
- Implement show more/less toggle using line-clamp
- Add debounced click handler to prevent rapid toggling

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208793595806273
  - https://app.asana.com/0/0/1208706530282621