### PR TITLE
Fix: Prevent flash of "NoStories" and confirm cache behavior

### DIFF
--- a/packages/mesh/app/media/_components/media-stories.tsx
+++ b/packages/mesh/app/media/_components/media-stories.tsx
@@ -80,6 +80,7 @@ export default function MediaStories({
     getInitialPageData(allCategories)
   )
   const followingCategoriesCount = user.followingCategories.length; // Define the count variable
+  const prevCurrentCategorySlugRef = useRef<string | undefined>();
 
   // Helper function to check if category data is considered "loaded"
   const isCategoryDataLoaded = (data: PageData[string] | undefined): boolean => {
@@ -525,33 +526,54 @@ const handleReFocusOrVisible = useCallback(() => {
     };
   }, [handleReFocusOrVisible]); // Now depends on the memoized handler
 
-  let contentJsx: JSX.Element
+  // Effect 5: Update prevCurrentCategorySlugRef after currentCategory.slug changes
+  useEffect(() => {
+    prevCurrentCategorySlugRef.current = currentCategory?.slug;
+  }, [currentCategory?.slug]);
 
-  if (isLoading || !currentCategory) {
-    contentJsx = <Loading withCategory={false} />
-  } else if (!latestStoriesInfo?.stories.length && !mostPickedStory) {
-    contentJsx = <NoStories />
+
+  let contentJsx: JSX.Element;
+  
+  // Determine data for the current render cycle to avoid inconsistencies
+  const currentSlugForRender = currentCategory?.slug;
+  const categoryDataForRender = currentSlugForRender ? pageDataInCategories[currentSlugForRender] : undefined;
+  const isDataActuallyLoadedForRender = currentSlugForRender ? isCategoryDataLoaded(categoryDataForRender) : false;
+
+  let showLoadingIndicator = isLoading;
+
+  if (currentSlugForRender && 
+      prevCurrentCategorySlugRef.current !== currentSlugForRender && 
+      !isDataActuallyLoadedForRender) {
+    showLoadingIndicator = true;
+  }
+
+  if (showLoadingIndicator || !currentCategory) {
+    contentJsx = <Loading withCategory={false} />;
+  } else if (!isDataActuallyLoadedForRender || (!categoryDataForRender?.latestStoriesInfo?.stories.length && !categoryDataForRender?.mostPickedStory)) {
+    // If data is not considered loaded (e.g. still pristine), or if loaded but genuinely empty
+    contentJsx = <NoStories />;
   } else {
+    // Data is loaded and not empty
     contentJsx = (
       <>
         <DesktopStories
-          latestStoriesInfo={latestStoriesInfo}
-          mostPickedStory={mostPickedStory}
-          publishersAndStories={publishersAndStories}
+          latestStoriesInfo={categoryDataForRender.latestStoriesInfo}
+          mostPickedStory={categoryDataForRender.mostPickedStory}
+          publishersAndStories={categoryDataForRender.publishersAndStories}
           publisherList={publisherList}
           loadMoreLatestStories={loadMoreLatestStories}
-          slug={currentCategorySlug ?? ''}
+          slug={currentSlugForRender ?? ''}
         />
         <NonDesktopStories
-          key={latestStoriesInfo.stories.length}
-          latestStoriesInfo={latestStoriesInfo}
-          mostPickedStory={mostPickedStory}
-          publishersAndStories={publishersAndStories}
+          key={categoryDataForRender.latestStoriesInfo.stories.length}
+          latestStoriesInfo={categoryDataForRender.latestStoriesInfo}
+          mostPickedStory={categoryDataForRender.mostPickedStory}
+          publishersAndStories={categoryDataForRender.publishersAndStories}
           publisherList={publisherList}
           loadMoreLatestStories={loadMoreLatestStories}
         />
       </>
-    )
+    );
   }
 
   return (


### PR DESCRIPTION
This commit addresses two main points for `media-stories.tsx`:

1.  **Fix "Flash of NoStories" (FoNS):**
    - I implemented a preemptive loading state by tracking the previous category slug (`prevCurrentCategorySlugRef`).
    - If a category tab is switched to, and its data is not yet loaded in memory (neither from cache nor network), a loading indicator (`showLoadingIndicator`) is now forced true for the initial render of that tab.
    - This ensures a skeleton UI appears immediately, preventing the brief display of a "no stories" message while the component waits for its `useEffect` to manage the loading state and fetch data.
    - Story rendering components now also use data consistently derived for the current render pass.

2.  **Cache Behavior Confirmation:**
    - I investigated localStorage caching utilities (`category-cache.ts`).
    - I confirmed that these utilities do not cause unexpected widespread cache clearing.
    - Cached items are removed individually due to:
        - TTL expiry (currently 1 hour).
        - Data corruption or parsing errors for a specific item.
    - This is expected behavior. If you experience more frequent cache misses than the TTL would suggest, external factors (browser settings, other application logic) might be involved.

This set of changes should improve the tab switching user experience by eliminating the FoNS issue and clarifies the expected cache persistence.