### PR TITLE
Fix: Correct type for prevCurrentCategorySlugRef in media-stories

### DIFF
--- a/packages/mesh/app/media/_components/media-stories.tsx
+++ b/packages/mesh/app/media/_components/media-stories.tsx
@@ -79,7 +79,7 @@ export default function MediaStories({
     getInitialPageData(allCategories)
   )
   const followingCategoriesCount = user.followingCategories.length; // Define the count variable
-  const prevCurrentCategorySlugRef = useRef<string | undefined>();
+  const prevCurrentCategorySlugRef = useRef<string | null | undefined>();
 
   // Helper function to check if category data is considered "loaded"
   const isCategoryDataLoaded = (data: PageData[string] | undefined): boolean => {


### PR DESCRIPTION
This commit resolves a TypeScript type error in
`packages/mesh/app/media/_components/media-stories.tsx` (Type 'string | null | undefined' is not assignable to type 'string | undefined') that occurred during the assignment to `prevCurrentCategorySlugRef.current`.

The fix involves changing the type definition of `prevCurrentCategorySlugRef` from `useRef<string | undefined>()`
to `useRef<string | null | undefined>()`.

The assignment logic remains:
`prevCurrentCategorySlugRef.current = currentCategory?.slug;`

This change makes the assignment type-correct by allowing the ref to store `null` (in addition to `string` or `undefined`), which aligns with the possible values of `currentCategory?.slug`.

This approach is chosen over coercing `null` to `undefined` in the assignment (i.e., `slug ?? undefined`), as that previous attempt unexpectedly broke menu link functionality. By only changing the ref's type, we fix the TypeScript error while aiming to preserve the runtime behavior that kept menu links working.