### PR TITLE
feat: enhance story type handling and add video support

### DIFF
--- a/packages/mesh/__tests__/components/story-card.test.tsx
+++ b/packages/mesh/__tests__/components/story-card.test.tsx
@@ -1,0 +1,153 @@
+import '@testing-library/jest-dom'
+
+import { render } from '@testing-library/react'
+
+// Mock all problematic dependencies
+jest.mock('@/hooks/use-display-picks', () => ({
+  useDisplayPicks: () => ({
+    displayPicks: [],
+    displayPicksCount: 0,
+  }),
+}))
+
+jest.mock('@/hooks/use-page-name', () => ({
+  __esModule: true,
+  default: () => 'homepage',
+}))
+
+jest.mock('@/hooks/use-user-payload', () => ({
+  __esModule: true,
+  default: () => null,
+}))
+
+jest.mock('next/navigation', () => ({
+  useParams: () => ({ lng: 'en' }),
+}))
+
+// Mock Icon component
+jest.mock('@/components/icon', () => {
+  return function MockIcon({ iconName }: { iconName: string }) {
+    return <span data-testid={iconName}>{iconName}</span>
+  }
+})
+
+// Mock other components
+jest.mock('@/components/general-objective/objective-pick-info', () => {
+  return function MockObjectivePickInfo() {
+    return <div>ObjectivePickInfo</div>
+  }
+})
+
+jest.mock('@/components/story-card/story-meta', () => {
+  return function MockStoryMeta() {
+    return <div>StoryMeta</div>
+  }
+})
+
+jest.mock('@/components/story-card/story-pick-button', () => {
+  return function MockStoryPickButton() {
+    return <div>StoryPickButton</div>
+  }
+})
+
+jest.mock('@/components/story-more-action-button', () => {
+  return function MockStoryMoreActionButton() {
+    return <div>StoryMoreActionButton</div>
+  }
+})
+
+jest.mock('@/app/[lng]/_components/image-with-fallback', () => {
+  return function MockImageWithFallback() {
+    return <div>ImageWithFallback</div>
+  }
+})
+
+jest.mock('@/utils/event-logs', () => ({
+  logClickEvent: jest.fn(),
+}))
+
+// Now import StoryCard after mocks are set up
+import StoryCard from '@/app/[lng]/_components/story-card'
+
+describe('StoryCard Video Icon', () => {
+  const mockStory = {
+    id: 'test-story-1',
+    title: 'Test Story Title',
+    url: 'https://example.com/story',
+    summary: 'Test story summary',
+    og_title: 'Test Story Title',
+    og_image: 'https://example.com/image.jpg',
+    og_description: 'Test story description',
+    published_date: '2025-01-15',
+    full_content: true,
+    commentCount: 5,
+    paywall: false,
+    full_screen_ad: 'none',
+    isMember: false,
+    source: {
+      id: 'source-1',
+      title: 'Test Source',
+      customId: 'test-source',
+    },
+    story_type: 'story',
+    picksCount: 10,
+    category: {
+      id: 'cat-1',
+      slug: 'test-category',
+    },
+    picks: [],
+    comment: {},
+  }
+
+  const mockGtmTags = {
+    story: 'gtm-story-click',
+    pick: 'gtm-pick-click',
+  }
+
+  it('shows video icon when story type is video', () => {
+    const videoStory = {
+      ...mockStory,
+      story_type: 'video',
+    }
+
+    const { getByTestId } = render(
+      <StoryCard story={videoStory} gtmTags={mockGtmTags} />
+    )
+
+    expect(getByTestId('icon-video-type')).toBeInTheDocument()
+  })
+
+  it('does not show video icon when story type is story', () => {
+    const regularStory = {
+      ...mockStory,
+      story_type: 'story',
+    }
+
+    const { queryByTestId } = render(
+      <StoryCard story={regularStory} gtmTags={mockGtmTags} />
+    )
+
+    expect(queryByTestId('icon-video-type')).not.toBeInTheDocument()
+  })
+
+  it('does not show video icon when story type is podcast', () => {
+    const podcastStory = {
+      ...mockStory,
+      story_type: 'podcast',
+    }
+
+    const { queryByTestId } = render(
+      <StoryCard story={podcastStory} gtmTags={mockGtmTags} />
+    )
+
+    expect(queryByTestId('icon-video-type')).not.toBeInTheDocument()
+  })
+
+  it('does not show video icon when story type is undefined', () => {
+    const { queryByTestId } = render(
+      <StoryCard story={mockStory} gtmTags={mockGtmTags} />
+    )
+
+    expect(queryByTestId('icon-video-type')).not.toBeInTheDocument()
+  })
+})

