### PR TITLE
feat: display mass recall live section based on json result

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,6 @@ steps:
     id: Build Image
     env:
       - 'NEXT_PUBLIC_ENV=${BRANCH_NAME}'
-      - 'NEXT_PUBLIC_SPECIALEVENT=$_SPECIALEVENT'
     entrypoint: 'bash'
     args:
       - '-c'
@@ -48,5 +47,4 @@ substitutions:
   _TARGET_PACKAGE: '' # default value
   _IMAGE_NAME: '' # default value
   _CLOUD_RUN_SERVICE_NAMES: '' # default value
-  _SPECIALEVENT: '' # default value
   _ENV: 'dev' # default value

--- a/packages/readr/constants/config.ts
+++ b/packages/readr/constants/config.ts
@@ -1,5 +1,4 @@
 const ENV = process.env.NEXT_PUBLIC_ENV || 'local'
-const IS_MASS_RECALL = process.env.NEXT_PUBLIC_SPECIALEVENT === 'True'
 
 // 這裡管理的是在 runtime 時，可被設定的環境變數 (通常沒有 `NEXT_PUBLIC_` 作為開頭)
 const USE_MOCK_SERVER = (process.env.USE_MOCK_SERVER ?? 'false') === 'true'
@@ -45,7 +44,6 @@ if (USE_MOCK_SERVER) API_ENDPOINT = `http://localhost:${MOCK_API_SERVER_PORT}/`
 export {
   API_ENDPOINT,
   EDITOOLS_API_ENDPOINT,
-  IS_MASS_RECALL,
   MISO_API_KEY,
   MOCK_API_SERVER_PORT,
   OAUTH_CLIENT_ID,

--- a/packages/readr/constants/environment-variables.ts
+++ b/packages/readr/constants/environment-variables.ts
@@ -1,7 +1,7 @@
 // 這裡管理的是在 Build 階段就會寫死數值的環境變數 (通常為 `NEXT_PUBLCI_` 開頭)
 const ENV = process.env.NEXT_PUBLIC_ENV || 'local'
-const IS_MASS_RECALL = process.env.NEXT_PUBLIC_SPECIALEVENT === 'True'
-
+const MASS_RECALL_DISPLAY_JSON_URL =
+  'https://storage.googleapis.com/whoareyou-gcs.readr.tw/json/202507_recall_homepage_display.json'
 let SITE_URL: string
 let GA_TRACKING_ID: string
 let GTM_ID: string
@@ -103,10 +103,10 @@ export {
   GOOGLE_ADSENSE_AD_CLIENT,
   GTM_ID,
   HEADER_JSON_URL,
-  IS_MASS_RECALL,
   LATEST_POSTS_IN_CATEGORIES_FOR_CATEGORY_PAGE_URL,
   LATEST_POSTS_IN_CATEGORIES_URL,
   LATEST_POSTS_URL,
+  MASS_RECALL_DISPLAY_JSON_URL,
   QA_RECORD_CONFIG,
   RECALL_TOPIC_PAGE_URL,
   SITE_URL,

--- a/packages/readr/pages/index.tsx
+++ b/packages/readr/pages/index.tsx
@@ -178,7 +178,11 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
         {
           next: { revalidate: 0 },
         }
-      ).then((res) => res.json())
+      )
+        .then((res) => res.json())
+        .catch((err) => {
+          console.error('Error fetching mass recall display JSON:', err)
+        })
 
       isMassRecall2025 =
         massRecallDisplayJsonData?.[

--- a/packages/readr/pages/index.tsx
+++ b/packages/readr/pages/index.tsx
@@ -17,11 +17,12 @@ import LatestReportSection from '~/components/index/latest-report-section'
 import MassRecallLiveSection from '~/components/index/mass-recall-live-section'
 import OpenDataSection from '~/components/index/open-data-section'
 import LayoutGeneral from '~/components/layout/layout-general'
-import { IS_MASS_RECALL } from '~/constants/config'
 import { DEFAULT_CATEGORY } from '~/constants/constant'
 import {
+  ENV,
   LATEST_POSTS_IN_CATEGORIES_URL,
   LATEST_POSTS_URL,
+  MASS_RECALL_DISPLAY_JSON_URL,
 } from '~/constants/environment-variables'
 import type { Post } from '~/graphql/fragments/post'
 import type { Category } from '~/graphql/query/category'
@@ -63,6 +64,7 @@ type PageProps = {
   featuredCollaboration: FeaturedCollaboration
   dataSetItems: DataSetItem[]
   dataSetCount: number
+  isMassRecall2025: boolean
 }
 
 const HiddenAnchor = styled.div`
@@ -95,6 +97,7 @@ const Index: NextPageWithLayout<PageProps> = ({
   featuredCollaboration,
   dataSetItems,
   dataSetCount,
+  isMassRecall2025,
 }) => {
   const anchorRef = useScrollToEnd(() =>
     gtag.sendEvent('homepage', 'scroll', 'scroll to end')
@@ -106,7 +109,7 @@ const Index: NextPageWithLayout<PageProps> = ({
   const shouldShowCollaborationSection = collaborations.length > 0
   return (
     <>
-      {IS_MASS_RECALL && <MassRecallLiveSection />}
+      {isMassRecall2025 && <MassRecallLiveSection />}
       {shouldShowEditorChoiceSection && (
         <EditorChoiceSection posts={editorChoices} />
       )}
@@ -145,6 +148,7 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
 
   const client = getGqlClient()
 
+  let isMassRecall2025 = false
   let editorChoices: EditorCard[] = []
   let categories: NavigationCategoryWithArticleCards[] = []
   let latest: NavigationCategoryWithArticleCards = {
@@ -168,6 +172,18 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
 
   try {
     {
+      // fetch mass recall display URL
+      const massRecallDisplayJsonData = await fetch(
+        MASS_RECALL_DISPLAY_JSON_URL,
+        {
+          next: { revalidate: 0 },
+        }
+      ).then((res) => res.json())
+
+      isMassRecall2025 =
+        massRecallDisplayJsonData[
+          ENV === 'local' ? `display_iframe_dev` : `display_iframe_${ENV}`
+        ] === 'TRUE'
       // fetch editor choice data
       const { data, errors: gqlErrors } = await client.query<{
         editorChoices: EditorChoice[]
@@ -485,6 +501,7 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
       featuredCollaboration,
       dataSetItems,
       dataSetCount,
+      isMassRecall2025,
     },
   }
 }

--- a/packages/readr/pages/index.tsx
+++ b/packages/readr/pages/index.tsx
@@ -181,7 +181,7 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
       ).then((res) => res.json())
 
       isMassRecall2025 =
-        massRecallDisplayJsonData[
+        massRecallDisplayJsonData?.[
           ENV === 'local' ? `display_iframe_dev` : `display_iframe_${ENV}`
         ] === 'TRUE'
       // fetch editor choice data


### PR DESCRIPTION
- 移除多個檔案原本基於環境變數來控制元件 `<MassRecallLiveSection />` 顯示與否的變數 `IS_MASS_RECALL`
- 在 `getServerSideProps` 函式宣告和賦值新變數 `isMassRecall2025`，接著 fetch JSON URL 並以結果決定 isMassRecall2025 的值，再將 `isMassRecall2025`以 props 形式傳入 `Index` 元件供內部使用
-  在`Index` 元件內使用變數`isMassRecall2025`，作為控制元件 `<MassRecallLiveSection />` 是否顯示的依據