### PR TITLE
feat: add mass recall live section to homepage

### DIFF
--- a/packages/readr/components/index/mass-recall-live-section.tsx
+++ b/packages/readr/components/index/mass-recall-live-section.tsx
@@ -1,0 +1,74 @@
+// 2025/7/26 立委罷免即時開票專區
+
+import NextLink from 'next/link'
+import styled from 'styled-components'
+
+const Container = styled.section`
+  margin: 0 auto;
+  margin-top: 28px;
+  margin-bottom: 17px;
+  width: 310px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  ${({ theme }) => `
+    ${theme.breakpoint.md} {
+      width: 696px;
+      margin-top: 40px;
+      margin-bottom: 59px;
+  `}
+
+  ${({ theme }) => `
+    ${theme.breakpoint.xl} {
+      width: 912px;
+      margin-bottom: 35.92px;
+  `}
+`
+
+const Title = styled.h1`
+  font-family: 'Noto Sans CJK TC';
+  width: 100%;
+  font-size: 16px;
+  font-weight: 700;
+  text-align: center;
+  color: #2550af;
+  background-color: #ebf02c;
+
+  ${({ theme }) => `
+    ${theme.breakpoint.xl} {
+      font-size: 20px;
+  `}
+`
+
+const Iframe = styled.iframe`
+  width: 100%;
+`
+
+const KnowMoreLink = styled(NextLink)`
+  font-family: 'Noto Sans CJK TC';
+  font-size: 16px;
+  font-weight: bold;
+  color: #2550af;
+  text-decoration: underline;
+`
+
+export default function MassRecallLiveSection(): JSX.Element {
+  const RecallIframeURL =
+    'https://www.mirrormedia.mg/projects/election2024-homepage/index.html'
+  const RecallTopicPageURL = ''
+
+  return (
+    <Container>
+      <Title>2025 READr立委罷免即時開票</Title>
+      <Iframe src={RecallIframeURL}></Iframe>
+      <KnowMoreLink
+        href={RecallTopicPageURL}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        查看更多
+      </KnowMoreLink>
+    </Container>
+  )
+}

--- a/packages/readr/components/index/mass-recall-live-section.tsx
+++ b/packages/readr/components/index/mass-recall-live-section.tsx
@@ -43,6 +43,17 @@ const Title = styled.h1`
 
 const Iframe = styled.iframe`
   width: 100%;
+  height: 270px;
+
+  ${({ theme }) => `
+    ${theme.breakpoint.md} {
+      height: 212px;
+  `}
+
+  ${({ theme }) => `
+    ${theme.breakpoint.xl} {
+      height: 206px;
+  `}
 `
 
 const KnowMoreLink = styled(NextLink)`
@@ -55,7 +66,7 @@ const KnowMoreLink = styled(NextLink)`
 
 export default function MassRecallLiveSection(): JSX.Element {
   const RecallIframeURL =
-    'https://www.mirrormedia.mg/projects/election2024-homepage/index.html'
+    'https://www.readr.tw/project/3/election2025-homepage/index.html'
   const RecallTopicPageURL = ''
 
   return (

--- a/packages/readr/constants/config.ts
+++ b/packages/readr/constants/config.ts
@@ -1,4 +1,5 @@
 const ENV = process.env.NEXT_PUBLIC_ENV || 'local'
+const IS_SPECIALEVENT = process.env.NEXT_PUBLIC_SPECIALEVENT === 'true'
 
 // 這裡管理的是在 runtime 時，可被設定的環境變數 (通常沒有 `NEXT_PUBLIC_` 作為開頭)
 const USE_MOCK_SERVER = (process.env.USE_MOCK_SERVER ?? 'false') === 'true'
@@ -44,6 +45,7 @@ if (USE_MOCK_SERVER) API_ENDPOINT = `http://localhost:${MOCK_API_SERVER_PORT}/`
 export {
   API_ENDPOINT,
   EDITOOLS_API_ENDPOINT,
+  IS_SPECIALEVENT,
   MISO_API_KEY,
   MOCK_API_SERVER_PORT,
   OAUTH_CLIENT_ID,

--- a/packages/readr/constants/config.ts
+++ b/packages/readr/constants/config.ts
@@ -1,5 +1,5 @@
 const ENV = process.env.NEXT_PUBLIC_ENV || 'local'
-const IS_SPECIALEVENT = process.env.NEXT_PUBLIC_SPECIALEVENT === 'True'
+const IS_MASS_RECALL = process.env.NEXT_PUBLIC_SPECIALEVENT === 'True'
 
 // 這裡管理的是在 runtime 時，可被設定的環境變數 (通常沒有 `NEXT_PUBLIC_` 作為開頭)
 const USE_MOCK_SERVER = (process.env.USE_MOCK_SERVER ?? 'false') === 'true'
@@ -45,7 +45,7 @@ if (USE_MOCK_SERVER) API_ENDPOINT = `http://localhost:${MOCK_API_SERVER_PORT}/`
 export {
   API_ENDPOINT,
   EDITOOLS_API_ENDPOINT,
-  IS_SPECIALEVENT,
+  IS_MASS_RECALL,
   MISO_API_KEY,
   MOCK_API_SERVER_PORT,
   OAUTH_CLIENT_ID,

--- a/packages/readr/constants/config.ts
+++ b/packages/readr/constants/config.ts
@@ -1,5 +1,5 @@
 const ENV = process.env.NEXT_PUBLIC_ENV || 'local'
-const IS_SPECIALEVENT = process.env.NEXT_PUBLIC_SPECIALEVENT === 'true'
+const IS_SPECIALEVENT = process.env.NEXT_PUBLIC_SPECIALEVENT === 'True'
 
 // 這裡管理的是在 runtime 時，可被設定的環境變數 (通常沒有 `NEXT_PUBLIC_` 作為開頭)
 const USE_MOCK_SERVER = (process.env.USE_MOCK_SERVER ?? 'false') === 'true'

--- a/packages/readr/constants/environment-variables.ts
+++ b/packages/readr/constants/environment-variables.ts
@@ -1,5 +1,7 @@
 // 這裡管理的是在 Build 階段就會寫死數值的環境變數 (通常為 `NEXT_PUBLCI_` 開頭)
 const ENV = process.env.NEXT_PUBLIC_ENV || 'local'
+const IS_SPECIALEVENT = process.env.NEXT_PUBLIC_SPECIALEVENT === 'true'
+
 let SITE_URL: string
 let GA_TRACKING_ID: string
 let GTM_ID: string
@@ -91,6 +93,7 @@ export {
   GOOGLE_ADSENSE_AD_CLIENT,
   GTM_ID,
   HEADER_JSON_URL,
+  IS_SPECIALEVENT,
   LATEST_POSTS_IN_CATEGORIES_FOR_CATEGORY_PAGE_URL,
   LATEST_POSTS_IN_CATEGORIES_URL,
   LATEST_POSTS_URL,

--- a/packages/readr/constants/environment-variables.ts
+++ b/packages/readr/constants/environment-variables.ts
@@ -1,6 +1,6 @@
 // 這裡管理的是在 Build 階段就會寫死數值的環境變數 (通常為 `NEXT_PUBLCI_` 開頭)
 const ENV = process.env.NEXT_PUBLIC_ENV || 'local'
-const IS_SPECIALEVENT = process.env.NEXT_PUBLIC_SPECIALEVENT === 'true'
+const IS_SPECIALEVENT = process.env.NEXT_PUBLIC_SPECIALEVENT === 'True'
 
 let SITE_URL: string
 let GA_TRACKING_ID: string

--- a/packages/readr/constants/environment-variables.ts
+++ b/packages/readr/constants/environment-variables.ts
@@ -1,6 +1,6 @@
 // 這裡管理的是在 Build 階段就會寫死數值的環境變數 (通常為 `NEXT_PUBLCI_` 開頭)
 const ENV = process.env.NEXT_PUBLIC_ENV || 'local'
-const IS_SPECIALEVENT = process.env.NEXT_PUBLIC_SPECIALEVENT === 'True'
+const IS_MASS_RECALL = process.env.NEXT_PUBLIC_SPECIALEVENT === 'True'
 
 let SITE_URL: string
 let GA_TRACKING_ID: string
@@ -93,7 +93,7 @@ export {
   GOOGLE_ADSENSE_AD_CLIENT,
   GTM_ID,
   HEADER_JSON_URL,
-  IS_SPECIALEVENT,
+  IS_MASS_RECALL,
   LATEST_POSTS_IN_CATEGORIES_FOR_CATEGORY_PAGE_URL,
   LATEST_POSTS_IN_CATEGORIES_URL,
   LATEST_POSTS_URL,

--- a/packages/readr/pages/index.tsx
+++ b/packages/readr/pages/index.tsx
@@ -16,6 +16,7 @@ import type { NavigationCategoryWithArticleCards } from '~/components/index/late
 import LatestReportSection from '~/components/index/latest-report-section'
 import OpenDataSection from '~/components/index/open-data-section'
 import LayoutGeneral from '~/components/layout/layout-general'
+import { IS_SPECIALEVENT } from '~/constants/config'
 import { DEFAULT_CATEGORY } from '~/constants/constant'
 import {
   LATEST_POSTS_IN_CATEGORIES_URL,
@@ -105,6 +106,7 @@ const Index: NextPageWithLayout<PageProps> = ({
 
   return (
     <>
+      {IS_SPECIALEVENT && 123}
       {shouldShowEditorChoiceSection && (
         <EditorChoiceSection posts={editorChoices} />
       )}

--- a/packages/readr/pages/index.tsx
+++ b/packages/readr/pages/index.tsx
@@ -14,6 +14,7 @@ import EditorChoiceSection from '~/components/index/editor-choice-section'
 import FeatureSection from '~/components/index/feature-section'
 import type { NavigationCategoryWithArticleCards } from '~/components/index/latest-report-section'
 import LatestReportSection from '~/components/index/latest-report-section'
+import MassRecallLiveSection from '~/components/index/mass-recall-live-section'
 import OpenDataSection from '~/components/index/open-data-section'
 import LayoutGeneral from '~/components/layout/layout-general'
 import { IS_SPECIALEVENT } from '~/constants/config'
@@ -106,7 +107,7 @@ const Index: NextPageWithLayout<PageProps> = ({
 
   return (
     <>
-      {IS_SPECIALEVENT && 123}
+      {IS_SPECIALEVENT && <MassRecallLiveSection />}
       {shouldShowEditorChoiceSection && (
         <EditorChoiceSection posts={editorChoices} />
       )}

--- a/packages/readr/pages/index.tsx
+++ b/packages/readr/pages/index.tsx
@@ -17,7 +17,7 @@ import LatestReportSection from '~/components/index/latest-report-section'
 import MassRecallLiveSection from '~/components/index/mass-recall-live-section'
 import OpenDataSection from '~/components/index/open-data-section'
 import LayoutGeneral from '~/components/layout/layout-general'
-import { IS_SPECIALEVENT } from '~/constants/config'
+import { IS_MASS_RECALL } from '~/constants/config'
 import { DEFAULT_CATEGORY } from '~/constants/constant'
 import {
   LATEST_POSTS_IN_CATEGORIES_URL,
@@ -107,7 +107,7 @@ const Index: NextPageWithLayout<PageProps> = ({
 
   return (
     <>
-      {IS_SPECIALEVENT && <MassRecallLiveSection />}
+      {IS_MASS_RECALL && <MassRecallLiveSection />}
       {shouldShowEditorChoiceSection && (
         <EditorChoiceSection posts={editorChoices} />
       )}


### PR DESCRIPTION
- 在首頁編輯精選上方新增 7/26 立委罷免即時開票專區`<MassRecallLiveSection />`，並設定 RWD 樣式
-  iframe 目前使用舊版進行測試，會再根據這次 iframe 補上高度

#### 參考連結

1. 設計稿
https://www.figma.com/design/RfJHjsr8rBa7iIC7ir41AZ/READr_Website?node-id=5212-286&p=f&t=IrYDqB2mNRfcyq07-0

2. 任務卡
https://app.asana.com/1/614399484723017/project/1210077071799813/task/1210737681550466?focus=true