### PR TITLE
Fix: Correct hook dependency array in media-stories.tsx

### DIFF
--- a/packages/mesh/app/media/_components/media-stories.tsx
+++ b/packages/mesh/app/media/_components/media-stories.tsx
@@ -79,6 +79,7 @@ export default function MediaStories({
   const [pageDataInCategories, setPageDataInCategories] = useState<PageData>(
     getInitialPageData(allCategories)
   )
+  const followingCategoriesCount = user.followingCategories.length; // Define the count variable
 
   // Helper function to check if category data is considered "loaded"
   const isCategoryDataLoaded = (data: PageData[string] | undefined): boolean => {
@@ -292,7 +293,7 @@ export default function MediaStories({
     fetchCategoryData, 
     pageDataInCategories, 
     initialLoadComplete, 
-    user.followingCategories.length
+    followingCategoriesCount // Use the variable here
   ])
 
   // Effect 2: Background Prefetching Other Categories
@@ -452,7 +453,7 @@ export default function MediaStories({
     pageDataInCategories, 
     initialLoadComplete, 
     initialActiveCategory,
-    user.followingCategories.length
+    followingCategoriesCount // Use the variable here
   ]);
 
   // Define the handler for refocus/visibility using useCallback


### PR DESCRIPTION
This commit fixes a build error (`Expected ',', got '.'`) in `packages/mesh/app/media/_components/media-stories.tsx`.

The error was caused by using `user.followingCategories.length` directly within the dependency arrays of `useEffect` hooks. This has been resolved by pre-calculating this length into a variable (`followingCategoriesCount`) and using that variable in the dependency arrays instead.

This change ensures the dependency arrays use stable primitive values, which should resolve the build failure.