### PR TITLE
refactor(api-data): update ul and ol block renderer

### DIFF
--- a/packages/mesh/app/story/[id]/_components/api-data-renderer/block-renderer/list-block.tsx
+++ b/packages/mesh/app/story/[id]/_components/api-data-renderer/block-renderer/list-block.tsx
@@ -2,13 +2,13 @@ import type { ApiDataBlockBase, ApiDataBlockType } from '../types'
 
 export interface ApiDataUnorderList extends ApiDataBlockBase {
   type: ApiDataBlockType.UnorderList
-  content: string[][]
+  content: string[][] | string[]
   alignment: 'center'
 }
 
 export interface ApiDataOrderList extends ApiDataBlockBase {
   type: ApiDataBlockType.OrderList
-  content: string[][]
+  content: string[][] | string[]
   alignment: 'center'
 }
 
@@ -17,7 +17,14 @@ export function UnorderListBlock({
 }: {
   apiDataBlock: ApiDataUnorderList
 }) {
-  const list = apiDataBlock.content[0]
+  let list: string[]
+
+  if (Array.isArray(apiDataBlock.content[0])) {
+    list = apiDataBlock.content[0]
+  } else {
+    list = apiDataBlock.content as string[]
+  }
+
   return (
     <ul>
       {list.map((listItem) => (
@@ -32,7 +39,13 @@ export function OrderListBlock({
 }: {
   apiDataBlock: ApiDataOrderList
 }) {
-  const list = apiDataBlock.content[0]
+  let list: string[]
+
+  if (Array.isArray(apiDataBlock.content[0])) {
+    list = apiDataBlock.content[0]
+  } else {
+    list = apiDataBlock.content as string[]
+  }
   return (
     <ol>
       {list.map((listItem) => (


### PR DESCRIPTION
處理異常的 apiData `unordered-list-item` 結構

這是正常的 ul 結構
```
        {
          "id": "scfc",
          "type": "unordered-list-item",
          "styles": {},
          "content": [
            [
              "<strong>《鏡週刊》關心您：未滿18歲禁止飲酒，飲酒過量害人害己，酒後不開車，安全有保障。</strong>",
              "<strong>《鏡週刊》關心您：若自身或旁人遭受身體虐待、精神虐待、性侵害、性騷擾，請立刻撥打110報案，再尋求113專線，求助專業社工人員。</strong>",
              "jhijii",
              "joilj"
            ]
          ],
          "alignment": "center"
        },
```
這篇文的 ul 結構
```
        {
          "id": "an0ie",
          "type": "unordered-list-item",
          "styles": {},
          "content": [
            "<strong>《鏡週刊》關心您：未滿18歲禁止飲酒，飲酒過量害人害己，酒後不開車，安全有保障。</strong>",
            "<strong>《鏡週刊》關心您：若自身或旁人遭受身體虐待、精神虐待、性侵害、性騷擾，請立刻撥打110報案，再尋求113專線，求助專業社工人員。</strong>"
          ],
          "alignment": "center"
        }
```
content 的內容少了一層 array
p.s. 正常的 ul 內容是我 mirror-cms-prod [這篇文章](https://mirror-cms-prod-ufaummkd5q-de.a.run.app/posts/274976) 中複製到 mirror-cms-dev [測試文章](https://mirror-cms-dev-ufaummkd5q-de.a.run.app/posts/212374)中產生的


draft-converter `convertBlocksToApiData` 在處理資料上沒有把狀態清乾淨，導致有出現過 list-item 會遇到這個問題，修改的話怕會影響到其他功能所以不處理，選擇在 renderer 上處理兩種可能的結構。