### PR TITLE
I've implemented a cache-first strategy for the /social page.

### DIFF
--- a/packages/mesh/app/media/_components/media-stories.tsx
+++ b/packages/mesh/app/media/_components/media-stories.tsx
@@ -34,12 +34,16 @@ type PageData = {
     mostPickedStory: Story | null
     latestStoriesInfo: LatestStoriesInfo
     publishersAndStories: MostSponsorPublisher[]
+    timestamp: number // New field
   }
 }
 
 const latestStoryPageCount = 20
 const displayPublisherCount = 5
 const displayPublisherStoriesCount = 3
+
+const TEN_MINUTES_MS = 10 * 60 * 1000
+const REFRESH_CHECK_INTERVAL_MS = 1 * 60 * 1000
 
 const getInitialPageData = (allCategories: Category[]) => {
   return allCategories.reduce((acc, curr) => {
@@ -53,6 +57,7 @@ const getInitialPageData = (allCategories: Category[]) => {
           shouldLoadmore: true,
         },
         publishersAndStories: [],
+        timestamp: 0, // Initialize timestamp
       }
     }
     return acc
@@ -167,6 +172,7 @@ export default function MediaStories({
         mostPickedStory: loadedMostPickedStory,
         latestStoriesInfo: loadedLatestStoriesInfo,
         publishersAndStories: loadedPublishersAndStories,
+        timestamp: Date.now(), // Add current timestamp here
       }
     },
     [followingPublisherIds]
@@ -235,23 +241,69 @@ export default function MediaStories({
       }
 
       const slug = initialActiveCategory.slug
-      if (isCategoryDataLoaded(pageDataInCategories[slug])) {
-        setIsLoading(false)
-        setInitialLoadComplete(true)
-        return
+      const existingData = pageDataInCategories[slug] // Get existing data directly
+      let shouldFetchInBackground = false
+
+      if (existingData) {
+        // If any data object exists for this slug
+        console.log(
+          '[Effect 1] Initial category data exists in state. Rendering from cache first.',
+          existingData
+        )
+        setIsLoading(false) // <<< IMPORTANT: Allow rendering of this cached data immediately
+
+        // Decide if a background fetch is needed for this existing data
+        if (
+          !existingData.timestamp ||
+          Date.now() - existingData.timestamp > TEN_MINUTES_MS ||
+          existingData.latestStoriesInfo.stories.length === 0
+        ) {
+          // Fetch if no timestamp, or stale, or has no stories (even if not stale, maybe prefetch was empty)
+          console.log(
+            '[Effect 1] Cached data is stale, empty, or untimestamped. Scheduling background fetch.'
+          )
+          shouldFetchInBackground = true
+        } else {
+          // Data exists and is fresh enough, no immediate background fetch needed from Effect 1
+          console.log(
+            '[Effect 1] Cached data is fresh. No immediate background fetch.'
+          )
+        }
+        setInitialLoadComplete(true) // Mark initial load as "complete" as we've decided what to do.
+        // The background fetch will happen without blocking this.
+      } else {
+        // No data whatsoever for this slug
+        console.log(
+          '[Effect 1] No data found for initial category. Fetching with loading screen.'
+        )
+        setIsLoading(true) // Show loading screen as there's nothing to display
+        shouldFetchInBackground = true // We must fetch
       }
 
-      setIsLoading(true)
-      try {
-        const result = await fetchCategoryData(initialActiveCategory)
-        if (result) {
-          setPageDataInCategories((prev) => ({ ...prev, [slug]: result }))
+      if (shouldFetchInBackground) {
+        console.log('[Effect 1] Initiating fetch for initial category:', slug)
+        try {
+          const result = await fetchCategoryData(initialActiveCategory)
+          if (result) {
+            setPageDataInCategories((prev) => ({ ...prev, [slug]: result }))
+            console.log(
+              '[Effect 1] Background fetch complete, data updated for',
+              slug
+            )
+          }
+        } catch (error) {
+          console.error(
+            `[Effect 1] Error fetching initial category ${slug} in background:`,
+            error
+          )
+        } finally {
+          if (!existingData) {
+            // If there was no initial data, we were in a loading state
+            setIsLoading(false)
+          }
+          // If there was existing data, isLoading was already false. The update will just re-render.
+          setInitialLoadComplete(true) // Ensure this is set after the fetch attempt too
         }
-      } catch (error) {
-        console.error(`Error fetching initial category ${slug}:`, error)
-      } finally {
-        setIsLoading(false)
-        setInitialLoadComplete(true)
       }
     }
 
@@ -271,10 +323,26 @@ export default function MediaStories({
   useEffect(() => {
     const prefetchAllOtherCategoriesData = async () => {
       const categoriesToPrefetch = user.followingCategories.filter(
-        (category) =>
-          category.slug &&
-          category.slug !== initialActiveCategory?.slug &&
-          !isCategoryDataLoaded(pageDataInCategories[category.slug])
+        (category) => {
+          if (!category.slug || category.slug === initialActiveCategory?.slug) {
+            return false
+          }
+          const categoryData = pageDataInCategories[category.slug]
+          const isDataCurrentlyLoaded = isCategoryDataLoaded(categoryData)
+          // Prefetch if not loaded OR if loaded but stale
+          if (!isDataCurrentlyLoaded) {
+            return true // Needs prefetching because it's not loaded
+          }
+          // If loaded, check for staleness
+          if (
+            categoryData.timestamp &&
+            Date.now() - categoryData.timestamp > TEN_MINUTES_MS
+          ) {
+            // console.log(`Prefetching stale data for background category: ${category.slug}`); // Optional: for debugging
+            return true // Needs prefetching because it's stale
+          }
+          return false // Already loaded and not stale
+        }
       )
 
       if (categoriesToPrefetch.length === 0) return
@@ -323,8 +391,22 @@ export default function MediaStories({
 
   // Effect 3: User Navigation (Load Current Category Data if not loaded by Effect 1 or 2)
   useEffect(() => {
+    console.log(
+      '[Effect 3 Hook Start] initialLoadComplete:',
+      initialLoadComplete,
+      'currentCategory:',
+      currentCategory?.slug,
+      'initialActiveCategory:',
+      initialActiveCategory?.slug
+    )
     const loadCurrentCategoryDataIfNeeded = async () => {
       if (!currentCategory?.slug || !initialLoadComplete) {
+        console.log(
+          '[Effect 3] loadCurrentCategoryDataIfNeeded: Early exit because !currentCategory?.slug or !initialLoadComplete. currentCategory?.slug:',
+          currentCategory?.slug,
+          'initialLoadComplete:',
+          initialLoadComplete
+        )
         if (!currentCategory && followingCategoriesCount === 0 && !isLoading) {
           // Prevent multiple setIsLoading(false)
           setIsLoading(false)
@@ -333,10 +415,15 @@ export default function MediaStories({
       }
 
       const categorySlug = currentCategory.slug
+      console.log(`[Effect 3] Processing category: ${categorySlug}`)
 
       // If it's the initial category, Effect 1 handles it.
       // isLoading will be set by Effect 1.
       if (categorySlug === initialActiveCategory?.slug) {
+        console.log(
+          '[Effect 3] loadCurrentCategoryDataIfNeeded: Early exit because categorySlug === initialActiveCategory?.slug. categorySlug:',
+          categorySlug
+        )
         if (
           isCategoryDataLoaded(pageDataInCategories[categorySlug]) &&
           isLoading
@@ -346,29 +433,104 @@ export default function MediaStories({
         return
       }
 
-      // If data is already loaded (e.g., by Effect 2 or previous navigation)
-      if (isCategoryDataLoaded(pageDataInCategories[categorySlug])) {
-        if (isLoading) setIsLoading(false)
-        return
+      // Cache-First Logic for Navigated Category
+      const existingData = pageDataInCategories[categorySlug]
+      let shouldFetchInBackground = false
+
+      // Keeping the detailed log for existingData as per previous subtask
+      console.log(
+        '[Effect 3] Existing categoryData - stories.length:',
+        existingData?.latestStoriesInfo?.stories?.length,
+        'timestamp:',
+        existingData?.timestamp,
+        'shouldLoadmore:',
+        existingData?.latestStoriesInfo?.shouldLoadmore,
+        'totalCount:',
+        existingData?.latestStoriesInfo?.totalCount,
+        'mostPickedStory:',
+        existingData?.mostPickedStory !== null
+      )
+
+      if (existingData) {
+        console.log(
+          '[Effect 3] Category data exists in state for navigated category. Rendering from cache first.',
+          categorySlug
+        )
+        setIsLoading(false) // Show cached data immediately
+
+        // Decide if a background fetch is needed
+        if (
+          !existingData.timestamp ||
+          Date.now() - existingData.timestamp > TEN_MINUTES_MS ||
+          existingData.latestStoriesInfo.stories.length === 0
+        ) {
+          console.log(
+            '[Effect 3] Cached data for navigated category is stale, empty, or untimestamped. Scheduling background fetch.',
+            categorySlug
+          )
+          shouldFetchInBackground = true
+        } else {
+          console.log(
+            '[Effect 3] Cached data for navigated category is fresh. No background fetch.',
+            categorySlug
+          )
+        }
+      } else {
+        // No data for this navigated category
+        console.log(
+          '[Effect 3] No data found for navigated category. Fetching with loading screen.',
+          categorySlug
+        )
+        setIsLoading(true) // Show loading screen
+        shouldFetchInBackground = true // Must fetch
       }
 
-      // If we reach here, data for the current, non-initial category needs to be fetched.
-      setIsLoading(true)
-      try {
-        const result = await fetchCategoryData(currentCategory)
-        if (result) {
-          setPageDataInCategories((prev) => ({
-            ...prev,
-            [categorySlug]: result,
-          }))
-        }
-      } catch (error) {
-        console.error(
-          `Error fetching navigated category ${categorySlug}:`,
-          error
+      if (shouldFetchInBackground) {
+        console.log(
+          '[Effect 3] Initiating fetch for navigated category:',
+          categorySlug
         )
-      } finally {
-        setIsLoading(false)
+
+        // Revised isLoading management for fetch block:
+        if (!existingData) {
+          // This condition ensures setIsLoading(true) was called if no cache.
+          // If existingData was present, setIsLoading(false) was called, so this fetch is background.
+        } else {
+          // If existingData was present and we are fetching in background,
+          // ensure isLoading is false.
+          if (isLoading) setIsLoading(false)
+        }
+
+        try {
+          const result = await fetchCategoryData(currentCategory)
+          if (result) {
+            setPageDataInCategories((prev) => ({
+              ...prev,
+              [categorySlug]: result,
+            }))
+            console.log(
+              '[Effect 3] Background fetch complete, data updated for navigated category:',
+              categorySlug
+            )
+          }
+        } catch (error) {
+          console.error(
+            `[Effect 3] Error fetching navigated category ${categorySlug}:`,
+            error
+          )
+        } finally {
+          // Only set isLoading to false if we actually set it to true for this fetch (i.e., !existingData).
+          if (!existingData) {
+            console.log(
+              `[Effect 3] Fetch attempt finished for ${categorySlug} (was loading). Setting isLoading to false.`
+            )
+            setIsLoading(false)
+          } else {
+            console.log(
+              `[Effect 3] Background fetch attempt finished for ${categorySlug} (was not loading). isLoading remains false.`
+            )
+          }
+        }
       }
     }
 
@@ -393,6 +555,48 @@ export default function MediaStories({
       setIsLoading(false)
     }
   }, [user.followingCategories.length, initialLoadComplete])
+
+  // Effect 4: Periodic Refresh of Active Category Data
+  useEffect(() => {
+    if (!initialLoadComplete || !currentCategory?.slug) {
+      return
+    }
+
+    const intervalId = setInterval(async () => {
+      const categorySlug = currentCategory.slug
+      if (!categorySlug) return
+
+      const currentCategoryData = pageDataInCategories[categorySlug]
+
+      if (
+        currentCategoryData &&
+        Date.now() - currentCategoryData.timestamp > TEN_MINUTES_MS
+      ) {
+        // console.log(`Refreshing data for active category: ${categorySlug}`); // Optional: for debugging
+        try {
+          // Consider setting a loading state if there's a global or per-category loading indicator
+          const result = await fetchCategoryData(currentCategory)
+          if (result) {
+            setPageDataInCategories((prev) => ({
+              ...prev,
+              [categorySlug]: result, // result already includes the new timestamp
+            }))
+          }
+        } catch (error) {
+          console.error(`Error refreshing category ${categorySlug}:`, error)
+        } finally {
+          // Consider unsetting loading state
+        }
+      }
+    }, REFRESH_CHECK_INTERVAL_MS)
+
+    return () => clearInterval(intervalId)
+  }, [
+    currentCategory,
+    fetchCategoryData,
+    pageDataInCategories,
+    initialLoadComplete,
+  ])
 
   let contentJsx: JSX.Element
 

--- a/packages/mesh/app/social/page.tsx
+++ b/packages/mesh/app/social/page.tsx
@@ -9,6 +9,15 @@ import ErrorPage from '@/components/status/error-page'
 import { useUser } from '@/context/user'
 import { type MongoDBResponse } from '@/utils/data-schema'
 
+// Define Types and Constants
+interface CachedSocialFeed {
+  feedData: MongoDBResponse
+  timestamp: number
+}
+
+const LOCAL_STORAGE_KEY_PREFIX = 'socialFeedCache_'
+// const TEN_MINUTES_MS = 10 * 60 * 1000; // For staleness check later, if needed
+
 import Feed from './_components/feed'
 import FollowSuggestionFeed from './_components/follow-suggestion-feed'
 import FollowSuggestionWidget from './_components/follow-suggestion-widget'
@@ -27,18 +36,99 @@ export default function Page() {
   if (!memberId) redirect('/login')
 
   useEffect(() => {
-    const fetchSocialData = async () => {
-      setIsLoading(true)
-      const response = await getSocialPageData(memberId, 0, feedsNumber)
-      if (!response) {
-        setIsNotFound(true)
-      } else {
-        setSocialData(response)
+    const memberCacheKey = memberId
+      ? `${LOCAL_STORAGE_KEY_PREFIX}${memberId}`
+      : null
+    let loadedFromCache = false
+
+    // Try to load from localStorage first
+    if (memberCacheKey) {
+      try {
+        const cachedItem = localStorage.getItem(memberCacheKey)
+        if (cachedItem) {
+          const cachedSocialData = JSON.parse(cachedItem) as CachedSocialFeed
+          // Optional: Add staleness check here if desired for immediate rendering
+          // For now, just load it if it exists
+          if (cachedSocialData && cachedSocialData.feedData) {
+            console.log(
+              '[Social Page] Loaded data from localStorage cache for member:',
+              memberId
+            )
+            setSocialData(cachedSocialData.feedData)
+            // Set isLoading to false because we have something to show.
+            // The fetch below will still run to get fresh data.
+            setIsLoading(false)
+            loadedFromCache = true
+          }
+        }
+      } catch (error) {
+        console.error(
+          '[Social Page] Error reading social feed from localStorage:',
+          error
+        )
+        // Optionally clear the corrupted item: localStorage.removeItem(memberCacheKey);
       }
-      setIsLoading(false)
     }
-    fetchSocialData()
-  }, [memberId])
+
+    // Proceed to fetch fresh data
+    const fetchSocialData = async () => {
+      // If we haven't loaded from cache and socialData is still null, then we are truly loading.
+      if (!loadedFromCache && !socialData) {
+        setIsLoading(true)
+      } else {
+        // If loaded from cache, or socialData somehow already set, ensure loading is false for background fetch.
+        setIsLoading(false)
+      }
+
+      try {
+        const response = await getSocialPageData(memberId, 0, feedsNumber)
+        if (!response) {
+          setIsNotFound(true)
+          // Clear cache if API returns not found? Or let it be for offline. For now, just set notFound.
+        } else {
+          setSocialData(response)
+          setIsNotFound(false) // Ensure isNotFound is false if data is successfully fetched
+          // Save to localStorage
+          if (memberCacheKey) {
+            try {
+              const newCachedData: CachedSocialFeed = {
+                feedData: response,
+                timestamp: Date.now(),
+              }
+              localStorage.setItem(
+                memberCacheKey,
+                JSON.stringify(newCachedData)
+              )
+              console.log(
+                '[Social Page] Saved fresh data to localStorage for member:',
+                memberId
+              )
+            } catch (error) {
+              console.error(
+                '[Social Page] Error saving social feed to localStorage:',
+                error
+              )
+            }
+          }
+        }
+      } catch (error) {
+        console.error('[Social Page] Error fetching social page data:', error)
+        if (!loadedFromCache) {
+          // If cache wasn't loaded, an error in fetch means not found or error state
+          setIsNotFound(true) // Or a more generic error state
+        }
+        // If cache was loaded, we can potentially just log the error and keep showing stale data.
+      } finally {
+        setIsLoading(false) // Always set isLoading to false after fetch attempt completes
+      }
+    }
+
+    if (memberId) {
+      // Ensure memberId is available
+      fetchSocialData()
+    }
+  }, [memberId]) // Keep memberId as a dependency. `socialData` is not needed as a dependency here
+  // as we are setting it. `feedsNumber` is a constant.
 
   if (isLoading) return <Loading />
   if (isNotFound) return <ErrorPage statusCode={404} />


### PR DESCRIPTION
This commit introduces a cache-first data loading mechanism for the /social page (/packages/mesh/app/social/page.tsx) using localStorage.

Key changes:
- On page load, I attempt to read social feed data from localStorage specific to the memberId.
- If cached data is found, it's displayed immediately to improve perceived load time for you.
- Fresh data is always fetched from the API in the background.
- Upon successful fetch, the page content is updated, and the new data (with a current timestamp) is saved back to localStorage, replacing the old cached entry.
- Loading indicators (`isLoading` state) are managed to show only when no cached data is available for immediate display during the initial data fetch.
- Error handling for localStorage operations and API fetches has been incorporated.

This aligns the /social page with a cache-first approach, similar to what was implemented for media stories, but leverages localStorage for persistence across sessions.