### PR TITLE
Revert: Rollback localStorage caching for media categories

### DIFF
--- a/packages/mesh/app/media/_components/media-stories.tsx
+++ b/packages/mesh/app/media/_components/media-stories.tsx
@@ -68,313 +68,140 @@ export default function MediaStories({
 }) {
   const { user } = useUser()
   const [isLoading, setIsLoading] = useState(true)
-  const [initialLoadComplete, setInitialLoadComplete] = useState(false)
   const [pageDataInCategories, setPageDataInCategories] = useState<PageData>(
     getInitialPageData(allCategories)
   )
   const searchParams = useSearchParams()
-
-  const initialActiveCategory = useMemo(() => {
-    const slugFromParams = searchParams.get(categorySearchParamName)
-    if (slugFromParams) {
-      const categoryFromSlug = user.followingCategories.find(
-        (category) => category.slug === slugFromParams
-      )
-      if (categoryFromSlug) return categoryFromSlug
-    }
-    return user.followingCategories[0] || null
-  }, [searchParams, user.followingCategories])
-  
-  // currentCategory is the category currently reflected in the URL/selected by user
-  const currentCategory = useMemo(() => {
-    const slugFromParams = searchParams.get(categorySearchParamName)
-    if (slugFromParams) {
-      return user.followingCategories.find(
-        (category) => category.slug === slugFromParams
-      )
-    }
-    // Fallback to initialActiveCategory if no slug, so UI doesn't break
-    // If initialActiveCategory is also null (no followed categories), currentCategory will be null.
-    return initialActiveCategory 
-  }, [searchParams, user.followingCategories, initialActiveCategory])
-
-  const currentCategorySlug = currentCategory?.slug // Used for rendering, derived from currentCategory
+  const currentCategorySlug = searchParams.get(categorySearchParamName)
+  const currentCategory = user.followingCategories.find(
+    (category) => category.slug === currentCategorySlug
+  )
 
   const followingPublisherIds = useMemo(
     () => user.followingPublishers.map((publisher) => publisher.id),
     [user.followingPublishers]
   )
   const { mostPickedStory, latestStoriesInfo, publishersAndStories } =
-    pageDataInCategories[currentCategorySlug ?? ''] || {
-      mostPickedStory: null,
-      latestStoriesInfo: { stories: [], totalCount: 0, shouldLoadmore: true },
-      publishersAndStories: [],
-    }
-
-  // Define a generic fetch function for a single category's data
-  const fetchCategoryData = useCallback(
-    async (categoryToFetch: Category) => {
-      if (!categoryToFetch?.slug || !categoryToFetch?.id) return null
-
-      const categorySlug = categoryToFetch.slug
-      const categoryId = categoryToFetch.id
-
-      const categoryLatestStoriesfetchBody = {
-        publishers: followingPublisherIds,
-        category: categoryId,
-        index: 0,
-        take: latestStoryPageCount,
-      }
-
-      const [
-        mostPickedStoryResponse,
-        latestStoriesResponse,
-        publishersAndStoriesResponse,
-      ] = await Promise.all([
-        getMostPickedStoriesInCategory(categorySlug),
-        getLatestStoriesInCategory(categoryLatestStoriesfetchBody),
-        getMostSponsorPublishersAndStories(categorySlug),
-      ])
-
-      const loadedMostPickedStory = mostPickedStoryResponse?.[0] ?? null
-      const loadedLatestStoriesInfo: LatestStoriesInfo = {
-        stories: latestStoriesResponse?.stories ?? [],
-        totalCount: latestStoriesResponse?.num_stories ?? 0,
-        shouldLoadmore:
-          (latestStoriesResponse?.stories?.length ?? 0) >= latestStoryPageCount,
-      }
-      const loadedPublishersAndStories =
-        publishersAndStoriesResponse
-          ?.slice(0, displayPublisherCount)
-          .map((publisherAndStory) => ({
-            publisher: publisherAndStory.publisher,
-            stories: publisherAndStory.stories.slice(
-              0,
-              displayPublisherStoriesCount
-            ),
-          })) ?? []
-
-      return {
-        slug: categorySlug,
-        data: {
-          mostPickedStory: loadedMostPickedStory,
-          latestStoriesInfo: loadedLatestStoriesInfo,
-          publishersAndStories: loadedPublishersAndStories,
-        },
-      }
-    },
-    [followingPublisherIds]
+    pageDataInCategories[
+      (currentCategory?.slug || user.followingCategories[0].slug) ?? ''
+    ]
+  const getLatestStoriesfetchBody = useMemo(
+    () => ({
+      publishers: followingPublisherIds,
+      category: currentCategory?.id ?? '',
+      index: 0,
+      take: latestStoryPageCount,
+    }),
+    [currentCategory?.id, followingPublisherIds]
   )
 
   const loadMoreLatestStories = useCallback(async () => {
-    if (!currentCategory || !currentCategory.id) return;
+    const latestStoriesResponse = await getLatestStoriesInCategory({
+      ...getLatestStoriesfetchBody,
+      index: latestStoriesInfo.stories.length,
+    })
 
-    const currentCategoryLatestStoriesfetchBody = {
-      publishers: followingPublisherIds,
-      category: currentCategory.id,
-      index: latestStoriesInfo.stories.length, // Use current length for pagination
-      take: latestStoryPageCount,
-    };
-
-    const latestStoriesResponse = await getLatestStoriesInCategory(currentCategoryLatestStoriesfetchBody)
-
-    if (!latestStoriesResponse?.stories) return
+    // do nothing to error response
+    if (!latestStoriesResponse) return
 
     const newLatestStoriesInfo: LatestStoriesInfo = {
-      stories: latestStoriesInfo.stories.concat(latestStoriesResponse.stories),
-      totalCount: latestStoriesResponse.num_stories ?? latestStoriesInfo.totalCount,
-      shouldLoadmore: latestStoriesResponse.stories.length >= latestStoryPageCount,
+      stories: latestStoriesInfo.stories.concat(
+        latestStoriesResponse.stories ?? []
+      ),
+      totalCount: latestStoriesResponse.num_stories ?? 0,
+      // only stop infinite scroll when response return empty array
+      shouldLoadmore: latestStoriesResponse.stories.length !== 0 ? true : false,
     }
-    
-    if (currentCategory.slug) {
-      setPageDataInCategories((oldPageData) => ({
+
+    const currentPageData = pageDataInCategories[currentCategory?.slug ?? '']
+    setPageDataInCategories((oldPageData) => {
+      return {
         ...oldPageData,
-        [currentCategory.slug!]: { // currentCategory.slug known to be defined here
-          ...(oldPageData[currentCategory.slug!] || {}), // Spread existing data for the category
+        [currentCategory?.slug ?? '']: {
+          ...currentPageData,
           latestStoriesInfo: newLatestStoriesInfo,
         },
-      }))
+      }
+    })
+  }, [
+    currentCategory?.slug,
+    getLatestStoriesfetchBody,
+    latestStoriesInfo.stories,
+    pageDataInCategories,
+  ])
+
+  useEffect(() => {
+    if (!currentCategorySlug) {
+      replaceSearchParams(
+        categorySearchParamName,
+        user.followingCategories[0].slug ?? ''
+      )
+    }
+  }, [currentCategorySlug, user.followingCategories])
+
+  useEffect(() => {
+    const fetchPageData = async () => {
+      try {
+        const [
+          mostPickedStoryResponse,
+          latestStoriesResponse,
+          publishersAndStoriesResponse,
+        ] = await Promise.all([
+          getMostPickedStoriesInCategory(currentCategory?.slug ?? ''),
+          getLatestStoriesInCategory(getLatestStoriesfetchBody),
+          getMostSponsorPublishersAndStories(currentCategory?.slug ?? ''),
+        ])
+
+        // TODO: handle page display stories no repeated in mostPicked, latest, publisher stories
+        const mostPickedStory = mostPickedStoryResponse?.[0] ?? null
+        const latestStoriesInfo: LatestStoriesInfo = {
+          stories: latestStoriesResponse?.stories ?? [],
+          totalCount: latestStoriesResponse?.num_stories ?? 0,
+          shouldLoadmore: true,
+        }
+
+        const publishersAndStories =
+          publishersAndStoriesResponse
+            ?.slice(0, displayPublisherCount)
+            .map((publisherAndStories) => ({
+              publisher: publisherAndStories.publisher,
+              stories: publisherAndStories.stories.slice(
+                0,
+                displayPublisherStoriesCount
+              ),
+            })) ?? []
+
+        setPageDataInCategories((oldPageData) => ({
+          ...oldPageData,
+          [currentCategory?.slug ?? '']: {
+            mostPickedStory,
+            latestStoriesInfo,
+            publishersAndStories,
+          },
+        }))
+
+        setIsLoading(false)
+      } catch (error) {
+        console.error('fetchPageData error', error)
+      }
+    }
+
+    if (!mostPickedStory && currentCategory) {
+      setIsLoading(true)
+      fetchPageData()
     }
   }, [
     currentCategory,
-    followingPublisherIds,
-    latestStoriesInfo.stories, // Ensure it reacts to changes in story length
-    latestStoriesInfo.totalCount, // Ensure it reacts to changes in totalCount
-    pageDataInCategories, // To access existing data if needed, though direct set is better
-  ])
-
-  // Effect to set initial URL slug if not present
-  useEffect(() => {
-    if (!searchParams.get(categorySearchParamName) && initialActiveCategory?.slug) {
-      replaceSearchParams(categorySearchParamName, initialActiveCategory.slug)
-    }
-  }, [searchParams, initialActiveCategory])
-
-
-  // 1. Effect for Initial Active Category Load
-  useEffect(() => {
-    const loadInitialCategory = async () => {
-      if (!initialActiveCategory?.slug) {
-        if (user.followingCategories.length === 0) {
-          setIsLoading(false)
-        }
-        setInitialLoadComplete(true)
-        return
-      }
-
-      const slug = initialActiveCategory.slug
-      const existingData = pageDataInCategories[slug]
-      if (existingData && !(existingData.mostPickedStory === null &&
-                           existingData.latestStoriesInfo.stories.length === 0 &&
-                           existingData.latestStoriesInfo.totalCount === 0 &&
-                           existingData.latestStoriesInfo.shouldLoadmore === true)) {
-        setIsLoading(false)
-        setInitialLoadComplete(true)
-        return
-      }
-      
-      setIsLoading(true)
-      try {
-        const result = await fetchCategoryData(initialActiveCategory)
-        if (result) {
-          setPageDataInCategories((prev) => ({ ...prev, [result.slug]: result.data }))
-        }
-      } catch (error) {
-        console.error(`Error fetching initial category ${initialActiveCategory.slug}:`, error)
-      } finally {
-        setIsLoading(false)
-        setInitialLoadComplete(true)
-      }
-    }
-
-    if (!initialLoadComplete) {
-      loadInitialCategory()
-    }
-  }, [
-    initialActiveCategory, 
-    fetchCategoryData, 
-    pageDataInCategories, 
-    initialLoadComplete, 
-    user.followingCategories.length
-  ])
-
-
-  // 2. Effect for Background Prefetching Other Categories
-  useEffect(() => {
-    const prefetchAllOtherCategories = async () => {
-      const categoriesToFetch = user.followingCategories.filter(
-        (category) => category.slug !== initialActiveCategory?.slug
-      )
-
-      if (categoriesToFetch.length === 0) return
-
-      try {
-        const results = await Promise.all(
-          categoriesToFetch.map(category => {
-            if (!category.slug) { // Add null/undefined check for category.slug
-              return Promise.resolve(null); 
-            }
-            // Avoid re-fetching if data already seems loaded (e.g. by quick user navigation)
-            const existingData = pageDataInCategories[category.slug];
-            if (existingData && !(existingData.mostPickedStory === null &&
-                                 existingData.latestStoriesInfo.stories.length === 0 &&
-                                 existingData.latestStoriesInfo.totalCount === 0 &&
-                                 existingData.latestStoriesInfo.shouldLoadmore === true)) {
-              return Promise.resolve(null); // Already loaded or being loaded, skip prefetch
-            }
-            return fetchCategoryData(category);
-          })
-        )
-        
-        const newPageData = results.reduce((acc, result) => {
-          if (result?.slug) {
-            acc[result.slug] = result.data
-          }
-          return acc
-        }, {} as PageData)
-
-        if (Object.keys(newPageData).length > 0) {
-          setPageDataInCategories((prevData) => ({ ...prevData, ...newPageData }))
-        }
-      } catch (error) {
-        console.error('Error prefetching other categories data:', error)
-      }
-    }
-
-    if (initialLoadComplete && user.followingCategories.length > 0) {
-      prefetchAllOtherCategories()
-    }
-  }, [
-    initialLoadComplete, 
-    user.followingCategories, 
-    fetchCategoryData, 
-    initialActiveCategory,
-    pageDataInCategories // Dependency to re-evaluate if specific categories need fetching
-  ])
-
-
-  // 3. Effect for Handling Subsequent currentCategory (URL-driven) Changes
-  useEffect(() => {
-    const loadCurrentCategoryData = async () => {
-      if (!currentCategory?.slug || !initialLoadComplete) {
-        // If no current category or initial load isn't done, do nothing.
-        // If initial load isn't complete, the initial load effect handles its category.
-        // If no current category (e.g. no followed cats), ensure loading is false.
-        if (!currentCategory && user.followingCategories.length === 0) {
-            setIsLoading(false);
-        }
-        return;
-      }
-      
-      // If currentCategory is the one that was initially loaded, its data should be there.
-      // No need to re-fetch unless specific conditions arise (e.g. stale data, not handled here)
-      if (currentCategory.slug === initialActiveCategory?.slug) {
-        setIsLoading(false); // Data was handled by initial load effect
-        return;
-      }
-
-      const categoryData = pageDataInCategories[currentCategory.slug]
-      // Check if data is in initial (unfetched) state
-      if (categoryData && !(categoryData.mostPickedStory === null &&
-                             categoryData.latestStoriesInfo.stories.length === 0 &&
-                             categoryData.latestStoriesInfo.totalCount === 0 &&
-                             categoryData.latestStoriesInfo.shouldLoadmore === true)) {
-        setIsLoading(false) // Data is already loaded (e.g., by background prefetch)
-        return
-      }
-
-      setIsLoading(true)
-      try {
-        const result = await fetchCategoryData(currentCategory)
-        if (result) {
-          setPageDataInCategories((prev) => ({ ...prev, [result.slug]: result.data }))
-        }
-      } catch (error) {
-        console.error(`Error fetching current category ${currentCategory.slug}:`, error)
-      } finally {
-        setIsLoading(false)
-      }
-    }
-
-    // Only run this effect if the initial load sequence has completed.
-    // The initial load effect handles the very first category.
-    if (initialLoadComplete) {
-      loadCurrentCategoryData()
-    }
-  }, [
-    currentCategory, 
-    fetchCategoryData, 
-    pageDataInCategories, 
-    initialLoadComplete, 
-    initialActiveCategory, // To compare with currentCategory
-    user.followingCategories.length // For the no-categories case
+    currentCategory?.slug,
+    getLatestStoriesfetchBody,
+    mostPickedStory,
   ])
 
   let contentJsx: JSX.Element
 
-  if (isLoading || !currentCategory) { // currentCategory check for no-followed-categories scenario
+  if (isLoading || !currentCategory) {
     contentJsx = <Loading withCategory={false} />
-  } else if (!latestStoriesInfo?.stories.length && !mostPickedStory) { // Check both
+  } else if (!latestStoriesInfo?.stories.length) {
     contentJsx = <NoStories />
   } else {
     contentJsx = (
@@ -409,4 +236,3 @@ export default function MediaStories({
     </main>
   )
 }
-// No changes to the rendering logic (contentJsx, return statement) from the previous correct version.


### PR DESCRIPTION
This commit reverts the previous implementation of localStorage caching for the media categories page due to a bug causing a blank page on initial load.

The reverted changes include:
- Removal of caching logic (reading from/writing to localStorage) in `packages/mesh/app/media/_components/media-stories.tsx`.
- Deletion of the `packages/mesh/app/media/utils/category-cache.ts` utility file.

The component is now restored to a state prior to this caching attempt, which directly fetches data from the network. Further work will be done to re-implement caching correctly.