### PR TITLE
feat: Implement local storage cache for profile bookmarks

### DIFF
--- a/packages/mesh/hooks/use-profile-state.ts
+++ b/packages/mesh/hooks/use-profile-state.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 
 import { getMemberProfile, getVisitorProfile } from '@/app/actions/get-profile'
+import { getLocalStorage, setLocalStorage } from '@/utils/local-storage'
 import { useUser } from '@/context/user'
 import { PickObjective } from '@/types/objective'
 import type { ProfileTypes } from '@/types/profile'
@@ -9,6 +10,8 @@ type ProfileConfigType = {
   customId: string
   takesCount: number
 }
+
+const USER_PROFILE_CACHE_KEY_PREFIX = 'userProfile-'
 
 const initialProfileState: ProfileTypes = {
   name: '',
@@ -38,11 +41,32 @@ export default function useProfileState({
   const isCurrentUser = customId === user.customId
 
   const fetchMemberProfile = useCallback(async () => {
-    const memberProfileResult = await getMemberProfile(customId, takesCount)
-    if (!memberProfileResult) {
-      throw new Error('Failed to fetch member profile')
+    const cacheKey = `${USER_PROFILE_CACHE_KEY_PREFIX}${customId}`
+    const cachedData = getLocalStorage(cacheKey, null)
+
+    if (cachedData) {
+      setProfileData({ ...user, ...cachedData })
+      // setIsLoading(false); // Decide if needed here or rely on finally
     }
-    setProfileData({ ...user, ...memberProfileResult })
+
+    try {
+      const memberProfileResult = await getMemberProfile(customId, takesCount)
+      if (!memberProfileResult) {
+        throw new Error('Failed to fetch member profile')
+      }
+      setLocalStorage(cacheKey, memberProfileResult)
+      setProfileData({ ...user, ...memberProfileResult })
+    } catch (error) {
+      // If fetching fresh data fails, and we had cached data,
+      // we might want to ensure the UI isn't stuck in a loading state
+      // or revert to cached data if not already set.
+      // For now, we'll let the main error handling take over.
+      if (!cachedData) {
+        // Only throw if there's no cache, otherwise we've already set profile data
+        throw error
+      }
+      console.error('Failed to fetch fresh profile, using cached data if available', error)
+    }
   }, [customId, takesCount, user])
 
   const fetchVisitorProfile = useCallback(async () => {

--- a/packages/mesh/utils/local-storage.ts
+++ b/packages/mesh/utils/local-storage.ts
@@ -1,0 +1,16 @@
+const PREFIX = 'mesh'
+
+function getKey(key: string): string {
+  return `${PREFIX}.${key}`
+}
+
+function setLocalStorage(key: string, value: any): void {
+  window.localStorage.setItem(getKey(key), JSON.stringify(value))
+}
+
+function getLocalStorage(key: string, defaultValue: any): any {
+  const value = window.localStorage.getItem(getKey(key))
+  return value !== null ? JSON.parse(value) : defaultValue
+}
+
+export { getLocalStorage, setLocalStorage }


### PR DESCRIPTION
This commit introduces a local storage caching mechanism for your profile data, specifically benefiting the bookmarks tab.

Key changes:
- Added a local storage utility (`packages/mesh/utils/local-storage.ts`), adapted from an existing utility in the `readr` package.
- Modified the `useProfileState` hook (`packages/mesh/hooks/use-profile-state.ts`) to:
    - On initial load of your current profile, attempt to load profile data (including bookmarks) from local storage for faster display.
    - Always fetch fresh profile data in the background.
    - Update the local storage with the latest fetched data.
    - Ensure caching only applies to your own profile.
- If fetching fresh data fails but cached data is available, the cached data will continue to be displayed to improve resilience.

This change aims to improve the perceived performance of loading the profile page, especially the bookmarks section, by showing cached content while fresh data is retrieved.