### PR TITLE
Fix: Correct TypeScript type error for prevCurrentCategorySlugRef

### DIFF
--- a/packages/mesh/app/media/_components/media-stories.tsx
+++ b/packages/mesh/app/media/_components/media-stories.tsx
@@ -527,7 +527,7 @@ const handleReFocusOrVisible = useCallback(() => {
 
   // Effect 5: Update prevCurrentCategorySlugRef after currentCategory.slug changes
   useEffect(() => {
-    prevCurrentCategorySlugRef.current = currentCategory?.slug;
+    prevCurrentCategorySlugRef.current = currentCategory?.slug ?? undefined;
   }, [currentCategory?.slug]);
 
 


### PR DESCRIPTION
This commit resolves a TypeScript type error in
`packages/mesh/app/media/_components/media-stories.tsx`: `Type 'string | null | undefined' is not assignable to type 'string | undefined'`.

The error occurred during the assignment to `prevCurrentCategorySlugRef.current` because `currentCategory?.slug` can be `null`, while the ref was typed as `MutableRefObject<string | undefined>`.

The fix changes the assignment to:
`prevCurrentCategorySlugRef.current = currentCategory?.slug ?? undefined;` This uses the nullish coalescing operator to ensure that if `currentCategory?.slug` is `null`, `undefined` is assigned instead, satisfying the ref's type.