### PR TITLE
Fix: Resolve TypeScript and ESLint errors in media package

### DIFF
--- a/packages/mesh/.eslintrc.js
+++ b/packages/mesh/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   //TODO: ESLint: Failed to load config "../../.eslintrc" to extend from. Referenced from: /app/.eslintrc.json
   extends: [
-    '../../.eslintrc',
+    '../../.eslintrc.js',
     'next/core-web-vitals',
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',

--- a/packages/mesh/app/media/_components/media-stories.tsx
+++ b/packages/mesh/app/media/_components/media-stories.tsx
@@ -271,6 +271,9 @@ export default function MediaStories({
       try {
         const results = await Promise.all(
           categoriesToFetch.map(category => {
+            if (!category.slug) { // Add null/undefined check for category.slug
+              return Promise.resolve(null); 
+            }
             // Avoid re-fetching if data already seems loaded (e.g. by quick user navigation)
             const existingData = pageDataInCategories[category.slug];
             if (existingData && !(existingData.mostPickedStory === null &&


### PR DESCRIPTION
This commit addresses build failures caused by:
1. A TypeScript error in `packages/mesh/app/media/_components/media-stories.tsx`:
   - `Type 'null' cannot be used as an index type` when accessing `pageDataInCategories[category.slug]`.
   - Fixed by adding a null check for `category.slug` before its use as an object key.

2. An ESLint configuration error:
   - `ESLint: Failed to load config "../../.eslintrc" to extend from. Referenced from: /app/.eslintrc.js`.
   - Fixed by correcting the `extends` path in `packages/mesh/.eslintrc.js` to `../../.eslintrc.js` to accurately point to the root ESLint configuration file.

These changes should allow the build process to complete successfully.