### PR TITLE
refactor(mesh): get homepage abtest version in client side

### DIFF
--- a/packages/mesh/app/_components/category-story/ad.tsx
+++ b/packages/mesh/app/_components/category-story/ad.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import AdManager from '@/components/ad/ad-manager-ad'
+import AdSense from '@/components/ad/adsense-ad'
+import { useABTest } from '@/context/ab-test'
+
+export function Ad() {
+  const { version } = useABTest()
+
+  if (!version) return null
+
+  return version === 'A' ? (
+    <AdSense pageKey="homepage" adKey="A2" className="mt-10" />
+  ) : (
+    <AdManager pageKey="homepage" adKey="A3" className="mt-10" />
+  )
+}

--- a/packages/mesh/app/_components/category-story/section.tsx
+++ b/packages/mesh/app/_components/category-story/section.tsx
@@ -2,33 +2,21 @@ import {
   fetchAllCategory,
   fetchCategoryStory,
 } from '@/app/actions/get-homepage'
-import AdManager from '@/components/ad/ad-manager-ad'
-import AdSense from '@/components/ad/adsense-ad'
 
+import { Ad } from './ad'
 import NavList from './nav-list'
 
-type Props = {
-  version: 'A' | 'B'
-}
-
-export default async function CategoryStorySection({ version }: Props) {
+export default async function CategoryStorySection() {
   const data = await fetchAllCategory()
   const categories = data?.categories ?? []
 
   const initialSlug = categories?.[0]?.slug
   const categoryStories = await fetchCategoryStory(initialSlug)
 
-  const shouldShowGAMAds = version === 'B'
-
   return (
     <section className="flex flex-col px-5 pt-5 md:px-[70px] lg:px-10 lg:pb-10">
       <NavList categories={categories} initialStories={categoryStories} />
-      {!shouldShowGAMAds && (
-        <AdSense pageKey="homepage" adKey="A2" className="mt-10" />
-      )}
-      {shouldShowGAMAds && (
-        <AdManager pageKey="homepage" adKey="A3" className="mt-10" />
-      )}
+      <Ad />
     </section>
   )
 }

--- a/packages/mesh/app/_components/daily-highlight/ad-after-main-group.tsx
+++ b/packages/mesh/app/_components/daily-highlight/ad-after-main-group.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import AdManager from '@/components/ad/ad-manager-ad'
+import { useABTest } from '@/context/ab-test'
+
+export function AdAfterMainGroup() {
+  const { version } = useABTest()
+
+  if (version !== 'B') return null
+
+  return <AdManager pageKey="homepage" adKey="A1" className="mb-10" />
+}

--- a/packages/mesh/app/_components/daily-highlight/ad-after-no-group.tsx
+++ b/packages/mesh/app/_components/daily-highlight/ad-after-no-group.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import AdManager from '@/components/ad/ad-manager-ad'
+import AdSense from '@/components/ad/adsense-ad'
+import { useABTest } from '@/context/ab-test'
+
+export function AdAfterNoGroup() {
+  const { version } = useABTest()
+
+  if (!version) return null
+
+  return version === 'A' ? (
+    <AdSense pageKey="homepage" adKey="A1" className="my-5 lg:mb-0" />
+  ) : (
+    <AdManager pageKey="homepage" adKey="A2" className="my-5" />
+  )
+}

--- a/packages/mesh/app/_components/daily-highlight/section.tsx
+++ b/packages/mesh/app/_components/daily-highlight/section.tsx
@@ -2,25 +2,19 @@ import {
   fetchDailyHighlightGroup,
   fetchDailyHighlightNoGroup,
 } from '@/app/actions/get-homepage'
-import AdManager from '@/components/ad/ad-manager-ad'
-import AdSense from '@/components/ad/adsense-ad'
 import { displayDateWithWeekday } from '@/utils/story-display'
 
 import StoryCard from '../story-card'
+import { AdAfterMainGroup } from './ad-after-main-group'
+import { AdAfterNoGroup } from './ad-after-no-group'
 import MainGroup from './main-group'
 
-type Props = {
-  version: 'A' | 'B'
-}
-
-export default async function DailyHighlight({ version }: Props) {
+export default async function DailyHighlight() {
   const groupData = await fetchDailyHighlightGroup()
   const noGroupData = await fetchDailyHighlightNoGroup()
 
   const groupStories = groupData && groupData.slice(0, 4)
   const noGroupStories = noGroupData && noGroupData.slice(0, 6)
-
-  const shouldShowGAMAds = version === 'B'
 
   return (
     <section className="flex flex-col px-5 pt-4 sm:pt-5 md:px-[70px] lg:px-10 lg:pb-10">
@@ -30,13 +24,8 @@ export default async function DailyHighlight({ version }: Props) {
           {displayDateWithWeekday()}
         </time>
       </div>
-
       {groupStories && <MainGroup stories={groupStories} />}
-
-      {shouldShowGAMAds && (
-        <AdManager pageKey="homepage" adKey="A1" className="mb-10" />
-      )}
-
+      <AdAfterMainGroup />
       <div className="flex flex-col gap-y-5 lg:grid lg:grid-cols-2 lg:gap-x-10 lg:[&>*:nth-child(5)]:shadow-none">
         {noGroupStories &&
           noGroupStories.map((story) => (
@@ -50,12 +39,7 @@ export default async function DailyHighlight({ version }: Props) {
             />
           ))}
       </div>
-      {!shouldShowGAMAds && (
-        <AdSense pageKey="homepage" adKey="A1" className="my-5 lg:mb-0" />
-      )}
-      {shouldShowGAMAds && (
-        <AdManager pageKey="homepage" adKey="A2" className="my-5" />
-      )}
+      <AdAfterNoGroup />
     </section>
   )
 }

--- a/packages/mesh/app/_components/data-layer-logger.tsx
+++ b/packages/mesh/app/_components/data-layer-logger.tsx
@@ -3,23 +3,25 @@
 import { useEffect } from 'react'
 import TagManager from 'react-gtm-module'
 
-type Props = {
-  version: 'A' | 'B'
-}
+import { useABTest } from '@/context/ab-test'
 
-export default function DataLayerLogger({ version }: Props) {
+export default function DataLayerLogger() {
+  const { version } = useABTest()
+
   useEffect(() => {
-    const tagManagerArgs = {
-      dataLayer: {
-        event: 'pageview',
-        page: {
-          title: document.title,
-          url: window.location.pathname,
-          adsDisplayVersion: version,
+    if (version) {
+      const tagManagerArgs = {
+        dataLayer: {
+          event: 'pageview',
+          page: {
+            title: document.title,
+            url: window.location.pathname,
+            adsDisplayVersion: version,
+          },
         },
-      },
+      }
+      TagManager.dataLayer(tagManagerArgs)
     }
-    TagManager.dataLayer(tagManagerArgs)
   }, [version])
 
   return null

--- a/packages/mesh/app/_components/readr-story-ad.tsx
+++ b/packages/mesh/app/_components/readr-story-ad.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import AdSense from '@/components/ad/adsense-ad'
+import { useABTest } from '@/context/ab-test'
+
+export function ReadrStoryAd() {
+  const { version } = useABTest()
+
+  if (version !== 'A') return null
+
+  return <AdSense pageKey="homepage" adKey="A3" className="mt-5 lg:mt-10" />
+}

--- a/packages/mesh/app/_components/readr-story.tsx
+++ b/packages/mesh/app/_components/readr-story.tsx
@@ -1,21 +1,15 @@
 import { fetchRecentReadrStory } from '@/app/actions/get-homepage'
-import AdSense from '@/components/ad/adsense-ad'
 
 import FeaturedCard from './featured-card'
+import { ReadrStoryAd } from './readr-story-ad'
 
-type Props = {
-  version: 'A' | 'B'
-}
-
-export default async function ReadrStory({ version }: Props) {
+export default async function ReadrStory() {
   const data = await fetchRecentReadrStory()
   if (!data) return null
   const story = data.stories[0]
   const customId = data.customId
   const publisher = data.title
   const publisherId = data.id
-
-  const shouldShowGAMAds = version === 'B'
 
   return (
     <>
@@ -30,9 +24,7 @@ export default async function ReadrStory({ version }: Props) {
           pick: 'GTM-homepage_pick_readr_latest_ article',
         }}
       />
-      {!shouldShowGAMAds && (
-        <AdSense pageKey="homepage" adKey="A3" className="mt-5 lg:mt-10" />
-      )}
+      <ReadrStoryAd />
     </>
   )
 }

--- a/packages/mesh/app/_components/root-layout-wrapper.tsx
+++ b/packages/mesh/app/_components/root-layout-wrapper.tsx
@@ -3,6 +3,7 @@
 import { usePathname } from 'next/navigation'
 
 import LayoutTemplate from '@/components/layout-template'
+import { ABTestProvider } from '@/context/ab-test'
 
 import Loading from './loading'
 
@@ -16,9 +17,11 @@ export default function RootLayoutWrapper({
   let childrenJsx = <>{children}</>
   if (pathname === '/') {
     childrenJsx = (
-      <LayoutTemplate type="default" suspenseFallback={<Loading />}>
-        {children}
-      </LayoutTemplate>
+      <ABTestProvider>
+        <LayoutTemplate type="default" suspenseFallback={<Loading />}>
+          {children}
+        </LayoutTemplate>
+      </ABTestProvider>
     )
   }
 

--- a/packages/mesh/app/_components/top-publisher/ad.tsx
+++ b/packages/mesh/app/_components/top-publisher/ad.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import AdManager from '@/components/ad/ad-manager-ad'
+import { useABTest } from '@/context/ab-test'
+
+export function Ad() {
+  const { version } = useABTest()
+
+  if (version !== 'B') return null
+
+  return <AdManager pageKey="homepage" adKey="A4" className="col-span-2" />
+}

--- a/packages/mesh/app/_components/top-publisher/section.tsx
+++ b/packages/mesh/app/_components/top-publisher/section.tsx
@@ -1,17 +1,11 @@
 import { fetchMostSponsoredPublisher } from '@/app/actions/get-homepage'
-import AdManager from '@/components/ad/ad-manager-ad'
 
+import { Ad } from './ad'
 import TopPublisherCard from './card'
 
-type Props = {
-  version: 'A' | 'B'
-}
-
-export default async function TopPublisherSection({ version }: Props) {
+export default async function TopPublisherSection() {
   const data = await fetchMostSponsoredPublisher()
   if (!data) return null
-
-  const shouldShowGAMAds = version === 'B'
 
   return (
     <section className="px-5 pb-10 pt-8 sm:pb-[22px] md:px-[70px] lg:px-10 lg:pb-15 lg:pt-10 xxl:pb-[43px]">
@@ -24,9 +18,7 @@ export default async function TopPublisherSection({ version }: Props) {
       >
         {data.map((publisher, index) => (
           <>
-            {index === 2 && shouldShowGAMAds && (
-              <AdManager pageKey="homepage" adKey="A4" className="col-span-2" />
-            )}
+            {index === 2 && <Ad />}
             <TopPublisherCard key={publisher.id} publisher={publisher} />
           </>
         ))}

--- a/packages/mesh/app/page.tsx
+++ b/packages/mesh/app/page.tsx
@@ -11,25 +11,23 @@ export const dynamic = 'force-static'
 export const revalidate = 600
 
 export default function Home() {
-  const ABConst = Math.random() < 0.5 ? 'A' : 'B'
-
   return (
     <main>
-      <DataLayerLogger version={ABConst} />
+      <DataLayerLogger />
       {/* @ts-expect-error Async Server Component */}
-      <DailyHighlightSection version={ABConst} />
+      <DailyHighlightSection />
       {/* @ts-expect-error Async Server Component */}
       <MostPickedStorySection />
       {/* @ts-expect-error Async Server Component */}
-      <CategoryStorySection version={ABConst} />
+      <CategoryStorySection />
       {/* @ts-expect-error Async Server Component */}
       <TopCollectorSection />
       {/* @ts-expect-error Async Server Component */}
       <MostLikedCommentSection />
       {/* @ts-expect-error Async Server Component */}
-      <ReadrStorySection version={ABConst} />
+      <ReadrStorySection />
       {/* @ts-expect-error Async Server Component */}
-      <TopPublisherSection version={ABConst} />
+      <TopPublisherSection />
     </main>
   )
 }

--- a/packages/mesh/context/ab-test.tsx
+++ b/packages/mesh/context/ab-test.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { createContext, useContext, useEffect, useState } from 'react'
+
+type TestVersion = 'A' | 'B' | null
+
+const ABTestContext = createContext<{ version: TestVersion } | undefined>(
+  undefined
+)
+
+export function ABTestProvider({ children }: { children: ReactNode }) {
+  const [testVersion, setTestVersion] = useState<TestVersion>(null)
+  console.log(testVersion)
+  useEffect(() => {
+    setTestVersion(Math.random() < 0.5 ? 'A' : 'B')
+  }, [])
+
+  return (
+    <ABTestContext.Provider value={{ version: testVersion }}>
+      {children}
+    </ABTestContext.Provider>
+  )
+}
+
+export function useABTest() {
+  const context = useContext(ABTestContext)
+  if (context === undefined) {
+    throw new Error('useABTest must be used within a ABTestProvider')
+  }
+  return context
+}


### PR DESCRIPTION
# Notable Change

Get ab test version in client side and use context for client components to get the version.