### PR TITLE
refactor(mesh): add hook to redirect to login

### DIFF
--- a/packages/mesh/app/_components/category-story/comment.tsx
+++ b/packages/mesh/app/_components/category-story/comment.tsx
@@ -1,6 +1,5 @@
 'use client'
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 
 import { likeComment, unlikeComment } from '@/app/actions/comment'
@@ -12,6 +11,7 @@ import TOAST_MESSAGE from '@/constants/toast'
 import { useToast } from '@/context/toast'
 import { useUser } from '@/context/user'
 import { useCommentClamp } from '@/hooks/use-comment-clamp'
+import useRedirectLogin from '@/hooks/use-redirect-login'
 import type { CategoryStory } from '@/types/homepage'
 import { debounce } from '@/utils/performance'
 import { displayTimeFromNow } from '@/utils/story-display'
@@ -27,7 +27,7 @@ export default function Comment({ comment }: Props) {
   const [likeCount, setLikeCount] = useState(0)
   const { user } = useUser()
   const { addToast } = useToast()
-  const router = useRouter()
+  const { detectIfShouldRedirectToLogin } = useRedirectLogin()
   const memberId = user.memberId
   const commentId = comment.id
   useEffect(() => {
@@ -48,7 +48,7 @@ export default function Comment({ comment }: Props) {
   }, [commentId, memberId])
 
   const handleCommentLiked = debounce(async () => {
-    if (!memberId) router.push('/login')
+    if (detectIfShouldRedirectToLogin()) return
 
     if (isLikedBySelf) {
       try {

--- a/packages/mesh/app/collection/(query)/[id]/_components/collection-more-action-button.tsx
+++ b/packages/mesh/app/collection/(query)/[id]/_components/collection-more-action-button.tsx
@@ -13,6 +13,7 @@ import TOAST_MESSAGE from '@/constants/toast'
 import { useToast } from '@/context/toast'
 import { useUser } from '@/context/user'
 import useClickOutside from '@/hooks/use-click-outside'
+import useRedirectLogin from '@/hooks/use-redirect-login'
 import useWindowDimensions from '@/hooks/use-window-dimension'
 import { getTailwindConfigBreakpointNumber } from '@/utils/tailwind'
 
@@ -252,6 +253,7 @@ const ActionSheet = forwardRef(function ActionSheet(
   const router = useRouter()
   const { user } = useUser()
   const { addToast } = useToast()
+  const { detectIfShouldRedirectToLogin } = useRedirectLogin()
 
   const hasPosition = isPositionValid(position)
 
@@ -288,6 +290,9 @@ const ActionSheet = forwardRef(function ActionSheet(
       }
       case ActionType.Report: {
         // TODO: report the collection
+        if (detectIfShouldRedirectToLogin()) {
+          return
+        }
         onOpenDialog(ActionType.Report)
         break
       }

--- a/packages/mesh/app/login/_components/login-steps-title.tsx
+++ b/packages/mesh/app/login/_components/login-steps-title.tsx
@@ -4,6 +4,7 @@ import { getCurrentUser } from '@/app/actions/auth'
 import Icon from '@/components/icon'
 import { type LoginStepsKey, LoginState, useLogin } from '@/context/login'
 import { useUser } from '@/context/user'
+import { loginRedirectPathKey } from '@/hooks/use-redirect-login'
 
 const chevronMap: Pick<
   Record<LoginStepsKey, { title: string; goBackTo: LoginStepsKey }>,
@@ -41,8 +42,8 @@ export default function LoginStepsTitle() {
   const { setUser } = useUser()
 
   const handleSkipButton = async () => {
-    const redirectRoute = localStorage.getItem('login-redirect') ?? '/'
-    localStorage.removeItem('login-redirect')
+    const redirectRoute = localStorage.getItem(loginRedirectPathKey) ?? '/'
+    localStorage.removeItem(loginRedirectPathKey)
     const userData = await getCurrentUser()
     if (userData) {
       setUser(userData)

--- a/packages/mesh/app/login/_components/login-steps.tsx
+++ b/packages/mesh/app/login/_components/login-steps.tsx
@@ -4,6 +4,7 @@ import { createElement, useEffect } from 'react'
 import Spinner from '@/components/spinner'
 import { type LoginStepsKey, LoginState, useLogin } from '@/context/login'
 import useHandleSignIn from '@/hooks/use-handle-sign-in'
+import { loginRedirectPathKey } from '@/hooks/use-redirect-login'
 
 import LoginEmail from './login-email'
 import LoginEmailConfirmation from './login-email-confirmation'
@@ -37,8 +38,8 @@ export default function LoginSteps() {
         setStep(LoginState.TermsConfirmation)
         break
       case 'redirect': {
-        const redirectRoute = localStorage.getItem('login-redirect') ?? '/'
-        localStorage.removeItem('login-redirect')
+        const redirectRoute = localStorage.getItem(loginRedirectPathKey) ?? '/'
+        localStorage.removeItem(loginRedirectPathKey)
         router.push(redirectRoute)
         break
       }

--- a/packages/mesh/components/collection-card/collection-pick-button.tsx
+++ b/packages/mesh/components/collection-card/collection-pick-button.tsx
@@ -1,11 +1,10 @@
 'use client'
 
-import { useRouter } from 'next/navigation'
-
 import type { ButtonColor, ButtonSize } from '@/components/button'
 import Button from '@/components/button'
 import { usePickModal } from '@/context/pick-modal'
 import { useUser } from '@/context/user'
+import useRedirectLogin from '@/hooks/use-redirect-login'
 import { PickObjective } from '@/types/objective'
 import { debounce } from '@/utils/performance'
 
@@ -22,15 +21,13 @@ export default function CollectionPickButton({
   size?: ButtonSize
   gtmClassName?: string
 }) {
-  const router = useRouter()
   const { user } = useUser()
   const { openPickModal } = usePickModal()
-  const memberId = user.memberId
+  const { detectIfShouldRedirectToLogin } = useRedirectLogin()
   const isStoryPicked = user.pickCollectionIds.has(collectionId)
 
   const handleClickPick = debounce(async () => {
-    if (!memberId) {
-      router.push('/login')
+    if (detectIfShouldRedirectToLogin()) {
       return
     }
     openPickModal(

--- a/packages/mesh/components/layout-template/header/article-header.tsx
+++ b/packages/mesh/components/layout-template/header/article-header.tsx
@@ -2,7 +2,6 @@
 
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
-import { usePathname, useRouter } from 'next/navigation'
 import { twMerge } from 'tailwind-merge'
 
 import Button from '@/components/button'
@@ -20,17 +19,12 @@ const MobileSearchWrapper = dynamic(
 import NotificationWrapper from '@/components/notification-wrapper'
 import { LOGO_ICONS } from '@/constants/layout'
 import { isUserLoggedIn, useUser } from '@/context/user'
+import useRedirectLogin from '@/hooks/use-redirect-login'
 
 export default function ArticleHeader({ showNav }: { showNav: () => void }) {
-  const pathname = usePathname()
-  const router = useRouter()
   const { user } = useUser()
   const isLoggedIn = isUserLoggedIn(user)
-
-  const handleLoginButton = () => {
-    localStorage.setItem('login-redirect', pathname)
-    router.push('/login')
-  }
+  const { detectIfShouldRedirectToLogin } = useRedirectLogin()
 
   return (
     <header className="fixed inset-x-0 top-0 z-layout h-[theme(height.header.default)] border-b bg-white sm:h-[theme(height.header.sm)]">
@@ -70,7 +64,7 @@ export default function ArticleHeader({ showNav }: { showNav: () => void }) {
                 size="sm"
                 color="white"
                 text="登入"
-                onClick={handleLoginButton}
+                onClick={detectIfShouldRedirectToLogin}
               />
             </div>
           )}

--- a/packages/mesh/components/layout-template/header/collection-header.tsx
+++ b/packages/mesh/components/layout-template/header/collection-header.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import Link from 'next/link'
-import { useRouter } from 'next/navigation'
 import { twMerge } from 'tailwind-merge'
 
 import Button from '@/components/button'
@@ -9,11 +8,12 @@ import Icon from '@/components/icon'
 import NotificationWrapper from '@/components/notification-wrapper'
 import { LOGO_ICONS } from '@/constants/layout'
 import { isUserLoggedIn, useUser } from '@/context/user'
+import useRedirectLogin from '@/hooks/use-redirect-login'
 
 export default function CollectionHeader() {
-  const router = useRouter()
   const { user } = useUser()
   const isLoggedIn = isUserLoggedIn(user)
+  const { detectIfShouldRedirectToLogin } = useRedirectLogin()
 
   return (
     <header className="fixed inset-x-0 top-0 z-layout h-[theme(height.header.default)] border-b bg-white sm:h-[theme(height.header.sm)]">
@@ -53,10 +53,7 @@ export default function CollectionHeader() {
                 size="sm"
                 color="white"
                 text="登入"
-                onClick={() => {
-                  // TODO: handle on login here
-                  router.push('/login')
-                }}
+                onClick={detectIfShouldRedirectToLogin}
               />
             </div>
           )}

--- a/packages/mesh/components/layout-template/header/default-header.tsx
+++ b/packages/mesh/components/layout-template/header/default-header.tsx
@@ -2,7 +2,6 @@
 
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
-import { usePathname, useRouter } from 'next/navigation'
 import { twMerge } from 'tailwind-merge'
 
 import Button from '@/components/button'
@@ -10,6 +9,7 @@ import Icon from '@/components/icon'
 import NotificationWrapper from '@/components/notification-wrapper'
 import { LOGO_ICONS } from '@/constants/layout'
 import { isUserLoggedIn, useUser } from '@/context/user'
+import useRedirectLogin from '@/hooks/use-redirect-login'
 const DesktopSearchBar = dynamic(
   () => import('@/components/desktop-search-bar'),
   {
@@ -24,15 +24,9 @@ const MobileSearchWrapper = dynamic(
 )
 
 export default function DefaultHeader() {
-  const pathname = usePathname()
-  const router = useRouter()
   const { user } = useUser()
   const isLoggedIn = isUserLoggedIn(user)
-
-  const handleLoginButton = () => {
-    localStorage.setItem('login-redirect', pathname)
-    router.push('/login')
-  }
+  const { detectIfShouldRedirectToLogin } = useRedirectLogin()
 
   return (
     <>
@@ -71,7 +65,7 @@ export default function DefaultHeader() {
                   size="sm"
                   color="white"
                   text="登入"
-                  onClick={handleLoginButton}
+                  onClick={detectIfShouldRedirectToLogin}
                 />
               </div>
             )}

--- a/packages/mesh/components/layout-template/nav/default-nav.tsx
+++ b/packages/mesh/components/layout-template/nav/default-nav.tsx
@@ -87,9 +87,10 @@ const NonMobileNav = ({
                     }
                     iconInfo={{
                       ...iconInfo,
-                      href:
-                        iconInfo.href +
-                        `/member/${userCustomId}?tab=${TabCategory.PICKS}`,
+                      href: userCustomId
+                        ? iconInfo.href +
+                          `/member/${userCustomId}?tab=${TabCategory.PICKS}`
+                        : '/login',
                     }}
                     avatarUrl={avatarUrl}
                   />

--- a/packages/mesh/components/navigation/add-bookmark-button.tsx
+++ b/packages/mesh/components/navigation/add-bookmark-button.tsx
@@ -1,11 +1,10 @@
 'use client'
 
-import { useRouter } from 'next/navigation'
-
 import { addBookmark, removeBookmark } from '@/app/actions/bookmark'
 import TOAST_MESSAGE from '@/constants/toast'
 import { useToast } from '@/context/toast'
 import { useUser } from '@/context/user'
+import useRedirectLogin from '@/hooks/use-redirect-login'
 import { BookmarkObjective } from '@/types/objective'
 
 import Icon from '../icon'
@@ -17,9 +16,9 @@ export default function AddBookMarkButton({
   bookmarkObjective: BookmarkObjective
   targetId: string
 }) {
-  const router = useRouter()
   const { addToast } = useToast()
   const { user, setUser } = useUser()
+  const { detectIfShouldRedirectToLogin } = useRedirectLogin()
   const userBookmarkSetKey =
     bookmarkObjective === BookmarkObjective.Story
       ? 'bookmarkStoryIds'
@@ -27,8 +26,7 @@ export default function AddBookMarkButton({
   const isAddedBookmark = user[userBookmarkSetKey].has(targetId)
 
   const onToggleBookmark = async () => {
-    if (!user.memberId) {
-      router.push('/login')
+    if (detectIfShouldRedirectToLogin()) {
       return
     }
     if (isAddedBookmark) {

--- a/packages/mesh/components/story-card/story-pick-button.tsx
+++ b/packages/mesh/components/story-card/story-pick-button.tsx
@@ -1,11 +1,10 @@
 'use client'
 
-import { usePathname, useRouter } from 'next/navigation'
-
 import type { ButtonColor } from '@/components/button'
 import Button from '@/components/button'
 import { usePickModal } from '@/context/pick-modal'
 import { useUser } from '@/context/user'
+import useRedirectLogin from '@/hooks/use-redirect-login'
 import { PickObjective } from '@/types/objective'
 import { debounce } from '@/utils/performance'
 
@@ -20,17 +19,13 @@ export default function StoryPickButton({
   color?: ButtonColor
   gtmClassName?: string
 }) {
-  const router = useRouter()
-  const pathname = usePathname()
   const { user } = useUser()
   const { openPickModal } = usePickModal()
-  const memberId = user.memberId
+  const { detectIfShouldRedirectToLogin } = useRedirectLogin()
   const isStoryPicked = user.pickStoryIds.has(storyId)
 
   const handleClickPick = debounce(async () => {
-    if (!memberId) {
-      localStorage.setItem('login-redirect', pathname)
-      router.push('/login')
+    if (detectIfShouldRedirectToLogin()) {
       return
     }
     openPickModal(PickObjective.Story, storyId, storyTitle, isStoryPicked)

--- a/packages/mesh/components/story-more-action-button.tsx
+++ b/packages/mesh/components/story-more-action-button.tsx
@@ -14,6 +14,7 @@ import { useToast } from '@/context/toast'
 import { useUser } from '@/context/user'
 import useClickOutside from '@/hooks/use-click-outside'
 import usePageName from '@/hooks/use-page-name'
+import useRedirectLogin from '@/hooks/use-redirect-login'
 import useUserPayload from '@/hooks/use-user-payload'
 import { PaymentType } from '@/types/payment'
 import { logStoryInteractionEvent } from '@/utils/event-logs'
@@ -249,6 +250,7 @@ const ActionSheet = forwardRef(function ActionSheet(
   const { addToast } = useToast()
   const pageName = usePageName()
   const userPayolad = useUserPayload()
+  const { detectIfShouldRedirectToLogin } = useRedirectLogin()
 
   const onAction = async (type: ActionType) => {
     if (!storyId) {
@@ -260,6 +262,9 @@ const ActionSheet = forwardRef(function ActionSheet(
     }
     switch (type) {
       case ActionType.Sponsor: {
+        if (detectIfShouldRedirectToLogin()) {
+          return
+        }
         if (!publisherId) {
           addToast({ status: 'fail', text: TOAST_MESSAGE.moreActionError })
           console.error(
@@ -271,8 +276,7 @@ const ActionSheet = forwardRef(function ActionSheet(
         break
       }
       case ActionType.AddBookMark: {
-        if (!user.memberId) {
-          router.push('/login')
+        if (detectIfShouldRedirectToLogin()) {
           return
         }
         if (isStoryAddedBookmark) {
@@ -366,6 +370,9 @@ const ActionSheet = forwardRef(function ActionSheet(
         openShareSheet()
         break
       case ActionType.AddCollection:
+        if (detectIfShouldRedirectToLogin()) {
+          return
+        }
         openAddCollection()
         break
       default:

--- a/packages/mesh/context/comment.tsx
+++ b/packages/mesh/context/comment.tsx
@@ -17,6 +17,7 @@ import { MobileCommentModalContent } from '@/components/comment/mobile-comment-s
 import TOAST_MESSAGE from '@/constants/toast'
 import { type User } from '@/context/user'
 import type { GetStoryQuery } from '@/graphql/__generated__/graphql'
+import useRedirectLogin from '@/hooks/use-redirect-login'
 import useWindowDimensions from '@/hooks/use-window-dimension'
 import type { CommentObjectiveData } from '@/types/comment'
 import { CommentObjective } from '@/types/objective'
@@ -290,6 +291,7 @@ export function CommentProvider({
   })
   const { addToast } = useToast()
   const { width } = useWindowDimensions()
+  const { detectIfShouldRedirectToLogin } = useRedirectLogin()
 
   const handleDeleteCommentModalOnConfirm = useCallback(
     async (user: User) => {
@@ -328,7 +330,7 @@ export function CommentProvider({
 
   const handleCommentPublish = useCallback(
     async ({ user, targetId }: { user: User; targetId: string }) => {
-      if (!user?.memberId) throw new Error('no user id')
+      if (detectIfShouldRedirectToLogin()) return
       if (!targetId) throw new Error('no story id')
 
       dispatch({
@@ -454,6 +456,9 @@ export function CommentProvider({
 
   const handleReport = (e: React.MouseEvent<HTMLLIElement>) => {
     e.stopPropagation()
+    if (detectIfShouldRedirectToLogin()) {
+      return
+    }
     dispatch({ type: 'TOGGLE_REPORTING_MODAL', payload: { isVisible: true } })
     dispatch({
       type: 'UPDATE_EDIT_DRAWER',

--- a/packages/mesh/hooks/use-comment-like.tsx
+++ b/packages/mesh/hooks/use-comment-like.tsx
@@ -9,6 +9,8 @@ import type { GetStoryQuery } from '@/graphql/__generated__/graphql'
 import { type CommentType } from '@/types/profile'
 import { debounce } from '@/utils/performance'
 
+import useRedirectLogin from './use-redirect-login'
+
 // 從 Story Query 中提取 Comment 型別
 type CommentTypeFromStory = NonNullable<
   NonNullable<GetStoryQuery['story']>['comments']
@@ -52,6 +54,7 @@ export const useCommentLike = ({
   const { user } = useUser()
   const { addToast } = useToast()
   const { updateCommentLikeStatus } = useComment()
+  const { detectIfShouldRedirectToLogin } = useRedirectLogin()
 
   const memberLikedList = useMemo(() => {
     if (isCommentType(commentData)) {
@@ -68,6 +71,8 @@ export const useCommentLike = ({
   )
 
   const handleLikeComment = debounce(async () => {
+    if (detectIfShouldRedirectToLogin()) return
+
     const likeCommentArgs = {
       memberId: user.memberId,
       commentId: commentData.id,

--- a/packages/mesh/hooks/use-follow.ts
+++ b/packages/mesh/hooks/use-follow.ts
@@ -1,7 +1,5 @@
 'use client'
 
-import { usePathname, useRouter } from 'next/navigation'
-
 import {
   addMemberFollowing,
   removeMemberFollowing,
@@ -11,18 +9,17 @@ import { useToast } from '@/context/toast'
 import { useUser } from '@/context/user'
 import { debounce } from '@/utils/performance'
 
+import useRedirectLogin from './use-redirect-login'
+
 export const useFollow = (followingId: string) => {
-  const router = useRouter()
-  const pathname = usePathname()
   const { user, setUser } = useUser()
+  const { detectIfShouldRedirectToLogin } = useRedirectLogin()
   const memberId = user.memberId
   const isFollowing = user.followingMemberIds.has(followingId)
   const { addToast } = useToast()
 
   const handleClickFollow = debounce(async () => {
-    if (!memberId) {
-      localStorage.setItem('login-redirect', pathname)
-      router.push('/login')
+    if (detectIfShouldRedirectToLogin()) {
       return
     }
 

--- a/packages/mesh/hooks/use-redirect-login.ts
+++ b/packages/mesh/hooks/use-redirect-login.ts
@@ -1,0 +1,25 @@
+'use client'
+
+import { usePathname, useRouter } from 'next/navigation'
+import { useCallback } from 'react'
+
+import { useUser } from '@/context/user'
+
+export const loginRedirectPathKey = 'login-redirect'
+
+export default function useRedirectLogin() {
+  const { user } = useUser()
+  const router = useRouter()
+  const pathname = usePathname()
+
+  const detectIfShouldRedirectToLogin = useCallback(() => {
+    if (!user.memberId) {
+      localStorage.setItem(loginRedirectPathKey, pathname)
+      router.push('/login')
+      return true
+    }
+    return false
+  }, [pathname, router, user.memberId])
+
+  return { detectIfShouldRedirectToLogin }
+}


### PR DESCRIPTION
# Notable Change

Add `useRedirectLogin` hook for pages to handle redirect logic and save pathname.

The function `detectIfShouldRedirectToLogin` will return `true` for caller to return if redirection is triggered.

## Scope 

- header (default, article, collection) login button
- pick button
  - 集錦
  - 文章
- bookmark button
- comment block
  - 留言
  - 愛心
  - 檢舉
- collection-more-action
  - 檢舉
- story-more-action
  - 贊助
  - 書籤
  - 加入集錦
- follow member


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209356588257263