### PR TITLE
refactor: add optional check in case ad-block break gpt-ad 

### DIFF
--- a/packages/mesh/components/ad/google-ad-manager/ad-manager-ad.tsx
+++ b/packages/mesh/components/ad/google-ad-manager/ad-manager-ad.tsx
@@ -42,7 +42,7 @@ export default function AdManager({ pageKey, adKey, slot }: Props) {
     if (window.googletag && adSize && adDivId && adUnitPath) {
       window.googletag = window.googletag || { cmd: [] }
 
-      window.googletag?.cmd.push(() => {
+      window.googletag.cmd?.push(() => {
         const slot = window.googletag.defineSlot(adUnitPath, adSize, adDivId)
 
         if (slot) {

--- a/packages/mesh/components/ad/google-ad-manager/ad-manager-ad.tsx
+++ b/packages/mesh/components/ad/google-ad-manager/ad-manager-ad.tsx
@@ -42,7 +42,7 @@ export default function AdManager({ pageKey, adKey, slot }: Props) {
     if (window.googletag && adSize && adDivId && adUnitPath) {
       window.googletag = window.googletag || { cmd: [] }
 
-      window.googletag.cmd.push(() => {
+      window.googletag?.cmd.push(() => {
         const slot = window.googletag.defineSlot(adUnitPath, adSize, adDivId)
 
         if (slot) {


### PR DESCRIPTION
# Notable Changes

在有 adBlock 的狀況下，gpt-ad 的 script 會被阻擋載入，導致 window.googletag 的值不如預期造成錯誤，因此加上 optional check 在 cmd 前面，避免網頁壞掉

adBlock 阻擋 script 載入，browser 會顯示成 cors 問題，實際上是因為請求被中斷 browser 沒有拿到對應的 cors 而判定成 cors 問題
![image (5)](https://github.com/user-attachments/assets/f0706392-b0c7-4a0f-81ca-54e1a72c01b2)

實際遇到的頁面壞掉
![image (6)](https://github.com/user-attachments/assets/62e70d55-f8db-4e38-b230-26630a4b2d1d)
