### PR TITLE
fix(mesh): reset page data accidentally

### DIFF
--- a/packages/mesh/app/_components/category-story/nav-list.tsx
+++ b/packages/mesh/app/_components/category-story/nav-list.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useRouter, useSearchParams } from 'next/navigation'
+import { useSearchParams } from 'next/navigation'
 import type { MouseEventHandler } from 'react'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { fetchCategoryStory } from '@/app/actions/get-homepage'
 import Button from '@/components/button'
@@ -13,6 +13,7 @@ import useInView from '@/hooks/use-in-view'
 import useUserPayload from '@/hooks/use-user-payload'
 import type { CategoryStory } from '@/types/homepage'
 import { logCategoryClick } from '@/utils/event-logs'
+import { replaceSearchParams, setSearchParams } from '@/utils/search-params'
 
 import StorySection from './story-section'
 
@@ -39,32 +40,18 @@ type Props = {
 
 export default function NavList({ categories, initialStories }: Props) {
   const [data, setData] = useState<CategoryStory[] | null>(initialStories)
-  const router = useRouter()
   const userPayload = useUserPayload()
   const searchParams = useSearchParams()
   const activeCategorySlug = searchParams.get(categorySearchParamName)
-  const activeCategory = useMemo(
-    () => categories?.find((category) => category.slug === activeCategorySlug),
-    [activeCategorySlug, categories]
+  const activeCategory = categories?.find(
+    (category) => category.slug === activeCategorySlug
   )
 
-  const updateCategorySearchParams = (categorySlug: string) => {
-    const newSearchParams = new URLSearchParams(searchParams)
-    newSearchParams.set(categorySearchParamName, categorySlug ?? '')
-    router.push(`?${newSearchParams.toString()}`, { scroll: false })
-  }
-
   useEffect(() => {
-    const replaceCategorySearchParams = (categorySlug: string) => {
-      const newSearchParams = new URLSearchParams(searchParams)
-      newSearchParams.set(categorySearchParamName, categorySlug ?? '')
-      router.replace(`?${newSearchParams.toString()}`, { scroll: false })
-    }
-
     if (!activeCategorySlug) {
-      replaceCategorySearchParams(categories[0].slug ?? '')
+      replaceSearchParams(categorySearchParamName, categories[0].slug ?? '')
     }
-  }, [activeCategorySlug, categories, router, searchParams])
+  }, [activeCategorySlug, categories])
 
   useEffect(() => {
     const fetchCategoryData = async (categorySlug: string) => {
@@ -113,7 +100,10 @@ export default function NavList({ categories, initialStories }: Props) {
                   }}
                   onClick={() => {
                     logCategoryClick(userPayload, category?.title ?? '')
-                    updateCategorySearchParams(category.slug ?? '')
+                    setSearchParams(
+                      categorySearchParamName,
+                      category.slug ?? ''
+                    )
                   }}
                 />
               </div>

--- a/packages/mesh/app/media/_components/category-selector.tsx
+++ b/packages/mesh/app/media/_components/category-selector.tsx
@@ -1,4 +1,3 @@
-import { useRouter, useSearchParams } from 'next/navigation'
 import type { MouseEventHandler } from 'react'
 import { useRef, useState } from 'react'
 
@@ -18,6 +17,7 @@ import {
   undoDeleteCategroies,
 } from '@/utils/edit-category'
 import { logCategoryClick } from '@/utils/event-logs'
+import { setSearchParams } from '@/utils/search-params'
 
 import type { Category } from '../page'
 import CategoryEditor from './category-editor'
@@ -49,8 +49,6 @@ export default function CategorySelector({
   const displayCategories = user.followingCategories
   const { addToast } = useToast()
   const userPayoload = useUserPayload()
-  const router = useRouter()
-  const searchParams = useSearchParams()
 
   const [showCategoryEditor, setShowCategoryEditor] = useState(false)
   const { memberId } = user
@@ -64,12 +62,6 @@ export default function CategorySelector({
   const showNavigatePrevious =
     isLeadingRefInView !== null && !isLeadingRefInView
   const showNavigateNext = isEndingRefInView !== null && !isEndingRefInView
-
-  const updateCategorySearchParams = (categorySlug: string) => {
-    const newSearchParams = new URLSearchParams(searchParams)
-    newSearchParams.set(categorySearchParamName, categorySlug ?? '')
-    router.push(`?${newSearchParams.toString()}`)
-  }
 
   const onEditCategoriesFinish = async (newCategories: Category[]) => {
     const addedCategoryIds = getAddedCategoryIds(
@@ -112,7 +104,7 @@ export default function CategorySelector({
       (category) => category.slug === currentCategory?.slug
     )
     if (isCurrentCategoryDeleted) {
-      updateCategorySearchParams(finalCategories[0].slug ?? '')
+      setSearchParams(categorySearchParamName, finalCategories[0].slug ?? '')
     }
 
     setUser((user) => ({
@@ -145,7 +137,10 @@ export default function CategorySelector({
                   }}
                   onClick={() => {
                     logCategoryClick(userPayoload, category?.title ?? '')
-                    updateCategorySearchParams(category.slug ?? '')
+                    setSearchParams(
+                      categorySearchParamName,
+                      category.slug ?? ''
+                    )
                   }}
                 />
               </div>

--- a/packages/mesh/app/media/_components/media-stories.tsx
+++ b/packages/mesh/app/media/_components/media-stories.tsx
@@ -194,10 +194,6 @@ export default function MediaStories({
     mostPickedStory,
   ])
 
-  useEffect(() => {
-    setPageDataInCategories(getInitialPageData(allCategories))
-  }, [allCategories, user.followingPublishers])
-
   let contentJsx: JSX.Element
 
   if (isLoading || !currentCategory) {

--- a/packages/mesh/utils/search-params.ts
+++ b/packages/mesh/utils/search-params.ts
@@ -1,0 +1,25 @@
+/**
+ * Use window.history to add search param to prevent next router reload the page
+ */
+export function replaceSearchParams(paramName: string, paramValue: string) {
+  const searchParams = new URLSearchParams(window.location.search)
+  searchParams.set(paramName, paramValue)
+  window.history.replaceState(
+    null,
+    '',
+    `${window.location.pathname}?${searchParams.toString()}`
+  )
+}
+
+/**
+ * Use window.history to add search param to prevent next router reload the page
+ */
+export function setSearchParams(paramName: string, paramValue: string) {
+  const searchParams = new URLSearchParams(window.location.search)
+  searchParams.set(paramName, paramValue)
+  window.history.pushState(
+    null,
+    '',
+    `${window.location.pathname}?${searchParams.toString()}`
+  )
+}


### PR DESCRIPTION
# Notable Change

remove unnecessary `useEffect` to reset pageData.


Revert PR #1077 cause replace window.history.replace/setState with router.replace/push make it too slow to change when category change.

## Know issue: (extreme case)
Keep clicking category button to swtich in a small period of time quickly will break the page and the component seems unmount without error happening.