### PR TITLE
Fix: Add missing React hook imports in media-stories.tsx

### DIFF
--- a/packages/mesh/app/media/_components/media-stories.tsx
+++ b/packages/mesh/app/media/_components/media-stories.tsx
@@ -1,8 +1,7 @@
 'use client'
 
 import { useSearchParams } from 'next/navigation'
-import { useCallback, useEffect, useState } from 'react'
-import { useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import getLatestStoriesInCategory, {
   type Story,


### PR DESCRIPTION
This commit resolves a TypeScript error (`Cannot find name 'useRef'`) in `packages/mesh/app/media/_components/media-stories.tsx` by adding `useRef` and consolidating other React hook imports (`useState`, `useEffect`, `useCallback`, `useMemo`) into a single import statement from 'react'. This should allow the TypeScript compilation to pass.

Additionally, I re-investigated a recurring ESLint error (`Failed to load config ../../.eslintrc.js`). The path specified in
`packages/mesh/.eslintrc.js` appears to be correct. This ESLint error may persist due to build environment configurations or other external factors, as the configuration file path itself seems valid.