### PR TITLE
refactor(mesh): adjust utils of .length

### DIFF
--- a/packages/mesh/app/[slug]/_components/desktop-stories.tsx
+++ b/packages/mesh/app/[slug]/_components/desktop-stories.tsx
@@ -76,7 +76,7 @@ export default function DesktopStories({
   return (
     <section className="hidden lg:block lg:px-10 lg:pb-15 lg:pt-10 xxl:pb-10">
       <div className="lg:flex lg:gap-x-10">
-        {otherStories.length !== 0 && (
+        {!!otherStories.length && (
           <div className="w-articleMain shrink-0">
             <h2 className="lg:title-1 lg:mb-6 lg:text-primary-700">最新報導</h2>
             <div className="flex flex-col gap-y-5">{getStoriesContent()}</div>
@@ -84,7 +84,7 @@ export default function DesktopStories({
         )}
 
         <aside className="lg:flex lg:flex-col lg:gap-y-3">
-          {publishersAndStories &&
+          {!!publishersAndStories?.length &&
             publishersAndStories.map((data) => (
               <PublisherCard key={data.publisher.id} data={data} />
             ))}

--- a/packages/mesh/app/_components/category-story/comment.tsx
+++ b/packages/mesh/app/_components/category-story/comment.tsx
@@ -38,7 +38,7 @@ export default function Comment({ comment }: Props) {
       const data = await fetchCommentLikes(commentId, memberId)
       if (data) {
         setLikeCount(data.likeCount || 0)
-        if (data.isLikedBySelf && data.isLikedBySelf.length !== 0) {
+        if (data.isLikedBySelf && data.isLikedBySelf.length) {
           setIsLikedBySelf(true)
         }
         setIsLoading(false)

--- a/packages/mesh/app/_components/category-story/story-section.tsx
+++ b/packages/mesh/app/_components/category-story/story-section.tsx
@@ -36,17 +36,16 @@ export default function StorySection({ activeTitle, stories, slug }: Props) {
         </div>
       </NextLink>
 
-      {stories && stories.length > 0 ? (
+      {stories && !!stories.length ? (
         <div className="flex flex-col gap-y-5 lg:flex-row lg:gap-x-10">
           <div className="lg:max-w-[500px]">
             <MainCard story={stories[0]} />
-            {stories[0].comment &&
-              Object.keys(stories[0].comment).length !== 0 && (
-                <Comment
-                  comment={stories[0].comment as CommentType}
-                  key={stories[0].id}
-                />
-              )}
+            {stories[0].comment && !!Object.keys(stories[0].comment).length && (
+              <Comment
+                comment={stories[0].comment as CommentType}
+                key={stories[0].id}
+              />
+            )}
           </div>
 
           <div className="flex flex-col gap-y-5">

--- a/packages/mesh/app/actions/edit-collection.ts
+++ b/packages/mesh/app/actions/edit-collection.ts
@@ -72,10 +72,10 @@ async function updateCollection({
   const globalLogFields = getLogTraceObjectFromHeaders()
 
   const isAllDefaults =
-    Object.keys(updateCollectionData).length === 0 &&
-    createCollectionPicksData.length === 0 &&
-    updateCollectionPicksData.length === 0 &&
-    deleteCollectionPicksData.length === 0
+    !Object.keys(updateCollectionData).length &&
+    !createCollectionPicksData.length &&
+    !updateCollectionPicksData.length &&
+    !deleteCollectionPicksData.length
 
   if (isAllDefaults) {
     logServerSideError(
@@ -121,7 +121,7 @@ export async function updateCollectionTitle({
       },
     }
   }
-  if (Object.keys(updateCollectionData).length === 0) return null
+  if (!Object.keys(updateCollectionData).length) return null
   return await updateCollection({
     collectionId,
     updateCollectionData,

--- a/packages/mesh/app/actions/get-homepage.ts
+++ b/packages/mesh/app/actions/get-homepage.ts
@@ -193,7 +193,7 @@ async function fetchCategoryInformation(slug: string) {
     globalLogFields
   )
 
-  if (!data || !data.categories || data.categories.length === 0) {
+  if (!data || !data.categories || !data.categories.length) {
     return null
   }
   const { categories } = data

--- a/packages/mesh/app/media/_components/category-editor.tsx
+++ b/packages/mesh/app/media/_components/category-editor.tsx
@@ -80,7 +80,7 @@ export default function CategoryEditor({
           <Button
             size="lg"
             color="primary"
-            text={selectingCategories.length === 0 ? '至少要選1個' : '儲存'}
+            text={!selectingCategories.length ? '至少要選1個' : '儲存'}
             disabled={selectingCategories.length === 0}
             onClick={() => {
               onFinish(selectingCategories)

--- a/packages/mesh/app/media/_components/media-stories.tsx
+++ b/packages/mesh/app/media/_components/media-stories.tsx
@@ -110,7 +110,7 @@ export default function MediaStories({
       ),
       totalCount: latestStoriesResponse.num_stories ?? 0,
       // only stop infinite scroll when response return empty array
-      shouldLoadmore: latestStoriesResponse.stories.length !== 0 ? true : false,
+      shouldLoadmore: latestStoriesResponse.stories.length ? true : false,
     }
 
     const currentPageData = pageDataInCategories[currentCategory?.slug ?? '']

--- a/packages/mesh/app/profile/_components/article-card.tsx
+++ b/packages/mesh/app/profile/_components/article-card.tsx
@@ -135,22 +135,21 @@ const ArticleCard = ({
    * GetPublisherProfile 不會取用留言，因為Publisher不會顯示留言
    */
   const commentList = (hasComment(storyData) && storyData.comment) || []
-  const authorComment =
-    commentList.length !== 0
-      ? commentList[0]
-      : {
-          __typename: 'Comment',
-          id: '',
-          content: '',
-          createdAt: '',
-          likeCount: 0,
-          member: {
-            __typename: 'Member',
-            id: memberId,
-            name,
-            avatar,
-          },
-        }
+  const authorComment = commentList.length
+    ? commentList[0]
+    : {
+        __typename: 'Comment',
+        id: '',
+        content: '',
+        createdAt: '',
+        likeCount: 0,
+        member: {
+          __typename: 'Member',
+          id: memberId,
+          name,
+          avatar,
+        },
+      }
 
   const { displayPicks, displayPicksCount } = useDisplayPicks({
     id: storyData.id,

--- a/packages/mesh/app/social/_components/more-feed.tsx
+++ b/packages/mesh/app/social/_components/more-feed.tsx
@@ -30,7 +30,7 @@ export default function MoreFeed({ feedsNumber }: { feedsNumber: number }) {
         if (!nextPageDataResponse) return
         const { stories: nextStories } = nextPageDataResponse
 
-        if (nextStories.length > 0) {
+        if (nextStories.length) {
           setMoreStories((prevStories) => [...prevStories, ...nextStories])
           setPage((prevPage) => prevPage + 1)
         }

--- a/packages/mesh/components/desktop-search-bar.tsx
+++ b/packages/mesh/components/desktop-search-bar.tsx
@@ -28,7 +28,7 @@ export default function DesktopSearchBar({
   const activeDropdown = useMemo(() => {
     if (!isFocused) return null
     if (searchSuggestion) return 'suggestion'
-    if (recentSearch.length > 0) return 'recent'
+    if (recentSearch.length) return 'recent'
     return null
   }, [isFocused, recentSearch.length, searchSuggestion])
 

--- a/packages/mesh/components/notification-dropdown.tsx
+++ b/packages/mesh/components/notification-dropdown.tsx
@@ -48,7 +48,7 @@ export default function NotificationDropdown({
             <Icon iconName="icon-close" size="l" />
           </button>
         </div>
-        {announcement && announcement.length > 0 ? (
+        {announcement && announcement.length ? (
           <div className="flex flex-col gap-1 rounded-t-md bg-highlight-red p-5">
             <p className="subtitle-2 text-primary-700">系統維修公告</p>
             <p className="body-3 max-w-[335px] text-primary-600">

--- a/packages/mesh/components/notification-wrapper.tsx
+++ b/packages/mesh/components/notification-wrapper.tsx
@@ -39,7 +39,7 @@ export default function NotificationWrapper() {
       getAnnouncement(),
     ])
 
-    if ((notificationResponse?.notifies ?? []).length > 0) {
+    if ((notificationResponse?.notifies ?? []).length) {
       const splittedData = splitNotification(notificationResponse)
       setNotificationData(splittedData)
       if (splittedData.current.length) {

--- a/packages/mesh/components/pickers-modal.tsx
+++ b/packages/mesh/components/pickers-modal.tsx
@@ -72,7 +72,7 @@ export default function PickersModal() {
           return
         }
 
-        if (data.picks.length > 0) {
+        if (data.picks.length) {
           const nextPickers = data.picks.map((p) => ({
             id: p.member?.id ?? '',
             name: p.member?.name ?? '',

--- a/packages/mesh/components/search-modal.tsx
+++ b/packages/mesh/components/search-modal.tsx
@@ -25,7 +25,7 @@ export default function SearchModal({
   } = useSearchSuggestion(inputRef)
   const activeRender = useMemo(() => {
     if (searchSuggestion) return 'suggestion'
-    if (recentSearch.length > 0) return 'recent'
+    if (recentSearch.length) return 'recent'
     return null
   }, [recentSearch.length, searchSuggestion])
 

--- a/packages/mesh/graphql/__generated__/fragment-masking.ts
+++ b/packages/mesh/graphql/__generated__/fragment-masking.ts
@@ -82,5 +82,5 @@ export function isFragmentReady<TQuery, TFrag>(
   const fragName = fragDef?.name?.value
 
   const fields = (fragName && deferredFields[fragName]) || []
-  return fields.length > 0 && fields.every((field) => data && field in data)
+  return !!fields.length && fields.every((field) => data && field in data)
 }

--- a/packages/mesh/hooks/use-display-commentcount.tsx
+++ b/packages/mesh/hooks/use-display-commentcount.tsx
@@ -14,7 +14,7 @@ export function useDisplayCommentCount({
 
   useEffect(() => {
     if (
-      interactCommentStack.length > 0 &&
+      interactCommentStack.length &&
       objectiveId &&
       interactCommentStack.includes(objectiveId)
     ) {

--- a/packages/mesh/hooks/use-form.ts
+++ b/packages/mesh/hooks/use-form.ts
@@ -26,7 +26,7 @@ export const useForm = <T extends Record<string, unknown>>(
   const validateForm = async () => {
     const newErrors = await validateFormFn(form)
     setErrors(newErrors)
-    return Object.keys(newErrors).length === 0
+    return !Object.keys(newErrors).length
   }
 
   const resetErrors = () => setErrors({})
@@ -53,7 +53,7 @@ export const useForm = <T extends Record<string, unknown>>(
     return false
   }
 
-  const isFormValid = Object.keys(errors).length === 0 && hasChange()
+  const isFormValid = !Object.keys(errors).length && hasChange()
 
   return {
     form,

--- a/packages/mesh/utils/comment.ts
+++ b/packages/mesh/utils/comment.ts
@@ -32,7 +32,7 @@ export function sortAndFilterComments(comments: Comment[]): Comment[] {
   const validComments = comments.filter((comment) => !!comment.likeCount)
 
   // 如果沒有有效的 likeCount，返回空陣列
-  if (validComments.length === 0) {
+  if (!validComments.length) {
     return []
   }
 

--- a/packages/mesh/utils/fetch-graphql.ts
+++ b/packages/mesh/utils/fetch-graphql.ts
@@ -20,7 +20,7 @@ export default async function queryGraphQL<
       variables,
     })
 
-    if (gqlErrors && gqlErrors.length > 0) {
+    if (gqlErrors && gqlErrors.length) {
       throw new Error(`[GraphQL error]: ${gqlErrors[0].message}`)
     }
     return data
@@ -47,7 +47,7 @@ export async function mutateGraphQL<
       mutation,
       variables,
     })
-    if (gqlErrors && gqlErrors.length > 0) {
+    if (gqlErrors && gqlErrors.length) {
       throw new Error(`[GraphQL error]: ${gqlErrors[0].message}`)
     }
     return data || null

--- a/packages/mesh/utils/transaction-records.ts
+++ b/packages/mesh/utils/transaction-records.ts
@@ -1,9 +1,9 @@
 import { type GetMemberSingleTransactionQuery } from '@/graphql/__generated__/graphql'
 
 export const recordSelector = (data: GetMemberSingleTransactionQuery) => {
-  if (data.member?.transaction && data.member.transaction.length > 0) {
+  if (data.member?.transaction && data.member.transaction.length) {
     return data.member?.transaction?.[0]
-  } else if (data.member?.sponsor && data.member.sponsor.length > 0) {
+  } else if (data.member?.sponsor && data.member.sponsor.length) {
     return data.member?.sponsor?.[0]
   }
   return null


### PR DESCRIPTION
前提：
- array.length 如果為 0，本身就是一種 falsy 的值。
- 不過如果在 component 中使用 `0 && <component>`，真的沒有東西的時候會顯示 0，很醜，詳細可看個人檔案頁面。此時可以用 `!!array.length` 等方法強制轉換成 boolean 值，便不會 render。

假設：
- array 不可能有複數，因此 `length > 0` 在判斷中可以簡化成 `length`。以此類推。