### PR TITLE
fix: homepage i18n translation

### DIFF
--- a/packages/mesh/app/[lng]/_components/category-story/nav-list.tsx
+++ b/packages/mesh/app/[lng]/_components/category-story/nav-list.tsx
@@ -45,7 +45,7 @@ type Props = {
 
 export default function NavList({ categories, initialStories }: Props) {
   const [data, setData] = useState<CategoryStory[] | null>(initialStories)
-  const { t } = useT('components/categroy-story')
+  const { t } = useT('components/category-story')
   const userPayload = useUserPayload()
   const router = useRouter()
   const searchParams = useSearchParams()

--- a/packages/mesh/app/[lng]/_components/most-liked-comments/card.tsx
+++ b/packages/mesh/app/[lng]/_components/most-liked-comments/card.tsx
@@ -64,7 +64,9 @@ export default function MostLikedCommentCard({ comment, rank }: Props) {
               </p>
               <p className="footnote text-primary-500">
                 {t('commentReceived', '留言獲得')}
-                <span className="text-primary-800">{comment.likeCount}</span>
+                <span className="text-primary-800">
+                  &nbsp;{comment.likeCount}&nbsp;
+                </span>
                 {t('hearts', '個愛心')}
               </p>
             </div>

--- a/packages/mesh/app/[lng]/_components/most-liked-comments/card.tsx
+++ b/packages/mesh/app/[lng]/_components/most-liked-comments/card.tsx
@@ -63,9 +63,9 @@ export default function MostLikedCommentCard({ comment, rank }: Props) {
                 </Link>
               </p>
               <p className="footnote text-primary-500">
-                留言獲得{' '}
-                <span className="text-primary-800">{comment.likeCount}</span>{' '}
-                個愛心
+                {t('commentReceived', '留言獲得')}
+                <span className="text-primary-800">{comment.likeCount}</span>
+                {t('hearts', '個愛心')}
               </p>
             </div>
           </div>

--- a/packages/mesh/components/story-card/story-meta.tsx
+++ b/packages/mesh/components/story-card/story-meta.tsx
@@ -28,7 +28,7 @@ export default function StoryMeta({
       <CommentCount objectiveId={storyId} initialCommentCounts={commentCount} />
       <Icon iconName="icon-dot" size="s" />
       <div>
-        <span>{publishDate ? displayTimeFromNow(publishDate) : null}</span>
+        <span>{publishDate ? displayTimeFromNow(publishDate, t) : null}</span>
       </div>
       {paywall && (
         <div className="flex items-center">

--- a/packages/mesh/i18n/locales/components/most-liked-comments/en-US.json
+++ b/packages/mesh/i18n/locales/components/most-liked-comments/en-US.json
@@ -1,5 +1,7 @@
 {
   "follow": "Follow",
   "following": "Following",
-  "MostLikedCommentSection-title": "Top liked comments of the week"
+  "MostLikedCommentSection-title": "Top liked comments of the week",
+  "commentReceived": "Comment received",
+  "hearts": "hearts"
 }

--- a/packages/mesh/i18n/locales/components/story-card/en-US.json
+++ b/packages/mesh/i18n/locales/components/story-card/en-US.json
@@ -3,5 +3,8 @@
   "already-picked": "Picked",
   "paywall": "Paid story",
   "podcast": "Podcast",
-  "full-screen-ad": "Full-screen ad"
+  "full-screen-ad": "Full-screen ad",
+  "minutesAgo": "{{count}} minutes ago",
+  "hoursAgo": "{{count}} hours ago",
+  "daysAgo": "{{count}} days ago"
 }

--- a/packages/mesh/i18n/locales/components/story-card/zh-TW.json
+++ b/packages/mesh/i18n/locales/components/story-card/zh-TW.json
@@ -3,5 +3,8 @@
   "already-picked": "已精選",
   "paywall": "付費文章",
   "podcast": "Podcast",
-  "full-screen-ad": "蓋板廣告"
+  "full-screen-ad": "蓋板廣告",
+  "minutesAgo": "{{count}} 分鐘前",
+  "hoursAgo": "{{count}} 小時前",
+  "daysAgo": "{{count}} 天前"
 }

--- a/packages/mesh/utils/story-display.ts
+++ b/packages/mesh/utils/story-display.ts
@@ -1,7 +1,10 @@
 import { DAY, HOUR, MINUTE } from '@/constants/time-unit'
 import { type UserActionStoryFragment } from '@/graphql/__generated__/graphql'
 
-export const displayTimeFromNow = (date: string | Date) => {
+export const displayTimeFromNow = (
+  date: string | Date,
+  t?: (key: string, fallback: string) => string
+) => {
   const differenceInMilliseconds = Date.now() - new Date(date).getTime()
   const differenceInMinutes = differenceInMilliseconds / MINUTE
   const differenceInHours = differenceInMilliseconds / HOUR
@@ -24,11 +27,23 @@ export const displayTimeFromNow = (date: string | Date) => {
   if (differenceInMilliseconds < 0) {
     return fullDisplayTime(date)
   } else if (differenceInMilliseconds < HOUR) {
-    return Math.floor(differenceInMinutes) + ' 分鐘前'
+    const minutes = Math.floor(differenceInMinutes)
+    return t
+      ? t('minutesAgo', `${minutes} 分鐘前`).replace(
+          '{{count}}',
+          minutes.toString()
+        )
+      : `${minutes} 分鐘前`
   } else if (differenceInMilliseconds < 24 * HOUR) {
-    return Math.floor(differenceInHours) + ' 小時前'
+    const hours = Math.floor(differenceInHours)
+    return t
+      ? t('hoursAgo', `${hours} 小時前`).replace('{{count}}', hours.toString())
+      : `${hours} 小時前`
   } else if (differenceInMilliseconds < 7 * DAY) {
-    return Math.floor(differenceInDays) + ' 天前'
+    const days = Math.floor(differenceInDays)
+    return t
+      ? t('daysAgo', `${days} 天前`).replace('{{count}}', days.toString())
+      : `${days} 天前`
   } else {
     return fullDisplayTime(date)
   }


### PR DESCRIPTION
## Update
- 主頁i18n翻譯

## Notes
1. 主要改動I18n的架構，解決了之前無法在server side翻譯的問題。
2.  client side 使用 `useT`, server side 使用 `getT`
3. 以上兩者的使用方式雷同，在初始化的時候給予`namespace`(以下簡稱`ns`)
4. `ns`的結構目前統一為兩層，頁面的翻譯使用 page.[頁面]、共用元件使用 `component.[元件]`

## Details
1. 分類類別顯示中文字
<img width="1108" height="707" alt="image" src="https://github.com/user-attachments/assets/7aa867f4-ee09-4f82-ad96-021fd69fe5a3" />
5. 右上角日期
<img width="1087" height="451" alt="image" src="https://github.com/user-attachments/assets/e746d820-6a49-4bc7-9918-6cb111c45a3d" />
6. 首頁上文章卡片的發布時間，以及精選人數
<img width="464" height="492" alt="image" src="https://github.com/user-attachments/assets/59648886-b8c2-40a0-9731-884949af9808" />
7. 首頁上本週精選文章數量
<img width="1012" height="335" alt="image" src="https://github.com/user-attachments/assets/48aedb1b-e74f-40a6-85de-70056fc24e01" />
8. 首頁留言排行榜上，顯示獲得幾個愛心的字段
<img width="431" height="240" alt="image" src="https://github.com/user-attachments/assets/69e2077a-5b6f-4f8f-ba7c-1ec2be742eb5" />
9. 贊助卡片
<img width="464" height="492" alt="image" src="https://github.com/user-attachments/assets/5d93b98b-1e67-46eb-9576-b6a5b4adcebf" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210748521619431