--- a/packages/mesh/__tests__/utils/story-type.test.tsx
+++ b/packages/mesh/__tests__/utils/story-type.test.tsx
@@ -1,0 +1,145 @@
+import {
+  extractYouTubeId,
+  getValidatedStoryType,
+  isVideoType,
+  STORY_TYPES,
+} from '@/utils/story-type'
+
+describe('extractYouTubeId', () => {
+  describe('valid YouTube URLs', () => {
+    it('extracts ID from youtube.com/watch URL', () => {
+      const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+      expect(extractYouTubeId(url)).toBe('dQw4w9WgXcQ')
+    })
+
+    it('extracts ID from youtu.be short URL', () => {
+      const url = 'https://youtu.be/dQw4w9WgXcQ'
+      expect(extractYouTubeId(url)).toBe('dQw4w9WgXcQ')
+    })
+
+    it('extracts ID from youtube.com/embed URL', () => {
+      const url = 'https://www.youtube.com/embed/dQw4w9WgXcQ'
+      expect(extractYouTubeId(url)).toBe('dQw4w9WgXcQ')
+    })
+
+    it('extracts ID from youtube.com/v URL', () => {
+      const url = 'https://www.youtube.com/v/dQw4w9WgXcQ'
+      expect(extractYouTubeId(url)).toBe('dQw4w9WgXcQ')
+    })
+
+    it('handles URLs with additional parameters', () => {
+      const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=30s'
+      expect(extractYouTubeId(url)).toBe('dQw4w9WgXcQ')
+    })
+  })
+
+  describe('security improvements', () => {
+    it('rejects IDs that are too short', () => {
+      const url = 'https://www.youtube.com/watch?v=short123'
+      expect(extractYouTubeId(url)).toBeNull()
+    })
+
+    it('rejects IDs that are too long', () => {
+      const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQextralong'
+      // Should extract exactly 11 characters, ignoring the extra characters
+      expect(extractYouTubeId(url)).toBe('dQw4w9WgXcQ')
+    })
+
+    it('rejects IDs with invalid characters', () => {
+      const url = 'https://www.youtube.com/watch?v=dQw4w9WgX@Q'
+      expect(extractYouTubeId(url)).toBeNull()
+    })
+
+    it('rejects IDs with spaces', () => {
+      const url = 'https://www.youtube.com/watch?v=dQw4w9W XcQ'
+      expect(extractYouTubeId(url)).toBeNull()
+    })
+
+    it('rejects IDs with special characters', () => {
+      const url = 'https://www.youtube.com/watch?v=dQw4w9W#XcQ'
+      expect(extractYouTubeId(url)).toBeNull()
+    })
+
+    it('accepts valid characters (letters, numbers, underscore, hyphen)', () => {
+      const url = 'https://www.youtube.com/watch?v=aB3_dEf-GhI'
+      expect(extractYouTubeId(url)).toBe('aB3_dEf-GhI')
+    })
+  })
+
+  describe('invalid URLs', () => {
+    it('returns null for non-YouTube URLs', () => {
+      const url = 'https://www.vimeo.com/123456789'
+      expect(extractYouTubeId(url)).toBeNull()
+    })
+
+    it('returns null for malformed YouTube URLs', () => {
+      const url = 'https://youtube.com/invalid'
+      expect(extractYouTubeId(url)).toBeNull()
+    })
+
+    it('returns null for empty string', () => {
+      expect(extractYouTubeId('')).toBeNull()
+    })
+
+    it('returns null for URLs without video ID', () => {
+      const url = 'https://www.youtube.com/watch'
+      expect(extractYouTubeId(url)).toBeNull()
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles URLs with fragments', () => {
+      const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ#t=30s'
+      expect(extractYouTubeId(url)).toBe('dQw4w9WgXcQ')
+    })
+
+    it('handles URLs with multiple query parameters', () => {
+      const url =
+        'https://www.youtube.com/watch?feature=player_embedded&v=dQw4w9WgXcQ&list=PLrAXtmRdnEQy'
+      expect(extractYouTubeId(url)).toBe('dQw4w9WgXcQ')
+    })
+
+    it('does not extract from URL parameters in the middle', () => {
+      const url = 'https://example.com/page?youtube=dQw4w9WgXcQ&other=param'
+      expect(extractYouTubeId(url)).toBeNull()
+    })
+  })
+})
+
+describe('Story Type Utilities', () => {
+  describe('isVideoType', () => {
+    it('returns true for video type', () => {
+      expect(isVideoType(STORY_TYPES.VIDEO)).toBe(true)
+    })
+
+    it('returns false for story type', () => {
+      expect(isVideoType(STORY_TYPES.STORY)).toBe(false)
+    })
+
+    it('returns false for podcast type', () => {
+      expect(isVideoType(STORY_TYPES.PODCAST)).toBe(false)
+    })
+  })
+
+  describe('getValidatedStoryType', () => {
+    it('returns VIDEO for "video" input', () => {
+      expect(getValidatedStoryType('video')).toBe(STORY_TYPES.VIDEO)
+    })
+
+    it('returns VIDEO for "VIDEO" input (case insensitive)', () => {
+      expect(getValidatedStoryType('VIDEO')).toBe(STORY_TYPES.VIDEO)
+    })
+
+    it('returns STORY for invalid input', () => {
+      expect(getValidatedStoryType('invalid')).toBe(STORY_TYPES.STORY)
+    })
+
+    it('returns STORY for null input', () => {
+      expect(getValidatedStoryType(null)).toBe(STORY_TYPES.STORY)
+    })
+
+    it('returns STORY for undefined input', () => {
+      expect(getValidatedStoryType(undefined)).toBe(STORY_TYPES.STORY)
+    })
+  })
+})

