### PR TITLE
Revert "Fix: Correct TypeScript type error for prevCurrentCategorySlu…

### DIFF
--- a/packages/mesh/app/media/_components/media-stories.tsx
+++ b/packages/mesh/app/media/_components/media-stories.tsx
@@ -527,7 +527,7 @@ const handleReFocusOrVisible = useCallback(() => {
 
   // Effect 5: Update prevCurrentCategorySlugRef after currentCategory.slug changes
   useEffect(() => {
-    prevCurrentCategorySlugRef.current = currentCategory?.slug ?? undefined;
+    prevCurrentCategorySlugRef.current = currentCategory?.slug;
   }, [currentCategory?.slug]);
 
 


### PR DESCRIPTION
…gRef"

This reverts commit <hash_of_fix/media-prevslugref-type> which attempted to fix a TypeScript type error for `prevCurrentCategorySlugRef.current` by using `?? undefined`.

Reason for revert: The aforementioned commit introduced a critical regression where all menu links/tabs in the media categories section became non-functional.

This revert restores the previous assignment:
`prevCurrentCategorySlugRef.current = currentCategory?.slug;`

This action is taken to immediately restore menu link functionality. The TypeScript type error (`Type 'string | null | undefined' is not assignable to type 'string | undefined'`) for this line will reappear as a known issue to be addressed more safely in a subsequent change.