--- a/packages/mesh/app/[lng]/_components/story-card.tsx
+++ b/packages/mesh/app/[lng]/_components/story-card.tsx
@@ -6,6 +6,7 @@ import type { ForwardedRef } from 'react'
 import { forwardRef } from 'react'
 
 import ObjectivePickInfo from '@/components/general-objective/objective-pick-info'
+import Icon from '@/components/icon'
 import StoryMeta from '@/components/story-card/story-meta'
 import StoryPickButton from '@/components/story-card/story-pick-button'
 import StoryMoreActionButton from '@/components/story-more-action-button'
@@ -15,6 +16,7 @@ import usePageName from '@/hooks/use-page-name'
 import useUserPayload from '@/hooks/use-user-payload'
 import type { CategoryStory, DailyStory, GtmTags } from '@/types/homepage'
 import { logClickEvent } from '@/utils/event-logs'
+import { getValidatedStoryType, isVideoType } from '@/utils/story-type'
 
 import ImageWithFallback from './image-with-fallback'
 
@@ -106,6 +108,19 @@ export default forwardRef(function StoryCard<
               className="object-cover"
               fallbackCategory={ImageCategory.STORY}
             />
+            {isVideoType(
+              getValidatedStoryType(
+                (story as { story_type?: string })?.story_type
+              )
+            ) && (
+              <div className="absolute inset-0 flex items-center justify-center">
+                <Icon
+                  iconName="icon-video-type"
+                  size="l"
+                  className="sm:size-11"
+                />
+              </div>
+            )}
           </div>
         </NextLink>
       </div>

--- a/packages/mesh/app/[lng]/profile/_components/article-card.tsx
+++ b/packages/mesh/app/[lng]/profile/_components/article-card.tsx
@@ -4,6 +4,7 @@ import ImageWithFallback from '@/app/[lng]/_components/image-with-fallback'
 import Comment from '@/app/[lng]/profile/_components/comment'
 import CollectionPickButton from '@/components/collection-card/collection-pick-button'
 import ObjectivePickInfo from '@/components/general-objective/objective-pick-info'
+import Icon from '@/components/icon'
 import StoryMeta from '@/components/story-card/story-meta'
 import StoryPickButton from '@/components/story-card/story-pick-button'
 import StoryMoreActionButton from '@/components/story-more-action-button'
@@ -20,7 +21,11 @@ import {
   type PickListItem,
 } from '@/types/profile'
 import { logClickEvent } from '@/utils/event-logs'
-import { type StoryType, getValidatedStoryType } from '@/utils/story-type'
+import {
+  type StoryType,
+  getValidatedStoryType,
+  isVideoType,
+} from '@/utils/story-type'
 
 type StoryDataTypes =
   | NonNullable<PickListItem>
@@ -206,6 +211,19 @@ const ArticleCard = ({
               fill
               className="size-full rounded-[inherit] object-cover"
             />
+            {isVideoType(
+              getValidatedStoryType(
+                (storyData as { story_type?: string })?.story_type
+              )
+            ) && (
+              <div className="absolute inset-0 flex items-center justify-center">
+                <Icon
+                  iconName="icon-video-type"
+                  size="l"
+                  className="sm:size-11"
+                />
+              </div>
+            )}
           </section>
         </Link>
         <div
@@ -295,6 +313,19 @@ const ArticleCard = ({
                   fill
                   className="object-cover"
                 />
+                {isVideoType(
+                  getValidatedStoryType(
+                    (storyData as { story_type?: string })?.story_type
+                  )
+                ) && (
+                  <div className="absolute inset-0 flex items-center justify-center">
+                    <Icon
+                      iconName="icon-video-type"
+                      size="l"
+                      className="sm:size-11"
+                    />
+                  </div>
+                )}
               </div>
             </section>
           </Link>

--- a/packages/mesh/app/[lng]/profile/_components/article-card.tsx
+++ b/packages/mesh/app/[lng]/profile/_components/article-card.tsx
@@ -20,6 +20,7 @@ import {
   type PickListItem,
 } from '@/types/profile'
 import { logClickEvent } from '@/utils/event-logs'
+import { type StoryType, getValidatedStoryType } from '@/utils/story-type'
 
 type StoryDataTypes =
   | NonNullable<PickListItem>
@@ -113,8 +114,8 @@ const storyGetters = {
     collection: (data) => `/collection/${data.id}`,
     default: '',
   }),
-  storyType: createGetter<'story' | 'podcast'>({
-    story: (data) => data.story_type ?? 'story',
+  storyType: createGetter<StoryType>({
+    story: (data) => getValidatedStoryType(data.story_type),
     collection: () => 'story',
     default: 'story',
   }),

--- a/packages/mesh/app/[lng]/story/[id]/_components/article.tsx
+++ b/packages/mesh/app/[lng]/story/[id]/_components/article.tsx
@@ -19,6 +19,7 @@ import { type GetStoryQuery } from '@/graphql/__generated__/graphql'
 import { useDisplayCommentCount } from '@/hooks/use-display-commentcount'
 import { useDisplayPicks } from '@/hooks/use-display-picks'
 import { displayTime } from '@/utils/story-display'
+import { extractYouTubeId, isVideoType } from '@/utils/story-type'
 
 import type { PublisherPolicy } from '../page'
 import ApiDataRenderer, { type ApiData } from './api-data-renderer/renderer'
@@ -31,6 +32,27 @@ export type StoryInteractions = NonNullable<
 >
 
 const inHousePublisherCustomIds = ['mirrormedia', 'readr']
+
+const VideoHero = ({ videoUrl }: { videoUrl: string }) => {
+  const youtubeId = extractYouTubeId(videoUrl)
+
+  if (!youtubeId) {
+    console.warn('Could not extract YouTube ID from URL:', videoUrl)
+    return null
+  }
+
+  return (
+    <div className="relative mb-6 aspect-video">
+      <iframe
+        src={`https://www.youtube.com/embed/${youtubeId}`}
+        className="absolute inset-0 size-full"
+        loading="lazy"
+        allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+        allowFullScreen
+      />
+    </div>
+  )
+}
 
 export default function Article({
   story,
@@ -125,7 +147,7 @@ export default function Article({
     } else {
       return (
         <article
-          className="story-renderer"
+          className="story-renderer *:break-words"
           dangerouslySetInnerHTML={{ __html: story?.content ?? '' }}
         />
       )
@@ -135,16 +157,21 @@ export default function Article({
   return (
     <div>
       <div>
-        {story?.og_image && (
-          <div className="relative mb-6 aspect-[2/1]">
-            <ImageWithFallback
-              src={story.og_image}
-              alt="hero image"
-              style={{ objectFit: 'cover' }}
-              fill
-              fallbackCategory={ImageCategory.STORY}
-            />
-          </div>
+        {/* Hero Section - Dynamic based on story type */}
+        {story && story.story_type && isVideoType(story.story_type) ? (
+          <VideoHero videoUrl={story.url || ''} />
+        ) : (
+          story?.og_image && (
+            <div className="relative mb-6 aspect-[2/1]">
+              <ImageWithFallback
+                src={story.og_image}
+                alt="hero image"
+                style={{ objectFit: 'cover' }}
+                fill
+                fallbackCategory={ImageCategory.STORY}
+              />
+            </div>
+          )
         )}
         <div className="px-5 sm:px-0">
           {/* article meta */}

--- a/packages/mesh/app/[lng]/story/[id]/_components/article.tsx
+++ b/packages/mesh/app/[lng]/story/[id]/_components/article.tsx
@@ -165,7 +165,7 @@ export default function Article({
             <div className="relative mb-6 aspect-[2/1]">
               <ImageWithFallback
                 src={story.og_image}
-                alt="hero image"
+                alt={`${story.title}'s OG Image`}
                 style={{ objectFit: 'cover' }}
                 fill
                 fallbackCategory={ImageCategory.STORY}

--- a/packages/mesh/app/[lng]/story/[id]/_components/client-layout.tsx
+++ b/packages/mesh/app/[lng]/story/[id]/_components/client-layout.tsx
@@ -16,6 +16,7 @@ import type { GetStoryQuery } from '@/graphql/__generated__/graphql'
 import { useDisplayPicks } from '@/hooks/use-display-picks'
 import { BookmarkObjective, PickObjective } from '@/types/objective'
 import { getStoryUrl } from '@/utils/get-url'
+import { type StoryType, STORY_TYPES } from '@/utils/story-type'
 
 import Loading from './loading'
 
@@ -27,7 +28,7 @@ export default function ClientLayout({
   children,
 }: {
   story: Story
-  storyType: 'story' | 'podcast'
+  storyType: StoryType
   children: React.ReactNode
 }) {
   const params = useParams()
@@ -39,7 +40,21 @@ export default function ClientLayout({
 
   const isSinglePickByCurrentUser =
     displayPicks.length === 1 && displayPicks[0].member.id === user.memberId
-  const navigationTitle = storyType === 'story' ? '新聞' : 'Podcast'
+
+  const getNavigationTitle = (type: StoryType): string => {
+    switch (type) {
+      case STORY_TYPES.STORY:
+        return '新聞'
+      case STORY_TYPES.PODCAST:
+        return 'Podcast'
+      case STORY_TYPES.VIDEO:
+        return 'Video'
+      default:
+        return '新聞'
+    }
+  }
+
+  const navigationTitle = getNavigationTitle(storyType)
 
   return (
     <LayoutTemplate

--- a/packages/mesh/app/[lng]/story/[id]/layout.tsx
+++ b/packages/mesh/app/[lng]/story/[id]/layout.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation'
 import { metadata as rootMetadata } from '@/app/[lng]/layout'
 import { getStory } from '@/app/actions/story'
 import { SITE_DESCRIPTION, SITE_TITLE, SITE_URL } from '@/constants/config'
+import { getValidatedStoryType } from '@/utils/story-type'
 
 import ClientLayout from './_components/client-layout'
 import CommentWrapper from './_components/comment-wrapper'
@@ -71,7 +72,7 @@ export default async function StoryLayout({
   const storyData = await getStory({ storyId })
   if (!storyData) notFound()
 
-  const storyType = storyData.story_type === 'story' ? 'story' : 'podcast'
+  const storyType = getValidatedStoryType(storyData.story_type)
   return (
     <StoryInteractionsWrapper storyId={storyId}>
       <CommentWrapper story={storyData}>

--- a/packages/mesh/app/[lng]/story/[id]/page.tsx
+++ b/packages/mesh/app/[lng]/story/[id]/page.tsx
@@ -10,6 +10,11 @@ import MisoPageView from '@/components/miso-page-view'
 import { GetStoriesDocument } from '@/graphql/__generated__/graphql'
 import queryGraphQL from '@/utils/fetch-graphql'
 import { getLogTraceObjectFromHeaders } from '@/utils/log'
+import {
+  getValidatedStoryType,
+  isPodcastType,
+  isStoryType,
+} from '@/utils/story-type'
 
 import { type ApiData } from './_components/api-data-renderer/renderer'
 import SideIndex from './_components/api-data-renderer/side-index'
@@ -79,7 +84,7 @@ export default async function Page({
   const { title, story_type, source, isMember, apiData, podcast, og_image } =
     storyData
 
-  const storyType = story_type === 'story' ? 'story' : 'podcast'
+  const storyType = getValidatedStoryType(story_type)
   const sourceCustomId = source?.customId ?? ''
   const isMemberStory = isMember ?? false
 
@@ -101,7 +106,7 @@ export default async function Page({
       <RelatedStories relatedStories={relatedStories} />
       <Comment targetId={storyId} />
       <aside className="hidden lg:fixed lg:right-[calc(((100vw-theme(width.articleMain))/2-theme(width.articleAside.lg))/2)] lg:top-[theme(height.header.sm)] lg:flex lg:w-[theme(width.articleAside.lg)] lg:flex-col xl:right-[calc((100vw-1440px)/2+((1440px-theme(width.articleMain))/2-theme(width.articleAside.xl))/2)] xl:w-[theme(width.articleAside.xl)]">
-        {!isMemberStory && storyType === 'story' && (
+        {!isMemberStory && isStoryType(storyType) && (
           <SideIndex
             apiData={apiData as ApiData}
             sourceCustomId={sourceCustomId}
@@ -110,7 +115,7 @@ export default async function Page({
         )}
       </aside>
       <AsideAd />
-      {storyType === 'podcast' && (
+      {isPodcastType(storyType) && (
         <AudioPlayer
           audioSrc={podcast?.url || ''}
           audioLogoSrc={og_image || ''}

--- a/packages/mesh/components/icon.tsx
+++ b/packages/mesh/components/icon.tsx
@@ -201,6 +201,7 @@ export type IconName =
   | 'icon-print-hover'
   | 'icon-mesh-ai'
   | 'icon-lock'
+  | 'icon-video-type'
 
 export type IconProps = {
   size: Size

--- a/packages/mesh/components/layout-template/navigation/mobile-navigation/index.tsx
+++ b/packages/mesh/components/layout-template/navigation/mobile-navigation/index.tsx
@@ -14,6 +14,7 @@ export default function MobileNavigation({
   title,
   rightButtons,
 }: MobileNavigationProps) {
+  console.log({ rightButtons })
   return (
     <header className="fixed inset-x-0 top-0 z-layout flex h-[60px] border-b bg-white sm:hidden">
       <div className="relative flex h-full grow items-center justify-between px-2">

--- a/packages/mesh/components/layout-template/navigation/mobile-navigation/index.tsx
+++ b/packages/mesh/components/layout-template/navigation/mobile-navigation/index.tsx
@@ -14,7 +14,6 @@ export default function MobileNavigation({
   title,
   rightButtons,
 }: MobileNavigationProps) {
-  console.log({ rightButtons })
   return (
     <header className="fixed inset-x-0 top-0 z-layout flex h-[60px] border-b bg-white sm:hidden">
       <div className="relative flex h-full grow items-center justify-between px-2">

--- a/packages/mesh/components/story-card/story-meta.tsx
+++ b/packages/mesh/components/story-card/story-meta.tsx
@@ -1,6 +1,8 @@
 'use client'
+
 import { useT } from '@/app/i18n/client'
 import { displayTimeFromNow } from '@/utils/story-display'
+import { type StoryType, STORY_TYPES } from '@/utils/story-type'
 
 import CommentCount from '../comment-count'
 import Icon from '../icon'
@@ -18,7 +20,7 @@ export default function StoryMeta({
   publishDate: string
   paywall: boolean
   fullScreenAd: string
-  storyType?: 'story' | 'podcast'
+  storyType?: StoryType
 }) {
   const { t } = useT('components/story-card')
 
@@ -42,12 +44,18 @@ export default function StoryMeta({
           {t('full-screen-ad', '蓋板廣告')}
         </div>
       )}
-      {storyType === 'podcast' ? (
+      {storyType === STORY_TYPES.PODCAST && (
         <div className="flex items-center">
           <Icon iconName="icon-dot" size="s" />
           {t('podcast', 'Podcast')}
         </div>
-      ) : null}
+      )}
+      {storyType === STORY_TYPES.VIDEO && (
+        <div className="flex items-center">
+          <Icon iconName="icon-dot" size="s" />
+          {t('video', 'Video')}
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/mesh/graphql/__generated__/graphql.ts
+++ b/packages/mesh/graphql/__generated__/graphql.ts
@@ -6021,6 +6021,7 @@ export type StoryRelateToOneForUpdateInput = {
 export enum StoryStoryTypeType {
   Podcast = 'podcast',
   Story = 'story',
+  Video = 'video',
 }
 
 export type StoryStoryTypeTypeNullableFilter = {

--- a/packages/mesh/public/icons/icon-video-type.svg
+++ b/packages/mesh/public/icons/icon-video-type.svg
@@ -1,0 +1,4 @@
+<svg width="52" height="52" viewBox="0 0 52 52" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="26" cy="26" r="24" fill="rgba(0, 0, 0, 0.6)"/>
+  <path d="M21 18.5V33.5L33 26L21 18.5Z" fill="white"/>
+</svg>

--- a/packages/mesh/utils/story-type.ts
+++ b/packages/mesh/utils/story-type.ts
@@ -1,0 +1,45 @@
+export const STORY_TYPES = {
+  STORY: 'story',
+  PODCAST: 'podcast',
+  VIDEO: 'video',
+} as const
+
+export type StoryType = typeof STORY_TYPES[keyof typeof STORY_TYPES]
+
+export const getValidatedStoryType = (
+  storyType: string | undefined | null
+): StoryType => {
+  if (!storyType) return STORY_TYPES.STORY
+
+  const upperCaseType = storyType.toUpperCase() as keyof typeof STORY_TYPES
+  return STORY_TYPES[upperCaseType] || STORY_TYPES.STORY
+}
+
+export const isVideoType = (storyType: StoryType): boolean => {
+  return storyType === STORY_TYPES.VIDEO
+}
+
+export const isPodcastType = (storyType: StoryType): boolean => {
+  return storyType === STORY_TYPES.PODCAST
+}
+
+export const isStoryType = (storyType: StoryType): boolean => {
+  return storyType === STORY_TYPES.STORY
+}
+
+// Extract YouTube video ID from various URL formats
+export const extractYouTubeId = (url: string): string | null => {
+  const patterns = [
+    /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&\n?#]+)/,
+    /youtube\.com\/v\/([^&\n?#]+)/,
+  ]
+
+  for (const pattern of patterns) {
+    const match = url.match(pattern)
+    if (match && match[1]) {
+      return match[1]
+    }
+  }
+
+  return null
+}

--- a/packages/mesh/utils/story-type.ts
+++ b/packages/mesh/utils/story-type.ts
@@ -30,8 +30,8 @@ export const isStoryType = (storyType: StoryType): boolean => {
 // Extract YouTube video ID from various URL formats
 export const extractYouTubeId = (url: string): string | null => {
   const patterns = [
-    /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([^&\n?#]+)/,
-    /youtube\.com\/v\/([^&\n?#]+)/,
+    /(?:youtube\.com\/watch\?.*v=|youtu\.be\/|youtube\.com\/embed\/)([a-zA-Z0-9_-]{11})/,
+    /youtube\.com\/v\/([a-zA-Z0-9_-]{11})/,
   ]
 
   for (const pattern of patterns) {


### PR DESCRIPTION
This pull request introduces a new video story type to the application, allowing for the
  display and handling of video-based content.

 ## Changes

   - Adds video to the StoryStoryTypeType GraphQL enum.
   - Creates a new story-type.ts utility for validating and checking story types.
   - Implements a VideoHero component that embeds a YouTube player for video stories.
   - Updates various UI components, including ArticleCard, StoryMeta, and mobile navigation, to
     recognize and display the new video type.
   - Refactors existing code to use the centralized story type validation logic.

### video type desktop
<img width="617" height="898" alt="image" src="https://github.com/user-attachments/assets/e2de3b02-ca16-45d2-ac92-d456c5460d75" />

### video type mobile
<img width="467" height="1012" alt="image" src="https://github.com/user-attachments/assets/9d1367e2-162b-4381-9115-bbe35215007d" />



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211061259716247